### PR TITLE
style: use absolute imports and add pass to abstract methods

### DIFF
--- a/src/croissant_maker/__main__.py
+++ b/src/croissant_maker/__main__.py
@@ -2,8 +2,9 @@
 
 import typer
 from pathlib import Path
-from .files import discover_files
-from .handlers import find_handler
+
+from croissant_maker.files import discover_files
+from croissant_maker.handlers import find_handler
 
 # Create the Typer application instance
 app = typer.Typer(

--- a/src/croissant_maker/handlers.py
+++ b/src/croissant_maker/handlers.py
@@ -19,6 +19,7 @@ class FileTypeHandler(ABC):
         Returns:
             True if the handler can process the file, False otherwise.
         """
+        pass
 
     @abstractmethod
     def extract_metadata(self, file_path: Path) -> dict:
@@ -31,6 +32,7 @@ class FileTypeHandler(ABC):
         Returns:
             Metadata extracted from the file as a dictionary.
         """
+        pass
 
 
 _registry: list[FileTypeHandler] = []


### PR DESCRIPTION
- Replace relative imports with absolute in ```__main__.py``` per PEP 8
- Add pass to abstract methods in ```handlers.py``` for consistency