### PR TITLE
Add GitHub Action for pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: Pre-commit checks
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.1 # Runs hooks from .pre-commit-config.yaml on changed files in a PR by default.


### PR DESCRIPTION
automatically run pre-commit hooks (linters, formatters via Ruff) on pull requests targeting the `main` branch.

This will help ensure code quality and consistency before merging.