### PR TITLE
Add File Discovery and Handler Registry with CLI

### DIFF
--- a/src/croissant_maker/__main__.py
+++ b/src/croissant_maker/__main__.py
@@ -1,4 +1,9 @@
+"""Command-line interface for Croissant Maker."""
+
 import typer
+from pathlib import Path
+from .files import discover_files
+from .handlers import find_handler
 
 # Create the Typer application instance
 app = typer.Typer(
@@ -9,16 +14,32 @@ app = typer.Typer(
 
 
 @app.command()
-def main():
+def main(
+    dir_path: str = typer.Argument(..., help="Directory to scan for dataset files"),
+) -> None:
     """
-    Placeholder main command. Currently does nothing.
-    (This docstring becomes the command's help text)
+    Scan a directory and identify files that can be processed by registered handlers.
+
+    Args:
+        dir_path: Path to the directory containing dataset files.
+
+    Raises:
+        typer.Exit: If the directory is invalid or inaccessible, exits with code 1.
     """
-    typer.echo("Croissant Maker - Tool starting point (currently does nothing).")
-    # Future logic for parsing arguments and calling core functions will go here
+    try:
+        files = discover_files(dir_path)
+        if not files:
+            typer.echo("No files found in the directory.")
+            return
+
+        for file_path in files:
+            handler = find_handler(Path(dir_path) / file_path)
+            status = "Supported" if handler else "Unsupported"
+            typer.echo(f"File: {file_path} -> {status}")
+    except (FileNotFoundError, PermissionError) as e:
+        typer.echo(f"Error: {e}")
+        raise typer.Exit(code=1)
 
 
-# This standard Python construct allows the script to be run directly
-# using `python -m croissant_maker` and executes the Typer app.
 if __name__ == "__main__":
     app()

--- a/src/croissant_maker/files.py
+++ b/src/croissant_maker/files.py
@@ -1,0 +1,34 @@
+"""File discovery utilities for Croissant Maker."""
+
+from pathlib import Path
+from typing import List
+
+
+def discover_files(dir_path: str) -> List[Path]:
+    """
+    Recursively discover all files in a directory and return their relative paths.
+
+    Args:
+        dir_path: Path to the directory to scan.
+
+    Returns:
+        List of relative file paths found in the directory.
+
+    Raises:
+        FileNotFoundError: If the directory does not exist or is not a directory.
+        PermissionError: If the directory cannot be accessed.
+    """
+    try:
+        directory = Path(dir_path).resolve()
+        if not directory.is_dir():
+            raise FileNotFoundError(f"{dir_path} is not a directory")
+
+        return [
+            file.relative_to(directory)
+            for file in directory.rglob("*")
+            if file.is_file()
+        ]
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"Directory not found: {e}")
+    except PermissionError as e:
+        raise PermissionError(f"Permission denied: {e}")

--- a/src/croissant_maker/handlers.py
+++ b/src/croissant_maker/handlers.py
@@ -1,0 +1,63 @@
+"""File handler framework for Croissant Maker."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+
+class FileTypeHandler(ABC):
+    """Abstract base class for file type handlers."""
+
+    @abstractmethod
+    def can_handle(self, file_path: Path) -> bool:
+        """
+        Check if the handler can process the given file.
+
+        Args:
+            file_path: Path to the file.
+
+        Returns:
+            True if the handler can process the file, False otherwise.
+        """
+
+    @abstractmethod
+    def extract_metadata(self, file_path: Path) -> dict:
+        """
+        Extract metadata from the file.
+
+        Args:
+            file_path: Path to the file.
+
+        Returns:
+            Metadata extracted from the file as a dictionary.
+        """
+
+
+_registry: list[FileTypeHandler] = []
+
+
+def register_handler(handler: FileTypeHandler) -> None:
+    """
+    Register a file type handler.
+
+    Args:
+        handler: Handler to register.
+    """
+    if handler not in _registry:
+        _registry.append(handler)
+
+
+def find_handler(file_path: Path) -> Optional[FileTypeHandler]:
+    """
+    Find the first handler that can process the given file.
+
+    Args:
+        file_path: Path to the file.
+
+    Returns:
+        Matching handler or None if no handler is found.
+    """
+    for handler in _registry:
+        if handler.can_handle(file_path):
+            return handler
+    return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,67 @@
+"""Tests for Croissant Maker CLI."""
+
+from pathlib import Path
+import pytest
+from typer.testing import CliRunner
+from croissant_maker.__main__ import app
+from croissant_maker.handlers import FileTypeHandler, register_handler
+
+runner = CliRunner()
+
+
+class DummyTextHandler(FileTypeHandler):
+    def can_handle(self, file_path: Path) -> bool:
+        """Check if the file has a .txt extension."""
+        return file_path.suffix == ".txt"
+
+    def extract_metadata(self, file_path: Path) -> dict:
+        """Return dummy metadata for testing."""
+        return {"type": "text"}
+
+
+@pytest.fixture
+def setup_handlers() -> None:
+    """Register the dummy handler and clean up after the test."""
+    from croissant_maker.handlers import _registry
+
+    original_registry = _registry.copy()
+    register_handler(DummyTextHandler())
+    yield
+    _registry.clear()
+    _registry.extend(original_registry)
+
+
+def test_cli_valid_directory(tmp_path: Path, setup_handlers: None) -> None:
+    """Test CLI with a directory containing files."""
+    (tmp_path / "file1.txt").write_text("test")
+    (tmp_path / "file2.csv").write_text("test")
+
+    result = runner.invoke(app, [str(tmp_path)])
+    assert result.exit_code == 0
+    assert "File: file1.txt -> Supported" in result.stdout
+    assert "File: file2.csv -> Unsupported" in result.stdout
+
+
+def test_cli_empty_directory(tmp_path: Path, setup_handlers: None) -> None:
+    """Test CLI with an empty directory."""
+    result = runner.invoke(app, [str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No files found in the directory." in result.stdout
+
+
+def test_cli_nonexistent_directory(tmp_path: Path) -> None:
+    """Test CLI with a nonexistent directory."""
+    nonexistent = tmp_path / "nonexistent"
+    result = runner.invoke(app, [str(nonexistent)])
+    assert result.exit_code == 1
+    assert "Error: Directory not found" in result.stdout
+
+
+def test_cli_not_a_directory(tmp_path: Path) -> None:
+    """Test CLI with a file instead of a directory."""
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("test")
+    result = runner.invoke(app, [str(file_path)])
+    assert result.exit_code == 1
+    assert "Error: Directory not found: " in result.stdout
+    assert "is not a directory" in result.stdout

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,36 @@
+"""Tests for file discovery utilities."""
+
+from pathlib import Path
+import pytest
+from croissant_maker.files import discover_files
+
+
+def test_discover_files(tmp_path: Path) -> None:
+    """Test discover_files finds files recursively and returns relative paths."""
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "file1.txt").write_text("test")
+    (tmp_path / "sub/file2.txt").write_text("test")
+
+    files = discover_files(str(tmp_path))
+    expected = {Path("file1.txt"), Path("sub/file2.txt")}
+    assert set(files) == expected
+
+
+def test_discover_files_empty_directory(tmp_path: Path) -> None:
+    """Test discover_files returns empty list for empty directory."""
+    files = discover_files(str(tmp_path))
+    assert files == []
+
+
+def test_discover_files_nonexistent_directory() -> None:
+    """Test discover_files raises FileNotFoundError for nonexistent directory."""
+    with pytest.raises(FileNotFoundError, match="Directory not found"):
+        discover_files("/nonexistent/path")
+
+
+def test_discover_files_not_a_directory(tmp_path: Path) -> None:
+    """Test discover_files raises FileNotFoundError for non-directory path."""
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("test")
+    with pytest.raises(FileNotFoundError, match="is not a directory"):
+        discover_files(str(file_path))

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,44 @@
+"""Tests for file handler framework."""
+
+from pathlib import Path
+from croissant_maker.handlers import FileTypeHandler, register_handler, find_handler
+
+
+class DummyHandler(FileTypeHandler):
+    def can_handle(self, file_path: Path) -> bool:
+        return file_path.suffix == ".txt"
+
+    def extract_metadata(self, file_path: Path) -> dict:
+        return {"type": "text"}
+
+
+class DummyHandler2(FileTypeHandler):
+    def can_handle(self, file_path: Path) -> bool:
+        return file_path.suffix == ".csv"
+
+    def extract_metadata(self, file_path: Path) -> dict:
+        return {"type": "csv"}
+
+
+def test_register_and_find_handler() -> None:
+    """Test registering handlers and finding the correct one."""
+    handler1 = DummyHandler()
+    handler2 = DummyHandler2()
+    register_handler(handler1)
+    register_handler(handler2)
+
+    assert find_handler(Path("test.txt")) == handler1
+    assert find_handler(Path("test.csv")) == handler2
+    assert find_handler(Path("test.jpg")) is None
+
+
+def test_find_handler_empty_registry() -> None:
+    """Test find_handler returns None with empty registry."""
+    from croissant_maker.handlers import _registry
+
+    original_registry = _registry.copy()
+    _registry.clear()
+
+    assert find_handler(Path("test.txt")) is None
+
+    _registry.extend(original_registry)


### PR DESCRIPTION
Closes #2

Implements file discovery and handler registry:

- Added `files.py`: `discover_files` for file listing.
- Added `handlers.py`: `FileTypeHandler` and registry.
- Added `__main__.py`: CLI to scan directories.
- Added tests: `test_files.py`, `test_handlers.py`, `test_cli.py`.

**Manual Tests**:

```
python -m croissant_maker test_dataset
```

File: file1.txt -> Unsupported
File: file2.csv -> Unsupported


```
python -m croissant_maker /nonexistent/path
```

Error: Directory not found: /nonexistent/path



```
python -m croissant_maker empty_dataset
```

No files found in the directory.

All tests pass (`pytest -v`). Passes Ruff and pre-commit.

**Next**: Add handlers (CSV, WFDB).