### PR TITLE
Unify Arrow-based type inference for CSV and Parquet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ authors = [
 ]
 
 # Core runtime dependencies needed for the tool to function.
+# Note: pandas is not a direct dependency — it is available transitively via wfdb.
 dependencies = [
     "typer >= 0.9.0",
-    "mlcroissant >= 1.0.0",
-    "pandas >= 1.3.0",
+    "mlcroissant >= 1.0.20",
     "rich >= 13.0.0",
     "wfdb >= 4.0.0",
     "pyarrow >= 15.0.0",

--- a/src/croissant_maker/handlers/csv_handler.py
+++ b/src/croissant_maker/handlers/csv_handler.py
@@ -1,10 +1,15 @@
 """CSV file handler for tabular data processing."""
 
 from pathlib import Path
-import pandas as pd
+
+import pyarrow as pa
+import pyarrow.csv as pa_csv
 
 from croissant_maker.handlers.base_handler import FileTypeHandler
-from croissant_maker.handlers.utils import analyze_data_sample, compute_file_hash
+from croissant_maker.handlers.utils import (
+    compute_file_hash,
+    infer_column_types_from_arrow_schema,
+)
 
 
 class CSVHandler(FileTypeHandler):
@@ -16,10 +21,26 @@ class CSVHandler(FileTypeHandler):
     - Gzip-compressed CSV files (.csv.gz)
     - Bzip2-compressed CSV files (.csv.bz2)
     - XZ-compressed CSV files (.csv.xz)
-    - Automatic column type detection using pandas
+    - Automatic column type detection using PyArrow
     - SHA256 hash computation for file integrity
-    - Sample data extraction for preview
+
+    Uses PyArrow's CSV reader which:
+    - Auto-detects compressed formats from filename extension
+    - Infers precise types (timestamp[s], date32, int64, float64, etc.)
+    - Reads multi-threaded by default for performance
     """
+
+    # Common timestamp formats for medical/clinical data beyond ISO-8601.
+    # PyArrow uses ISO8601 by default; these cover additional patterns found
+    # in datasets like MIMIC, eICU, and OMOP.
+    _TIMESTAMP_PARSERS = [
+        pa_csv.ISO8601,
+        "%Y-%m-%d %H:%M:%S",
+        "%m/%d/%Y",
+        "%d/%m/%Y",
+        "%m/%d/%Y %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+    ]
 
     def can_handle(self, file_path: Path) -> bool:
         """
@@ -43,9 +64,8 @@ class CSVHandler(FileTypeHandler):
         """
         Extract comprehensive metadata from a CSV file.
 
-        Reads a sample of the CSV file to infer column types, extracts
-        file statistics, computes integrity hashes, and prepares all
-        metadata needed for Croissant generation.
+        Uses PyArrow to read the CSV with automatic type inference,
+        including timestamp detection and precise numeric types.
 
         Args:
             file_path: Path to the CSV file
@@ -53,9 +73,8 @@ class CSVHandler(FileTypeHandler):
         Returns:
             Dictionary containing:
             - Basic file info (path, name, size, hash)
-            - Format information (encoding, compression)
+            - Format information (encoding)
             - Data structure (columns, types, row count)
-            - Sample data for preview
 
         Raises:
             ValueError: If the CSV file cannot be read or processed
@@ -64,45 +83,46 @@ class CSVHandler(FileTypeHandler):
         if not file_path.exists():
             raise FileNotFoundError(f"CSV file not found: {file_path}")
 
+        # Parse CSV — only this call needs error translation
         try:
-            # Read a sample for type inference (1000 rows for good accuracy)
-            df = pd.read_csv(file_path, nrows=1000)
-
-            if df.empty:
-                raise ValueError(f"CSV file is empty: {file_path}")
-
-            # Extract file properties
-            file_size = file_path.stat().st_size
-            sha256_hash = compute_file_hash(file_path)
-
-            # Analyze the data structure and types
-            data_analysis = analyze_data_sample(df)
-
-            # Determine encoding format based on file extension
-            name_lower = file_path.name.lower()
-            if name_lower.endswith(".csv.gz"):
-                encoding_format = "application/gzip"
-            elif name_lower.endswith(".csv.bz2"):
-                encoding_format = "application/x-bzip2"
-            elif name_lower.endswith(".csv.xz"):
-                encoding_format = "application/x-xz"
-            else:
-                encoding_format = "text/csv"
-
-            return {
-                "file_path": str(file_path),
-                "file_name": file_path.name,
-                "file_size": file_size,
-                "sha256": sha256_hash,
-                "encoding_format": encoding_format,
-                **data_analysis,  # Includes column_types, num_rows, columns, sample_data
-            }
-
-        except pd.errors.EmptyDataError:
-            raise ValueError(f"CSV file contains no data: {file_path}")
-        except pd.errors.ParserError as e:
+            convert_options = pa_csv.ConvertOptions(
+                timestamp_parsers=self._TIMESTAMP_PARSERS,
+            )
+            table = pa_csv.read_csv(str(file_path), convert_options=convert_options)
+        except pa.lib.ArrowInvalid as e:
             raise ValueError(f"Failed to parse CSV file {file_path}: {e}")
         except UnicodeDecodeError as e:
             raise ValueError(f"Encoding error in CSV file {file_path}: {e}")
-        except Exception as e:
-            raise ValueError(f"Failed to process CSV file {file_path}: {e}")
+
+        if table.num_rows == 0:
+            raise ValueError(f"CSV file is empty: {file_path}")
+
+        # Infer types from the Arrow schema (shared with Parquet handler)
+        column_types = infer_column_types_from_arrow_schema(table.schema)
+
+        # Extract file properties
+        file_size = file_path.stat().st_size
+        sha256_hash = compute_file_hash(file_path)
+
+        # Determine encoding format based on file extension
+        name_lower = file_path.name.lower()
+        if name_lower.endswith(".csv.gz"):
+            encoding_format = "application/gzip"
+        elif name_lower.endswith(".csv.bz2"):
+            encoding_format = "application/x-bzip2"
+        elif name_lower.endswith(".csv.xz"):
+            encoding_format = "application/x-xz"
+        else:
+            encoding_format = "text/csv"
+
+        return {
+            "file_path": str(file_path),
+            "file_name": file_path.name,
+            "file_size": file_size,
+            "sha256": sha256_hash,
+            "encoding_format": encoding_format,
+            "column_types": column_types,
+            "num_rows": table.num_rows,
+            "num_columns": table.num_columns,
+            "columns": table.column_names,
+        }

--- a/src/croissant_maker/handlers/parquet_handler.py
+++ b/src/croissant_maker/handlers/parquet_handler.py
@@ -1,12 +1,14 @@
 """Parquet file handler for tabular event streams (e.g., MEDS)."""
 
 from pathlib import Path
-from typing import Dict
+
+from pyarrow.parquet import ParquetFile
 
 from croissant_maker.handlers.base_handler import FileTypeHandler
-from croissant_maker.handlers.utils import compute_file_hash
-from pyarrow.parquet import ParquetFile
-import pyarrow.types as patypes
+from croissant_maker.handlers.utils import (
+    compute_file_hash,
+    infer_column_types_from_arrow_schema,
+)
 
 
 class ParquetHandler(FileTypeHandler):
@@ -14,7 +16,7 @@ class ParquetHandler(FileTypeHandler):
     Handler for Parquet files (.parquet) with schema-based type inference.
 
     - Uses pyarrow to read schema and row count without loading full data
-    - Emits Croissant-compatible column types
+    - Emits Croissant-compatible column types via shared map_arrow_type()
     - Computes SHA256 for reproducibility
     - Keeps memory usage minimal (schema-only)
     """
@@ -32,13 +34,9 @@ class ParquetHandler(FileTypeHandler):
             schema = pq.schema_arrow
             num_rows = pq.metadata.num_rows if pq.metadata is not None else 0
 
-            column_types: Dict[str, str] = {}
-            columns = []
-            for field in schema:
-                columns.append(field.name)
-                column_types[field.name] = self._map_arrow_type_to_croissant(
-                    field.type, patypes
-                )
+            # Use the shared Arrow type mapper (same as CSV handler)
+            column_types = infer_column_types_from_arrow_schema(schema)
+            columns = [field.name for field in schema]
 
             file_size = file_path.stat().st_size
             sha256_hash = compute_file_hash(file_path)
@@ -56,26 +54,3 @@ class ParquetHandler(FileTypeHandler):
             }
         except Exception as e:
             raise ValueError(f"Failed to process Parquet file {file_path}: {e}") from e
-
-    @staticmethod
-    def _map_arrow_type_to_croissant(arrow_type, patypes) -> str:
-        """Map pyarrow types to Croissant schema.org data types."""
-        try:
-            if patypes.is_integer(arrow_type):
-                return "sc:Integer"
-            if patypes.is_floating(arrow_type) or patypes.is_decimal(arrow_type):
-                return "sc:Float"
-            if patypes.is_boolean(arrow_type):
-                return "sc:Boolean"
-            if patypes.is_timestamp(arrow_type):
-                return "sc:Date"
-            if patypes.is_date(arrow_type):
-                return "sc:Date"
-            if patypes.is_string(arrow_type) or patypes.is_large_string(arrow_type):
-                return "sc:Text"
-            if patypes.is_binary(arrow_type) or patypes.is_large_binary(arrow_type):
-                return "sc:Text"
-        except Exception:
-            # Fallback to text for any exotic or extension types
-            pass
-        return "sc:Text"

--- a/src/croissant_maker/handlers/utils.py
+++ b/src/croissant_maker/handlers/utils.py
@@ -1,147 +1,104 @@
 """Shared utilities for file handlers."""
 
-import pandas as pd
 import hashlib
 import gzip  # Built-in: handles .gz (gzip) compression
 import bz2  # Built-in: handles .bz2 (bzip2) compression
 import lzma  # Built-in: handles .xz/.lzma (LZMA/xz) compression
-import re
 import logging
 from pathlib import Path
-from typing import Dict, Any, Union
+from typing import Dict, Union
+
+import pyarrow as pa
+import pyarrow.types as patypes
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)
 
-# Compile regex patterns once for performance
-_DATETIME_NAME_PATTERNS = [
-    re.compile(pattern)
-    for pattern in [
-        r".*time$",
-        r".*date$",
-        r".*timestamp$",
-        r"^date",
-        r"^time",
-        r"intime",
-        r"outtime",
-        r"charttime",
-        r"storetime",
-        r"dischtime",
-        r"admittime",
-        r"createtime",
-        r"updatetime",
-        r".*_dt$",
-        r".*_ts$",
-    ]
-]
 
-_DATETIME_VALUE_PATTERNS = [
-    re.compile(pattern)
-    for pattern in [
-        r"\d{4}-\d{2}-\d{2}",  # YYYY-MM-DD
-        r"\d{2}/\d{2}/\d{4}",  # MM/DD/YYYY
-        r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}",  # YYYY-MM-DD HH:MM:SS
-        r"\d{2}:\d{2}:\d{2}",  # HH:MM:SS
-    ]
-]
-
-
-def infer_column_types(df: pd.DataFrame) -> Dict[str, str]:
+def map_arrow_type(arrow_type: pa.DataType) -> str:
     """
-    Infer data types for DataFrame columns and map to Croissant types.
+    Map a PyArrow data type to the corresponding Croissant type string.
 
-    Uses pandas dtype detection combined with content analysis for
-    datetime fields that may be stored as strings.
+    Uses precise Croissant types where available (cr:Int64, cr:Float32, etc.)
+    and falls back to schema.org types for dates, text, and booleans.
+
+    This is the single source of truth for type mapping across all handlers
+    (CSV, Parquet, and future formats like JSON, O RC, Feather).
 
     Args:
-        df: DataFrame to analyze
+        arrow_type: A PyArrow DataType from a table or file schema.
+
+    Returns:
+        Croissant-compatible type string (e.g. "sc:DateTime", "cr:Int64").
+    """
+    try:
+        # Timestamps (with or without timezone) → sc:DateTime
+        if patypes.is_timestamp(arrow_type):
+            return "sc:DateTime"
+
+        # Date-only (no time component) → sc:Date
+        if patypes.is_date(arrow_type):
+            return "sc:Date"
+
+        # Time-only → sc:Time
+        if patypes.is_time(arrow_type):
+            return "sc:Time"
+
+        # Integers — use precise Croissant types with bit-width
+        if patypes.is_integer(arrow_type):
+            prefix = "cr:UInt" if patypes.is_unsigned_integer(arrow_type) else "cr:Int"
+            return f"{prefix}{arrow_type.bit_width}"
+
+        # Floats — use precise Croissant types with bit-width
+        # Croissant spec only defines cr:Float16, cr:Float32, cr:Float64.
+        # For smaller widths (e.g. float8) fall back to generic sc:Float,
+        # matching HuggingFace's behavior.
+        if patypes.is_floating(arrow_type):
+            bw = arrow_type.bit_width
+            if bw in (16, 32, 64):
+                return f"cr:Float{bw}"
+            return "sc:Float"
+
+        # Decimals → cr:Float64 (best general approximation)
+        if patypes.is_decimal(arrow_type):
+            return "cr:Float64"
+
+        # Booleans
+        if patypes.is_boolean(arrow_type):
+            return "sc:Boolean"
+
+        # Strings
+        if patypes.is_string(arrow_type) or patypes.is_large_string(arrow_type):
+            return "sc:Text"
+
+        # Binary data
+        if patypes.is_binary(arrow_type) or patypes.is_large_binary(arrow_type):
+            return "sc:Text"
+
+        # Null type (all values null) → safe fallback
+        if patypes.is_null(arrow_type):
+            return "sc:Text"
+
+    except Exception:
+        pass
+
+    # Fallback for any unrecognized or exotic types
+    return "sc:Text"
+
+
+def infer_column_types_from_arrow_schema(schema: pa.Schema) -> Dict[str, str]:
+    """
+    Infer Croissant types for all columns in a PyArrow schema.
+
+    This is the shared entry point used by both CSV and Parquet handlers.
+
+    Args:
+        schema: A PyArrow Schema (from a Table, ParquetFile, etc.)
 
     Returns:
         Dictionary mapping column names to Croissant type strings.
-        Returns empty dict if DataFrame is None or empty.
     """
-    if df is None or df.empty:
-        logger.warning("Empty or None DataFrame provided to infer_column_types")
-        return {}
-
-    type_mapping = {}
-
-    for column in df.columns:
-        try:
-            series = df[column].dropna()
-
-            if len(series) == 0:
-                type_mapping[column] = "sc:Text"
-                continue
-
-            # Check pandas dtype first
-            if pd.api.types.is_integer_dtype(series):
-                type_mapping[column] = "sc:Integer"
-            elif pd.api.types.is_float_dtype(series):
-                type_mapping[column] = "sc:Float"
-            elif pd.api.types.is_bool_dtype(series):
-                type_mapping[column] = "sc:Boolean"
-            elif pd.api.types.is_datetime64_any_dtype(series):
-                type_mapping[column] = "sc:Date"
-            else:
-                # Check if string column contains datetime values
-                if _is_likely_datetime_column(column, series):
-                    type_mapping[column] = "sc:Date"
-                else:
-                    type_mapping[column] = "sc:Text"
-        except Exception as e:
-            # Log warning but don't fail - default to Text for problematic columns
-            logger.warning(f"Could not infer type for column '{column}': {e}")
-            type_mapping[column] = "sc:Text"
-
-    return type_mapping
-
-
-def _is_likely_datetime_column(column_name: str, series: pd.Series) -> bool:
-    """
-    Determine if a column likely contains datetime data.
-
-    Uses column name patterns and value sampling to detect datetime columns.
-    """
-    # Check column name patterns
-    column_lower = column_name.lower()
-    name_matches = any(
-        pattern.match(column_lower) for pattern in _DATETIME_NAME_PATTERNS
-    )
-
-    if not name_matches:
-        return False
-
-    # Verify with sample values
-    sample_values = series.head(10).astype(str)
-
-    # Check if values match datetime patterns
-    for value in sample_values:
-        for dt_pattern in _DATETIME_VALUE_PATTERNS:
-            if dt_pattern.search(str(value)):
-                return True
-
-    return False
-
-
-def analyze_data_sample(df: pd.DataFrame, max_rows: int = 3) -> Dict[str, Any]:
-    """
-    Analyze a DataFrame and return useful metadata about the data.
-
-    Args:
-        df: DataFrame to analyze
-        max_rows: Maximum number of sample rows to include
-
-    Returns:
-        Dictionary containing column types, sample data, and basic stats
-    """
-    return {
-        "column_types": infer_column_types(df),
-        "num_rows": len(df),
-        "num_columns": len(df.columns),
-        "columns": list(df.columns),
-        "sample_data": df.head(max_rows).to_dict("records") if len(df) > 0 else [],
-    }
+    return {field.name: map_arrow_type(field.type) for field in schema}
 
 
 def compute_file_hash(file_path: Union[str, Path]) -> str:

--- a/tests/data/output/eicu_demo_croissant.jsonld
+++ b/tests/data/output/eicu_demo_croissant.jsonld
@@ -38,6 +38,7 @@
     "regex": "cr:regex",
     "repeated": "cr:repeated",
     "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
     "sc": "https://schema.org/",
     "separator": "cr:separator",
     "source": "cr:source",
@@ -357,14 +358,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_0",
       "name": "diagnosis",
-      "description": "Records from diagnosis.csv.gz (1000 rows)",
+      "description": "Records from diagnosis.csv.gz (24978 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_0_diagnosisid",
           "name": "diagnosisid",
           "description": "Column 'diagnosisid' from diagnosis.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_diagnosisid",
             "fileObject": {
@@ -380,7 +381,7 @@
           "@id": "file_0_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from diagnosis.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_patientunitstayid",
             "fileObject": {
@@ -412,7 +413,7 @@
           "@id": "file_0_diagnosisoffset",
           "name": "diagnosisoffset",
           "description": "Column 'diagnosisoffset' from diagnosis.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_diagnosisoffset",
             "fileObject": {
@@ -477,14 +478,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_1",
       "name": "vitalAperiodic",
-      "description": "Records from vitalAperiodic.csv.gz (1000 rows)",
+      "description": "Records from vitalAperiodic.csv.gz (274088 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_1_vitalaperiodicid",
           "name": "vitalaperiodicid",
           "description": "Column 'vitalaperiodicid' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_vitalaperiodicid",
             "fileObject": {
@@ -500,7 +501,7 @@
           "@id": "file_1_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_patientunitstayid",
             "fileObject": {
@@ -516,7 +517,7 @@
           "@id": "file_1_observationoffset",
           "name": "observationoffset",
           "description": "Column 'observationoffset' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_observationoffset",
             "fileObject": {
@@ -532,7 +533,7 @@
           "@id": "file_1_noninvasivesystolic",
           "name": "noninvasivesystolic",
           "description": "Column 'noninvasivesystolic' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_noninvasivesystolic",
             "fileObject": {
@@ -548,7 +549,7 @@
           "@id": "file_1_noninvasivediastolic",
           "name": "noninvasivediastolic",
           "description": "Column 'noninvasivediastolic' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_noninvasivediastolic",
             "fileObject": {
@@ -564,7 +565,7 @@
           "@id": "file_1_noninvasivemean",
           "name": "noninvasivemean",
           "description": "Column 'noninvasivemean' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_noninvasivemean",
             "fileObject": {
@@ -580,7 +581,7 @@
           "@id": "file_1_paop",
           "name": "paop",
           "description": "Column 'paop' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_paop",
             "fileObject": {
@@ -596,7 +597,7 @@
           "@id": "file_1_cardiacoutput",
           "name": "cardiacoutput",
           "description": "Column 'cardiacoutput' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_1_source_cardiacoutput",
             "fileObject": {
@@ -612,7 +613,7 @@
           "@id": "file_1_cardiacinput",
           "name": "cardiacinput",
           "description": "Column 'cardiacinput' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_1_source_cardiacinput",
             "fileObject": {
@@ -628,7 +629,7 @@
           "@id": "file_1_svr",
           "name": "svr",
           "description": "Column 'svr' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_svr",
             "fileObject": {
@@ -644,7 +645,7 @@
           "@id": "file_1_svri",
           "name": "svri",
           "description": "Column 'svri' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_svri",
             "fileObject": {
@@ -660,7 +661,7 @@
           "@id": "file_1_pvr",
           "name": "pvr",
           "description": "Column 'pvr' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_pvr",
             "fileObject": {
@@ -676,7 +677,7 @@
           "@id": "file_1_pvri",
           "name": "pvri",
           "description": "Column 'pvri' from vitalAperiodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_pvri",
             "fileObject": {
@@ -693,14 +694,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_2",
       "name": "admissionDx",
-      "description": "Records from admissionDx.csv.gz (1000 rows)",
+      "description": "Records from admissionDx.csv.gz (7578 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_2_admissiondxid",
           "name": "admissiondxid",
           "description": "Column 'admissiondxid' from admissionDx.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_admissiondxid",
             "fileObject": {
@@ -716,7 +717,7 @@
           "@id": "file_2_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from admissionDx.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_patientunitstayid",
             "fileObject": {
@@ -732,7 +733,7 @@
           "@id": "file_2_admitdxenteredoffset",
           "name": "admitdxenteredoffset",
           "description": "Column 'admitdxenteredoffset' from admissionDx.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_admitdxenteredoffset",
             "fileObject": {
@@ -797,14 +798,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_3",
       "name": "respiratoryCare",
-      "description": "Records from respiratoryCare.csv.gz (1000 rows)",
+      "description": "Records from respiratoryCare.csv.gz (5436 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_3_respcareid",
           "name": "respcareid",
           "description": "Column 'respcareid' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_respcareid",
             "fileObject": {
@@ -820,7 +821,7 @@
           "@id": "file_3_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_patientunitstayid",
             "fileObject": {
@@ -836,7 +837,7 @@
           "@id": "file_3_respcarestatusoffset",
           "name": "respcarestatusoffset",
           "description": "Column 'respcarestatusoffset' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_respcarestatusoffset",
             "fileObject": {
@@ -852,7 +853,7 @@
           "@id": "file_3_currenthistoryseqnum",
           "name": "currenthistoryseqnum",
           "description": "Column 'currenthistoryseqnum' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_currenthistoryseqnum",
             "fileObject": {
@@ -884,7 +885,7 @@
           "@id": "file_3_airwaysize",
           "name": "airwaysize",
           "description": "Column 'airwaysize' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_airwaysize",
             "fileObject": {
@@ -900,7 +901,7 @@
           "@id": "file_3_airwayposition",
           "name": "airwayposition",
           "description": "Column 'airwayposition' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "sc:Text",
           "source": {
             "@id": "file_3_source_airwayposition",
             "fileObject": {
@@ -916,7 +917,7 @@
           "@id": "file_3_cuffpressure",
           "name": "cuffpressure",
           "description": "Column 'cuffpressure' from respiratoryCare.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_cuffpressure",
             "fileObject": {
@@ -932,7 +933,7 @@
           "@id": "file_3_ventstartoffset",
           "name": "ventstartoffset",
           "description": "Column 'ventstartoffset' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_ventstartoffset",
             "fileObject": {
@@ -948,7 +949,7 @@
           "@id": "file_3_ventendoffset",
           "name": "ventendoffset",
           "description": "Column 'ventendoffset' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_ventendoffset",
             "fileObject": {
@@ -964,7 +965,7 @@
           "@id": "file_3_priorventstartoffset",
           "name": "priorventstartoffset",
           "description": "Column 'priorventstartoffset' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_priorventstartoffset",
             "fileObject": {
@@ -980,7 +981,7 @@
           "@id": "file_3_priorventendoffset",
           "name": "priorventendoffset",
           "description": "Column 'priorventendoffset' from respiratoryCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_priorventendoffset",
             "fileObject": {
@@ -1012,7 +1013,7 @@
           "@id": "file_3_lowexhmvlimit",
           "name": "lowexhmvlimit",
           "description": "Column 'lowexhmvlimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_lowexhmvlimit",
             "fileObject": {
@@ -1028,7 +1029,7 @@
           "@id": "file_3_hiexhmvlimit",
           "name": "hiexhmvlimit",
           "description": "Column 'hiexhmvlimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_hiexhmvlimit",
             "fileObject": {
@@ -1044,7 +1045,7 @@
           "@id": "file_3_lowexhtvlimit",
           "name": "lowexhtvlimit",
           "description": "Column 'lowexhtvlimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_lowexhtvlimit",
             "fileObject": {
@@ -1060,7 +1061,7 @@
           "@id": "file_3_hipeakpreslimit",
           "name": "hipeakpreslimit",
           "description": "Column 'hipeakpreslimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_hipeakpreslimit",
             "fileObject": {
@@ -1076,7 +1077,7 @@
           "@id": "file_3_lowpeakpreslimit",
           "name": "lowpeakpreslimit",
           "description": "Column 'lowpeakpreslimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_lowpeakpreslimit",
             "fileObject": {
@@ -1092,7 +1093,7 @@
           "@id": "file_3_hirespratelimit",
           "name": "hirespratelimit",
           "description": "Column 'hirespratelimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_hirespratelimit",
             "fileObject": {
@@ -1108,7 +1109,7 @@
           "@id": "file_3_lowrespratelimit",
           "name": "lowrespratelimit",
           "description": "Column 'lowrespratelimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_lowrespratelimit",
             "fileObject": {
@@ -1188,7 +1189,7 @@
           "@id": "file_3_peeplimit",
           "name": "peeplimit",
           "description": "Column 'peeplimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_peeplimit",
             "fileObject": {
@@ -1204,7 +1205,7 @@
           "@id": "file_3_cpaplimit",
           "name": "cpaplimit",
           "description": "Column 'cpaplimit' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_3_source_cpaplimit",
             "fileObject": {
@@ -1220,7 +1221,7 @@
           "@id": "file_3_setapneainterval",
           "name": "setapneainterval",
           "description": "Column 'setapneainterval' from respiratoryCare.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapneainterval",
             "fileObject": {
@@ -1236,7 +1237,7 @@
           "@id": "file_3_setapneatv",
           "name": "setapneatv",
           "description": "Column 'setapneatv' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapneatv",
             "fileObject": {
@@ -1252,7 +1253,7 @@
           "@id": "file_3_setapneaippeephigh",
           "name": "setapneaippeephigh",
           "description": "Column 'setapneaippeephigh' from respiratoryCare.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapneaippeephigh",
             "fileObject": {
@@ -1268,7 +1269,7 @@
           "@id": "file_3_setapnearr",
           "name": "setapnearr",
           "description": "Column 'setapnearr' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapnearr",
             "fileObject": {
@@ -1284,7 +1285,7 @@
           "@id": "file_3_setapneapeakflow",
           "name": "setapneapeakflow",
           "description": "Column 'setapneapeakflow' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapneapeakflow",
             "fileObject": {
@@ -1300,7 +1301,7 @@
           "@id": "file_3_setapneainsptime",
           "name": "setapneainsptime",
           "description": "Column 'setapneainsptime' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapneainsptime",
             "fileObject": {
@@ -1332,7 +1333,7 @@
           "@id": "file_3_setapneafio2",
           "name": "setapneafio2",
           "description": "Column 'setapneafio2' from respiratoryCare.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_setapneafio2",
             "fileObject": {
@@ -1349,14 +1350,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_4",
       "name": "nurseAssessment",
-      "description": "Records from nurseAssessment.csv.gz (1000 rows)",
+      "description": "Records from nurseAssessment.csv.gz (91589 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_4_nurseassessid",
           "name": "nurseassessid",
           "description": "Column 'nurseassessid' from nurseAssessment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_nurseassessid",
             "fileObject": {
@@ -1372,7 +1373,7 @@
           "@id": "file_4_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from nurseAssessment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_patientunitstayid",
             "fileObject": {
@@ -1388,7 +1389,7 @@
           "@id": "file_4_nurseassessoffset",
           "name": "nurseassessoffset",
           "description": "Column 'nurseassessoffset' from nurseAssessment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_nurseassessoffset",
             "fileObject": {
@@ -1404,7 +1405,7 @@
           "@id": "file_4_nurseassessentryoffset",
           "name": "nurseassessentryoffset",
           "description": "Column 'nurseassessentryoffset' from nurseAssessment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_nurseassessentryoffset",
             "fileObject": {
@@ -1492,7 +1493,7 @@
           "@id": "file_5_hospitalid",
           "name": "hospitalid",
           "description": "Column 'hospitalid' from hospital.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_hospitalid",
             "fileObject": {
@@ -1557,14 +1558,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_6",
       "name": "vitalPeriodic",
-      "description": "Records from vitalPeriodic.csv.gz (1000 rows)",
+      "description": "Records from vitalPeriodic.csv.gz (1634960 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_6_vitalperiodicid",
           "name": "vitalperiodicid",
           "description": "Column 'vitalperiodicid' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_vitalperiodicid",
             "fileObject": {
@@ -1580,7 +1581,7 @@
           "@id": "file_6_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_patientunitstayid",
             "fileObject": {
@@ -1596,7 +1597,7 @@
           "@id": "file_6_observationoffset",
           "name": "observationoffset",
           "description": "Column 'observationoffset' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_observationoffset",
             "fileObject": {
@@ -1612,7 +1613,7 @@
           "@id": "file_6_temperature",
           "name": "temperature",
           "description": "Column 'temperature' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_temperature",
             "fileObject": {
@@ -1628,7 +1629,7 @@
           "@id": "file_6_sao2",
           "name": "sao2",
           "description": "Column 'sao2' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_sao2",
             "fileObject": {
@@ -1644,7 +1645,7 @@
           "@id": "file_6_heartrate",
           "name": "heartrate",
           "description": "Column 'heartrate' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_heartrate",
             "fileObject": {
@@ -1660,7 +1661,7 @@
           "@id": "file_6_respiration",
           "name": "respiration",
           "description": "Column 'respiration' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_respiration",
             "fileObject": {
@@ -1676,7 +1677,7 @@
           "@id": "file_6_cvp",
           "name": "cvp",
           "description": "Column 'cvp' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_cvp",
             "fileObject": {
@@ -1692,7 +1693,7 @@
           "@id": "file_6_etco2",
           "name": "etco2",
           "description": "Column 'etco2' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_etco2",
             "fileObject": {
@@ -1708,7 +1709,7 @@
           "@id": "file_6_systemicsystolic",
           "name": "systemicsystolic",
           "description": "Column 'systemicsystolic' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_systemicsystolic",
             "fileObject": {
@@ -1724,7 +1725,7 @@
           "@id": "file_6_systemicdiastolic",
           "name": "systemicdiastolic",
           "description": "Column 'systemicdiastolic' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_systemicdiastolic",
             "fileObject": {
@@ -1740,7 +1741,7 @@
           "@id": "file_6_systemicmean",
           "name": "systemicmean",
           "description": "Column 'systemicmean' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_systemicmean",
             "fileObject": {
@@ -1756,7 +1757,7 @@
           "@id": "file_6_pasystolic",
           "name": "pasystolic",
           "description": "Column 'pasystolic' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_pasystolic",
             "fileObject": {
@@ -1772,7 +1773,7 @@
           "@id": "file_6_padiastolic",
           "name": "padiastolic",
           "description": "Column 'padiastolic' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_padiastolic",
             "fileObject": {
@@ -1788,7 +1789,7 @@
           "@id": "file_6_pamean",
           "name": "pamean",
           "description": "Column 'pamean' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_pamean",
             "fileObject": {
@@ -1804,7 +1805,7 @@
           "@id": "file_6_st1",
           "name": "st1",
           "description": "Column 'st1' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_st1",
             "fileObject": {
@@ -1820,7 +1821,7 @@
           "@id": "file_6_st2",
           "name": "st2",
           "description": "Column 'st2' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_st2",
             "fileObject": {
@@ -1836,7 +1837,7 @@
           "@id": "file_6_st3",
           "name": "st3",
           "description": "Column 'st3' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_st3",
             "fileObject": {
@@ -1852,7 +1853,7 @@
           "@id": "file_6_icp",
           "name": "icp",
           "description": "Column 'icp' from vitalPeriodic.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_icp",
             "fileObject": {
@@ -1869,14 +1870,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_7",
       "name": "carePlanGeneral",
-      "description": "Records from carePlanGeneral.csv.gz (1000 rows)",
+      "description": "Records from carePlanGeneral.csv.gz (33148 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_7_cplgeneralid",
           "name": "cplgeneralid",
           "description": "Column 'cplgeneralid' from carePlanGeneral.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_cplgeneralid",
             "fileObject": {
@@ -1892,7 +1893,7 @@
           "@id": "file_7_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from carePlanGeneral.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_patientunitstayid",
             "fileObject": {
@@ -1924,7 +1925,7 @@
           "@id": "file_7_cplitemoffset",
           "name": "cplitemoffset",
           "description": "Column 'cplitemoffset' from carePlanGeneral.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_cplitemoffset",
             "fileObject": {
@@ -1973,14 +1974,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_8",
       "name": "patient",
-      "description": "Records from patient.csv.gz (1000 rows)",
+      "description": "Records from patient.csv.gz (2520 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_8_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_patientunitstayid",
             "fileObject": {
@@ -1996,7 +1997,7 @@
           "@id": "file_8_patienthealthsystemstayid",
           "name": "patienthealthsystemstayid",
           "description": "Column 'patienthealthsystemstayid' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_patienthealthsystemstayid",
             "fileObject": {
@@ -2060,7 +2061,7 @@
           "@id": "file_8_hospitalid",
           "name": "hospitalid",
           "description": "Column 'hospitalid' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_hospitalid",
             "fileObject": {
@@ -2076,7 +2077,7 @@
           "@id": "file_8_wardid",
           "name": "wardid",
           "description": "Column 'wardid' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_wardid",
             "fileObject": {
@@ -2108,7 +2109,7 @@
           "@id": "file_8_admissionheight",
           "name": "admissionheight",
           "description": "Column 'admissionheight' from patient.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_8_source_admissionheight",
             "fileObject": {
@@ -2124,7 +2125,7 @@
           "@id": "file_8_hospitaladmittime24",
           "name": "hospitaladmittime24",
           "description": "Column 'hospitaladmittime24' from patient.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "sc:Time",
           "source": {
             "@id": "file_8_source_hospitaladmittime24",
             "fileObject": {
@@ -2140,7 +2141,7 @@
           "@id": "file_8_hospitaladmitoffset",
           "name": "hospitaladmitoffset",
           "description": "Column 'hospitaladmitoffset' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_hospitaladmitoffset",
             "fileObject": {
@@ -2172,7 +2173,7 @@
           "@id": "file_8_hospitaldischargeyear",
           "name": "hospitaldischargeyear",
           "description": "Column 'hospitaldischargeyear' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_hospitaldischargeyear",
             "fileObject": {
@@ -2188,7 +2189,7 @@
           "@id": "file_8_hospitaldischargetime24",
           "name": "hospitaldischargetime24",
           "description": "Column 'hospitaldischargetime24' from patient.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "sc:Time",
           "source": {
             "@id": "file_8_source_hospitaldischargetime24",
             "fileObject": {
@@ -2204,7 +2205,7 @@
           "@id": "file_8_hospitaldischargeoffset",
           "name": "hospitaldischargeoffset",
           "description": "Column 'hospitaldischargeoffset' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_hospitaldischargeoffset",
             "fileObject": {
@@ -2268,7 +2269,7 @@
           "@id": "file_8_unitadmittime24",
           "name": "unitadmittime24",
           "description": "Column 'unitadmittime24' from patient.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "sc:Time",
           "source": {
             "@id": "file_8_source_unitadmittime24",
             "fileObject": {
@@ -2300,7 +2301,7 @@
           "@id": "file_8_unitvisitnumber",
           "name": "unitvisitnumber",
           "description": "Column 'unitvisitnumber' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_unitvisitnumber",
             "fileObject": {
@@ -2332,7 +2333,7 @@
           "@id": "file_8_admissionweight",
           "name": "admissionweight",
           "description": "Column 'admissionweight' from patient.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_8_source_admissionweight",
             "fileObject": {
@@ -2348,7 +2349,7 @@
           "@id": "file_8_dischargeweight",
           "name": "dischargeweight",
           "description": "Column 'dischargeweight' from patient.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_8_source_dischargeweight",
             "fileObject": {
@@ -2364,7 +2365,7 @@
           "@id": "file_8_unitdischargetime24",
           "name": "unitdischargetime24",
           "description": "Column 'unitdischargetime24' from patient.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "sc:Time",
           "source": {
             "@id": "file_8_source_unitdischargetime24",
             "fileObject": {
@@ -2380,7 +2381,7 @@
           "@id": "file_8_unitdischargeoffset",
           "name": "unitdischargeoffset",
           "description": "Column 'unitdischargeoffset' from patient.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_unitdischargeoffset",
             "fileObject": {
@@ -2445,14 +2446,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_9",
       "name": "carePlanGoal",
-      "description": "Records from carePlanGoal.csv.gz (1000 rows)",
+      "description": "Records from carePlanGoal.csv.gz (3633 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_9_cplgoalid",
           "name": "cplgoalid",
           "description": "Column 'cplgoalid' from carePlanGoal.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_cplgoalid",
             "fileObject": {
@@ -2468,7 +2469,7 @@
           "@id": "file_9_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from carePlanGoal.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_patientunitstayid",
             "fileObject": {
@@ -2484,7 +2485,7 @@
           "@id": "file_9_cplgoaloffset",
           "name": "cplgoaloffset",
           "description": "Column 'cplgoaloffset' from carePlanGoal.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_cplgoaloffset",
             "fileObject": {
@@ -2565,14 +2566,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_10",
       "name": "treatment",
-      "description": "Records from treatment.csv.gz (1000 rows)",
+      "description": "Records from treatment.csv.gz (38290 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_10_treatmentid",
           "name": "treatmentid",
           "description": "Column 'treatmentid' from treatment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_10_source_treatmentid",
             "fileObject": {
@@ -2588,7 +2589,7 @@
           "@id": "file_10_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from treatment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_10_source_patientunitstayid",
             "fileObject": {
@@ -2604,7 +2605,7 @@
           "@id": "file_10_treatmentoffset",
           "name": "treatmentoffset",
           "description": "Column 'treatmentoffset' from treatment.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_10_source_treatmentoffset",
             "fileObject": {
@@ -2653,14 +2654,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_11",
       "name": "apacheApsVar",
-      "description": "Records from apacheApsVar.csv.gz (1000 rows)",
+      "description": "Records from apacheApsVar.csv.gz (2205 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_11_apacheapsvarid",
           "name": "apacheapsvarid",
           "description": "Column 'apacheapsvarid' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_apacheapsvarid",
             "fileObject": {
@@ -2676,7 +2677,7 @@
           "@id": "file_11_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_patientunitstayid",
             "fileObject": {
@@ -2692,7 +2693,7 @@
           "@id": "file_11_intubated",
           "name": "intubated",
           "description": "Column 'intubated' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_intubated",
             "fileObject": {
@@ -2708,7 +2709,7 @@
           "@id": "file_11_vent",
           "name": "vent",
           "description": "Column 'vent' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_vent",
             "fileObject": {
@@ -2724,7 +2725,7 @@
           "@id": "file_11_dialysis",
           "name": "dialysis",
           "description": "Column 'dialysis' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_dialysis",
             "fileObject": {
@@ -2740,7 +2741,7 @@
           "@id": "file_11_eyes",
           "name": "eyes",
           "description": "Column 'eyes' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_eyes",
             "fileObject": {
@@ -2756,7 +2757,7 @@
           "@id": "file_11_motor",
           "name": "motor",
           "description": "Column 'motor' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_motor",
             "fileObject": {
@@ -2772,7 +2773,7 @@
           "@id": "file_11_verbal",
           "name": "verbal",
           "description": "Column 'verbal' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_verbal",
             "fileObject": {
@@ -2788,7 +2789,7 @@
           "@id": "file_11_meds",
           "name": "meds",
           "description": "Column 'meds' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_meds",
             "fileObject": {
@@ -2804,7 +2805,7 @@
           "@id": "file_11_urine",
           "name": "urine",
           "description": "Column 'urine' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_urine",
             "fileObject": {
@@ -2820,7 +2821,7 @@
           "@id": "file_11_wbc",
           "name": "wbc",
           "description": "Column 'wbc' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_wbc",
             "fileObject": {
@@ -2836,7 +2837,7 @@
           "@id": "file_11_temperature",
           "name": "temperature",
           "description": "Column 'temperature' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_temperature",
             "fileObject": {
@@ -2852,7 +2853,7 @@
           "@id": "file_11_respiratoryrate",
           "name": "respiratoryrate",
           "description": "Column 'respiratoryrate' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_respiratoryrate",
             "fileObject": {
@@ -2868,7 +2869,7 @@
           "@id": "file_11_sodium",
           "name": "sodium",
           "description": "Column 'sodium' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_sodium",
             "fileObject": {
@@ -2884,7 +2885,7 @@
           "@id": "file_11_heartrate",
           "name": "heartrate",
           "description": "Column 'heartrate' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_heartrate",
             "fileObject": {
@@ -2900,7 +2901,7 @@
           "@id": "file_11_meanbp",
           "name": "meanbp",
           "description": "Column 'meanbp' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_meanbp",
             "fileObject": {
@@ -2916,7 +2917,7 @@
           "@id": "file_11_ph",
           "name": "ph",
           "description": "Column 'ph' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_ph",
             "fileObject": {
@@ -2932,7 +2933,7 @@
           "@id": "file_11_hematocrit",
           "name": "hematocrit",
           "description": "Column 'hematocrit' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_hematocrit",
             "fileObject": {
@@ -2948,7 +2949,7 @@
           "@id": "file_11_creatinine",
           "name": "creatinine",
           "description": "Column 'creatinine' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_creatinine",
             "fileObject": {
@@ -2964,7 +2965,7 @@
           "@id": "file_11_albumin",
           "name": "albumin",
           "description": "Column 'albumin' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_albumin",
             "fileObject": {
@@ -2980,7 +2981,7 @@
           "@id": "file_11_pao2",
           "name": "pao2",
           "description": "Column 'pao2' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_pao2",
             "fileObject": {
@@ -2996,7 +2997,7 @@
           "@id": "file_11_pco2",
           "name": "pco2",
           "description": "Column 'pco2' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_pco2",
             "fileObject": {
@@ -3012,7 +3013,7 @@
           "@id": "file_11_bun",
           "name": "bun",
           "description": "Column 'bun' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_bun",
             "fileObject": {
@@ -3028,7 +3029,7 @@
           "@id": "file_11_glucose",
           "name": "glucose",
           "description": "Column 'glucose' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_glucose",
             "fileObject": {
@@ -3044,7 +3045,7 @@
           "@id": "file_11_bilirubin",
           "name": "bilirubin",
           "description": "Column 'bilirubin' from apacheApsVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_bilirubin",
             "fileObject": {
@@ -3060,7 +3061,7 @@
           "@id": "file_11_fio2",
           "name": "fio2",
           "description": "Column 'fio2' from apacheApsVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_fio2",
             "fileObject": {
@@ -3084,7 +3085,7 @@
           "@id": "file_12_cpleolid",
           "name": "cpleolid",
           "description": "Column 'cpleolid' from carePlanEOL.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_cpleolid",
             "fileObject": {
@@ -3100,7 +3101,7 @@
           "@id": "file_12_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from carePlanEOL.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_patientunitstayid",
             "fileObject": {
@@ -3116,7 +3117,7 @@
           "@id": "file_12_cpleolsaveoffset",
           "name": "cpleolsaveoffset",
           "description": "Column 'cpleolsaveoffset' from carePlanEOL.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_cpleolsaveoffset",
             "fileObject": {
@@ -3132,7 +3133,7 @@
           "@id": "file_12_cpleoldiscussionoffset",
           "name": "cpleoldiscussionoffset",
           "description": "Column 'cpleoldiscussionoffset' from carePlanEOL.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_cpleoldiscussionoffset",
             "fileObject": {
@@ -3165,14 +3166,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_13",
       "name": "infusiondrug",
-      "description": "Records from infusiondrug.csv.gz (1000 rows)",
+      "description": "Records from infusiondrug.csv.gz (38256 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_13_infusiondrugid",
           "name": "infusiondrugid",
           "description": "Column 'infusiondrugid' from infusiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_infusiondrugid",
             "fileObject": {
@@ -3188,7 +3189,7 @@
           "@id": "file_13_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from infusiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_patientunitstayid",
             "fileObject": {
@@ -3204,7 +3205,7 @@
           "@id": "file_13_infusionoffset",
           "name": "infusionoffset",
           "description": "Column 'infusionoffset' from infusiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_infusionoffset",
             "fileObject": {
@@ -3236,7 +3237,7 @@
           "@id": "file_13_drugrate",
           "name": "drugrate",
           "description": "Column 'drugrate' from infusiondrug.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "sc:Text",
           "source": {
             "@id": "file_13_source_drugrate",
             "fileObject": {
@@ -3252,7 +3253,7 @@
           "@id": "file_13_infusionrate",
           "name": "infusionrate",
           "description": "Column 'infusionrate' from infusiondrug.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_13_source_infusionrate",
             "fileObject": {
@@ -3268,7 +3269,7 @@
           "@id": "file_13_drugamount",
           "name": "drugamount",
           "description": "Column 'drugamount' from infusiondrug.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_13_source_drugamount",
             "fileObject": {
@@ -3284,7 +3285,7 @@
           "@id": "file_13_volumeoffluid",
           "name": "volumeoffluid",
           "description": "Column 'volumeoffluid' from infusiondrug.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_13_source_volumeoffluid",
             "fileObject": {
@@ -3300,7 +3301,7 @@
           "@id": "file_13_patientweight",
           "name": "patientweight",
           "description": "Column 'patientweight' from infusiondrug.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_13_source_patientweight",
             "fileObject": {
@@ -3317,14 +3318,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_14",
       "name": "carePlanCareProvider",
-      "description": "Records from carePlanCareProvider.csv.gz (1000 rows)",
+      "description": "Records from carePlanCareProvider.csv.gz (5627 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_14_cplcareprovderid",
           "name": "cplcareprovderid",
           "description": "Column 'cplcareprovderid' from carePlanCareProvider.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_cplcareprovderid",
             "fileObject": {
@@ -3340,7 +3341,7 @@
           "@id": "file_14_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from carePlanCareProvider.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_patientunitstayid",
             "fileObject": {
@@ -3356,7 +3357,7 @@
           "@id": "file_14_careprovidersaveoffset",
           "name": "careprovidersaveoffset",
           "description": "Column 'careprovidersaveoffset' from carePlanCareProvider.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_careprovidersaveoffset",
             "fileObject": {
@@ -3460,7 +3461,7 @@
           "@id": "file_15_microlabid",
           "name": "microlabid",
           "description": "Column 'microlabid' from microLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_microlabid",
             "fileObject": {
@@ -3476,7 +3477,7 @@
           "@id": "file_15_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from microLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_patientunitstayid",
             "fileObject": {
@@ -3492,7 +3493,7 @@
           "@id": "file_15_culturetakenoffset",
           "name": "culturetakenoffset",
           "description": "Column 'culturetakenoffset' from microLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_culturetakenoffset",
             "fileObject": {
@@ -3573,14 +3574,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_16",
       "name": "nurseCare",
-      "description": "Records from nurseCare.csv.gz (1000 rows)",
+      "description": "Records from nurseCare.csv.gz (42080 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_16_nursecareid",
           "name": "nursecareid",
           "description": "Column 'nursecareid' from nurseCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_nursecareid",
             "fileObject": {
@@ -3596,7 +3597,7 @@
           "@id": "file_16_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from nurseCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_patientunitstayid",
             "fileObject": {
@@ -3628,7 +3629,7 @@
           "@id": "file_16_nursecareoffset",
           "name": "nursecareoffset",
           "description": "Column 'nursecareoffset' from nurseCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_nursecareoffset",
             "fileObject": {
@@ -3644,7 +3645,7 @@
           "@id": "file_16_nursecareentryoffset",
           "name": "nursecareentryoffset",
           "description": "Column 'nursecareentryoffset' from nurseCare.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_nursecareentryoffset",
             "fileObject": {
@@ -3709,14 +3710,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_17",
       "name": "physicalExam",
-      "description": "Records from physicalExam.csv.gz (1000 rows)",
+      "description": "Records from physicalExam.csv.gz (84058 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_17_physicalexamid",
           "name": "physicalexamid",
           "description": "Column 'physicalexamid' from physicalExam.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_physicalexamid",
             "fileObject": {
@@ -3732,7 +3733,7 @@
           "@id": "file_17_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from physicalExam.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_patientunitstayid",
             "fileObject": {
@@ -3748,7 +3749,7 @@
           "@id": "file_17_physicalexamoffset",
           "name": "physicalexamoffset",
           "description": "Column 'physicalexamoffset' from physicalExam.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_physicalexamoffset",
             "fileObject": {
@@ -3813,14 +3814,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_18",
       "name": "respiratoryCharting",
-      "description": "Records from respiratoryCharting.csv.gz (1000 rows)",
+      "description": "Records from respiratoryCharting.csv.gz (176089 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_18_respchartid",
           "name": "respchartid",
           "description": "Column 'respchartid' from respiratoryCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_respchartid",
             "fileObject": {
@@ -3836,7 +3837,7 @@
           "@id": "file_18_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from respiratoryCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_patientunitstayid",
             "fileObject": {
@@ -3852,7 +3853,7 @@
           "@id": "file_18_respchartoffset",
           "name": "respchartoffset",
           "description": "Column 'respchartoffset' from respiratoryCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_respchartoffset",
             "fileObject": {
@@ -3868,7 +3869,7 @@
           "@id": "file_18_respchartentryoffset",
           "name": "respchartentryoffset",
           "description": "Column 'respchartentryoffset' from respiratoryCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_respchartentryoffset",
             "fileObject": {
@@ -3933,14 +3934,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_19",
       "name": "note",
-      "description": "Records from note.csv.gz (1000 rows)",
+      "description": "Records from note.csv.gz (24758 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_19_noteid",
           "name": "noteid",
           "description": "Column 'noteid' from note.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_noteid",
             "fileObject": {
@@ -3956,7 +3957,7 @@
           "@id": "file_19_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from note.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_patientunitstayid",
             "fileObject": {
@@ -3972,7 +3973,7 @@
           "@id": "file_19_noteoffset",
           "name": "noteoffset",
           "description": "Column 'noteoffset' from note.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_noteoffset",
             "fileObject": {
@@ -3988,7 +3989,7 @@
           "@id": "file_19_noteenteredoffset",
           "name": "noteenteredoffset",
           "description": "Column 'noteenteredoffset' from note.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_noteenteredoffset",
             "fileObject": {
@@ -4069,14 +4070,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_20",
       "name": "admissiondrug",
-      "description": "Records from admissiondrug.csv.gz (1000 rows)",
+      "description": "Records from admissiondrug.csv.gz (7417 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_20_admissiondrugid",
           "name": "admissiondrugid",
           "description": "Column 'admissiondrugid' from admissiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_admissiondrugid",
             "fileObject": {
@@ -4092,7 +4093,7 @@
           "@id": "file_20_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from admissiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_patientunitstayid",
             "fileObject": {
@@ -4108,7 +4109,7 @@
           "@id": "file_20_drugoffset",
           "name": "drugoffset",
           "description": "Column 'drugoffset' from admissiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_drugoffset",
             "fileObject": {
@@ -4124,7 +4125,7 @@
           "@id": "file_20_drugenteredoffset",
           "name": "drugenteredoffset",
           "description": "Column 'drugenteredoffset' from admissiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_drugenteredoffset",
             "fileObject": {
@@ -4236,7 +4237,7 @@
           "@id": "file_20_drugdosage",
           "name": "drugdosage",
           "description": "Column 'drugdosage' from admissiondrug.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_20_source_drugdosage",
             "fileObject": {
@@ -4284,7 +4285,7 @@
           "@id": "file_20_drughiclseqno",
           "name": "drughiclseqno",
           "description": "Column 'drughiclseqno' from admissiondrug.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_drughiclseqno",
             "fileObject": {
@@ -4301,14 +4302,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_21",
       "name": "lab",
-      "description": "Records from lab.csv.gz (1000 rows)",
+      "description": "Records from lab.csv.gz (434660 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_21_labid",
           "name": "labid",
           "description": "Column 'labid' from lab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_labid",
             "fileObject": {
@@ -4324,7 +4325,7 @@
           "@id": "file_21_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from lab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_patientunitstayid",
             "fileObject": {
@@ -4340,7 +4341,7 @@
           "@id": "file_21_labresultoffset",
           "name": "labresultoffset",
           "description": "Column 'labresultoffset' from lab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_labresultoffset",
             "fileObject": {
@@ -4356,7 +4357,7 @@
           "@id": "file_21_labtypeid",
           "name": "labtypeid",
           "description": "Column 'labtypeid' from lab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_labtypeid",
             "fileObject": {
@@ -4388,7 +4389,7 @@
           "@id": "file_21_labresult",
           "name": "labresult",
           "description": "Column 'labresult' from lab.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_21_source_labresult",
             "fileObject": {
@@ -4452,7 +4453,7 @@
           "@id": "file_21_labresultrevisedoffset",
           "name": "labresultrevisedoffset",
           "description": "Column 'labresultrevisedoffset' from lab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_labresultrevisedoffset",
             "fileObject": {
@@ -4469,14 +4470,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_22",
       "name": "apachePredVar",
-      "description": "Records from apachePredVar.csv.gz (1000 rows)",
+      "description": "Records from apachePredVar.csv.gz (2205 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_22_apachepredvarid",
           "name": "apachepredvarid",
           "description": "Column 'apachepredvarid' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_apachepredvarid",
             "fileObject": {
@@ -4492,7 +4493,7 @@
           "@id": "file_22_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_patientunitstayid",
             "fileObject": {
@@ -4508,7 +4509,7 @@
           "@id": "file_22_sicuday",
           "name": "sicuday",
           "description": "Column 'sicuday' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_sicuday",
             "fileObject": {
@@ -4524,7 +4525,7 @@
           "@id": "file_22_saps3day1",
           "name": "saps3day1",
           "description": "Column 'saps3day1' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_saps3day1",
             "fileObject": {
@@ -4540,7 +4541,7 @@
           "@id": "file_22_saps3today",
           "name": "saps3today",
           "description": "Column 'saps3today' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_saps3today",
             "fileObject": {
@@ -4556,7 +4557,7 @@
           "@id": "file_22_saps3yesterday",
           "name": "saps3yesterday",
           "description": "Column 'saps3yesterday' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_saps3yesterday",
             "fileObject": {
@@ -4572,7 +4573,7 @@
           "@id": "file_22_gender",
           "name": "gender",
           "description": "Column 'gender' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_gender",
             "fileObject": {
@@ -4588,7 +4589,7 @@
           "@id": "file_22_teachtype",
           "name": "teachtype",
           "description": "Column 'teachtype' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_teachtype",
             "fileObject": {
@@ -4604,7 +4605,7 @@
           "@id": "file_22_region",
           "name": "region",
           "description": "Column 'region' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_region",
             "fileObject": {
@@ -4620,7 +4621,7 @@
           "@id": "file_22_bedcount",
           "name": "bedcount",
           "description": "Column 'bedcount' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_bedcount",
             "fileObject": {
@@ -4636,7 +4637,7 @@
           "@id": "file_22_admitsource",
           "name": "admitsource",
           "description": "Column 'admitsource' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_admitsource",
             "fileObject": {
@@ -4652,7 +4653,7 @@
           "@id": "file_22_graftcount",
           "name": "graftcount",
           "description": "Column 'graftcount' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_graftcount",
             "fileObject": {
@@ -4668,7 +4669,7 @@
           "@id": "file_22_meds",
           "name": "meds",
           "description": "Column 'meds' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_meds",
             "fileObject": {
@@ -4684,7 +4685,7 @@
           "@id": "file_22_verbal",
           "name": "verbal",
           "description": "Column 'verbal' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_verbal",
             "fileObject": {
@@ -4700,7 +4701,7 @@
           "@id": "file_22_motor",
           "name": "motor",
           "description": "Column 'motor' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_motor",
             "fileObject": {
@@ -4716,7 +4717,7 @@
           "@id": "file_22_eyes",
           "name": "eyes",
           "description": "Column 'eyes' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_eyes",
             "fileObject": {
@@ -4732,7 +4733,7 @@
           "@id": "file_22_age",
           "name": "age",
           "description": "Column 'age' from apachePredVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_age",
             "fileObject": {
@@ -4764,7 +4765,7 @@
           "@id": "file_22_thrombolytics",
           "name": "thrombolytics",
           "description": "Column 'thrombolytics' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_thrombolytics",
             "fileObject": {
@@ -4780,7 +4781,7 @@
           "@id": "file_22_diedinhospital",
           "name": "diedinhospital",
           "description": "Column 'diedinhospital' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_diedinhospital",
             "fileObject": {
@@ -4796,7 +4797,7 @@
           "@id": "file_22_aids",
           "name": "aids",
           "description": "Column 'aids' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_aids",
             "fileObject": {
@@ -4812,7 +4813,7 @@
           "@id": "file_22_hepaticfailure",
           "name": "hepaticfailure",
           "description": "Column 'hepaticfailure' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_hepaticfailure",
             "fileObject": {
@@ -4828,7 +4829,7 @@
           "@id": "file_22_lymphoma",
           "name": "lymphoma",
           "description": "Column 'lymphoma' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_lymphoma",
             "fileObject": {
@@ -4844,7 +4845,7 @@
           "@id": "file_22_metastaticcancer",
           "name": "metastaticcancer",
           "description": "Column 'metastaticcancer' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_metastaticcancer",
             "fileObject": {
@@ -4860,7 +4861,7 @@
           "@id": "file_22_leukemia",
           "name": "leukemia",
           "description": "Column 'leukemia' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_leukemia",
             "fileObject": {
@@ -4876,7 +4877,7 @@
           "@id": "file_22_immunosuppression",
           "name": "immunosuppression",
           "description": "Column 'immunosuppression' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_immunosuppression",
             "fileObject": {
@@ -4892,7 +4893,7 @@
           "@id": "file_22_cirrhosis",
           "name": "cirrhosis",
           "description": "Column 'cirrhosis' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_cirrhosis",
             "fileObject": {
@@ -4908,7 +4909,7 @@
           "@id": "file_22_electivesurgery",
           "name": "electivesurgery",
           "description": "Column 'electivesurgery' from apachePredVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_electivesurgery",
             "fileObject": {
@@ -4924,7 +4925,7 @@
           "@id": "file_22_activetx",
           "name": "activetx",
           "description": "Column 'activetx' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_activetx",
             "fileObject": {
@@ -4940,7 +4941,7 @@
           "@id": "file_22_readmit",
           "name": "readmit",
           "description": "Column 'readmit' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_readmit",
             "fileObject": {
@@ -4956,7 +4957,7 @@
           "@id": "file_22_ima",
           "name": "ima",
           "description": "Column 'ima' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_ima",
             "fileObject": {
@@ -4972,7 +4973,7 @@
           "@id": "file_22_midur",
           "name": "midur",
           "description": "Column 'midur' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_midur",
             "fileObject": {
@@ -4988,7 +4989,7 @@
           "@id": "file_22_ventday1",
           "name": "ventday1",
           "description": "Column 'ventday1' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_ventday1",
             "fileObject": {
@@ -5004,7 +5005,7 @@
           "@id": "file_22_oobventday1",
           "name": "oobventday1",
           "description": "Column 'oobventday1' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_oobventday1",
             "fileObject": {
@@ -5020,7 +5021,7 @@
           "@id": "file_22_oobintubday1",
           "name": "oobintubday1",
           "description": "Column 'oobintubday1' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_oobintubday1",
             "fileObject": {
@@ -5036,7 +5037,7 @@
           "@id": "file_22_diabetes",
           "name": "diabetes",
           "description": "Column 'diabetes' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_diabetes",
             "fileObject": {
@@ -5052,7 +5053,7 @@
           "@id": "file_22_managementsystem",
           "name": "managementsystem",
           "description": "Column 'managementsystem' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_managementsystem",
             "fileObject": {
@@ -5068,7 +5069,7 @@
           "@id": "file_22_var03hspxlos",
           "name": "var03hspxlos",
           "description": "Column 'var03hspxlos' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_var03hspxlos",
             "fileObject": {
@@ -5084,7 +5085,7 @@
           "@id": "file_22_pao2",
           "name": "pao2",
           "description": "Column 'pao2' from apachePredVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_22_source_pao2",
             "fileObject": {
@@ -5100,7 +5101,7 @@
           "@id": "file_22_fio2",
           "name": "fio2",
           "description": "Column 'fio2' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_fio2",
             "fileObject": {
@@ -5116,7 +5117,7 @@
           "@id": "file_22_ejectfx",
           "name": "ejectfx",
           "description": "Column 'ejectfx' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_ejectfx",
             "fileObject": {
@@ -5132,7 +5133,7 @@
           "@id": "file_22_creatinine",
           "name": "creatinine",
           "description": "Column 'creatinine' from apachePredVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_22_source_creatinine",
             "fileObject": {
@@ -5148,7 +5149,7 @@
           "@id": "file_22_dischargelocation",
           "name": "dischargelocation",
           "description": "Column 'dischargelocation' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_dischargelocation",
             "fileObject": {
@@ -5164,7 +5165,7 @@
           "@id": "file_22_visitnumber",
           "name": "visitnumber",
           "description": "Column 'visitnumber' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_visitnumber",
             "fileObject": {
@@ -5180,7 +5181,7 @@
           "@id": "file_22_amilocation",
           "name": "amilocation",
           "description": "Column 'amilocation' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_amilocation",
             "fileObject": {
@@ -5196,7 +5197,7 @@
           "@id": "file_22_day1meds",
           "name": "day1meds",
           "description": "Column 'day1meds' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_day1meds",
             "fileObject": {
@@ -5212,7 +5213,7 @@
           "@id": "file_22_day1verbal",
           "name": "day1verbal",
           "description": "Column 'day1verbal' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_day1verbal",
             "fileObject": {
@@ -5228,7 +5229,7 @@
           "@id": "file_22_day1motor",
           "name": "day1motor",
           "description": "Column 'day1motor' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_day1motor",
             "fileObject": {
@@ -5244,7 +5245,7 @@
           "@id": "file_22_day1eyes",
           "name": "day1eyes",
           "description": "Column 'day1eyes' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_day1eyes",
             "fileObject": {
@@ -5260,7 +5261,7 @@
           "@id": "file_22_day1pao2",
           "name": "day1pao2",
           "description": "Column 'day1pao2' from apachePredVar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_22_source_day1pao2",
             "fileObject": {
@@ -5276,7 +5277,7 @@
           "@id": "file_22_day1fio2",
           "name": "day1fio2",
           "description": "Column 'day1fio2' from apachePredVar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_day1fio2",
             "fileObject": {
@@ -5300,7 +5301,7 @@
           "@id": "file_23_customlabid",
           "name": "customlabid",
           "description": "Column 'customlabid' from customLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_customlabid",
             "fileObject": {
@@ -5316,7 +5317,7 @@
           "@id": "file_23_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from customLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_patientunitstayid",
             "fileObject": {
@@ -5332,7 +5333,7 @@
           "@id": "file_23_labotheroffset",
           "name": "labotheroffset",
           "description": "Column 'labotheroffset' from customLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_labotheroffset",
             "fileObject": {
@@ -5348,7 +5349,7 @@
           "@id": "file_23_labothertypeid",
           "name": "labothertypeid",
           "description": "Column 'labothertypeid' from customLab.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_labothertypeid",
             "fileObject": {
@@ -5380,7 +5381,7 @@
           "@id": "file_23_labotherresult",
           "name": "labotherresult",
           "description": "Column 'labotherresult' from customLab.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_23_source_labotherresult",
             "fileObject": {
@@ -5413,14 +5414,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_24",
       "name": "apachePatientResult",
-      "description": "Records from apachePatientResult.csv.gz (1000 rows)",
+      "description": "Records from apachePatientResult.csv.gz (3676 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_24_apachepatientresultsid",
           "name": "apachepatientresultsid",
           "description": "Column 'apachepatientresultsid' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_apachepatientresultsid",
             "fileObject": {
@@ -5436,7 +5437,7 @@
           "@id": "file_24_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_patientunitstayid",
             "fileObject": {
@@ -5484,7 +5485,7 @@
           "@id": "file_24_acutephysiologyscore",
           "name": "acutephysiologyscore",
           "description": "Column 'acutephysiologyscore' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_acutephysiologyscore",
             "fileObject": {
@@ -5500,7 +5501,7 @@
           "@id": "file_24_apachescore",
           "name": "apachescore",
           "description": "Column 'apachescore' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_apachescore",
             "fileObject": {
@@ -5532,7 +5533,7 @@
           "@id": "file_24_predictedicumortality",
           "name": "predictedicumortality",
           "description": "Column 'predictedicumortality' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_predictedicumortality",
             "fileObject": {
@@ -5564,7 +5565,7 @@
           "@id": "file_24_predictediculos",
           "name": "predictediculos",
           "description": "Column 'predictediculos' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_predictediculos",
             "fileObject": {
@@ -5580,7 +5581,7 @@
           "@id": "file_24_actualiculos",
           "name": "actualiculos",
           "description": "Column 'actualiculos' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_actualiculos",
             "fileObject": {
@@ -5596,7 +5597,7 @@
           "@id": "file_24_predictedhospitalmortality",
           "name": "predictedhospitalmortality",
           "description": "Column 'predictedhospitalmortality' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_predictedhospitalmortality",
             "fileObject": {
@@ -5628,7 +5629,7 @@
           "@id": "file_24_predictedhospitallos",
           "name": "predictedhospitallos",
           "description": "Column 'predictedhospitallos' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_predictedhospitallos",
             "fileObject": {
@@ -5644,7 +5645,7 @@
           "@id": "file_24_actualhospitallos",
           "name": "actualhospitallos",
           "description": "Column 'actualhospitallos' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_actualhospitallos",
             "fileObject": {
@@ -5660,7 +5661,7 @@
           "@id": "file_24_preopmi",
           "name": "preopmi",
           "description": "Column 'preopmi' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_preopmi",
             "fileObject": {
@@ -5676,7 +5677,7 @@
           "@id": "file_24_preopcardiaccath",
           "name": "preopcardiaccath",
           "description": "Column 'preopcardiaccath' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_preopcardiaccath",
             "fileObject": {
@@ -5692,7 +5693,7 @@
           "@id": "file_24_ptcawithin24h",
           "name": "ptcawithin24h",
           "description": "Column 'ptcawithin24h' from apachePatientResult.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_ptcawithin24h",
             "fileObject": {
@@ -5708,7 +5709,7 @@
           "@id": "file_24_unabridgedunitlos",
           "name": "unabridgedunitlos",
           "description": "Column 'unabridgedunitlos' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_unabridgedunitlos",
             "fileObject": {
@@ -5724,7 +5725,7 @@
           "@id": "file_24_unabridgedhosplos",
           "name": "unabridgedhosplos",
           "description": "Column 'unabridgedhosplos' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_unabridgedhosplos",
             "fileObject": {
@@ -5740,7 +5741,7 @@
           "@id": "file_24_actualventdays",
           "name": "actualventdays",
           "description": "Column 'actualventdays' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_actualventdays",
             "fileObject": {
@@ -5756,7 +5757,7 @@
           "@id": "file_24_predventdays",
           "name": "predventdays",
           "description": "Column 'predventdays' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_24_source_predventdays",
             "fileObject": {
@@ -5772,7 +5773,7 @@
           "@id": "file_24_unabridgedactualventdays",
           "name": "unabridgedactualventdays",
           "description": "Column 'unabridgedactualventdays' from apachePatientResult.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_unabridgedactualventdays",
             "fileObject": {
@@ -5796,7 +5797,7 @@
           "@id": "file_25_cplinfectid",
           "name": "cplinfectid",
           "description": "Column 'cplinfectid' from carePlanInfectiousDisease.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_cplinfectid",
             "fileObject": {
@@ -5812,7 +5813,7 @@
           "@id": "file_25_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from carePlanInfectiousDisease.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_patientunitstayid",
             "fileObject": {
@@ -5844,7 +5845,7 @@
           "@id": "file_25_cplinfectdiseaseoffset",
           "name": "cplinfectdiseaseoffset",
           "description": "Column 'cplinfectdiseaseoffset' from carePlanInfectiousDisease.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_cplinfectdiseaseoffset",
             "fileObject": {
@@ -5925,14 +5926,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_26",
       "name": "allergy",
-      "description": "Records from allergy.csv.gz (1000 rows)",
+      "description": "Records from allergy.csv.gz (2475 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_26_allergyid",
           "name": "allergyid",
           "description": "Column 'allergyid' from allergy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_allergyid",
             "fileObject": {
@@ -5948,7 +5949,7 @@
           "@id": "file_26_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from allergy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_patientunitstayid",
             "fileObject": {
@@ -5964,7 +5965,7 @@
           "@id": "file_26_allergyoffset",
           "name": "allergyoffset",
           "description": "Column 'allergyoffset' from allergy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_allergyoffset",
             "fileObject": {
@@ -5980,7 +5981,7 @@
           "@id": "file_26_allergyenteredoffset",
           "name": "allergyenteredoffset",
           "description": "Column 'allergyenteredoffset' from allergy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_allergyenteredoffset",
             "fileObject": {
@@ -6124,7 +6125,7 @@
           "@id": "file_26_drughiclseqno",
           "name": "drughiclseqno",
           "description": "Column 'drughiclseqno' from allergy.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_drughiclseqno",
             "fileObject": {
@@ -6141,14 +6142,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_27",
       "name": "nurseCharting",
-      "description": "Records from nurseCharting.csv.gz (1000 rows)",
+      "description": "Records from nurseCharting.csv.gz (1477163 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_27_nursingchartid",
           "name": "nursingchartid",
           "description": "Column 'nursingchartid' from nurseCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_nursingchartid",
             "fileObject": {
@@ -6164,7 +6165,7 @@
           "@id": "file_27_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from nurseCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_patientunitstayid",
             "fileObject": {
@@ -6180,7 +6181,7 @@
           "@id": "file_27_nursingchartoffset",
           "name": "nursingchartoffset",
           "description": "Column 'nursingchartoffset' from nurseCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_nursingchartoffset",
             "fileObject": {
@@ -6196,7 +6197,7 @@
           "@id": "file_27_nursingchartentryoffset",
           "name": "nursingchartentryoffset",
           "description": "Column 'nursingchartentryoffset' from nurseCharting.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_nursingchartentryoffset",
             "fileObject": {
@@ -6277,14 +6278,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_28",
       "name": "pastHistory",
-      "description": "Records from pastHistory.csv.gz (1000 rows)",
+      "description": "Records from pastHistory.csv.gz (12109 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_28_pasthistoryid",
           "name": "pasthistoryid",
           "description": "Column 'pasthistoryid' from pastHistory.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_28_source_pasthistoryid",
             "fileObject": {
@@ -6300,7 +6301,7 @@
           "@id": "file_28_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from pastHistory.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_28_source_patientunitstayid",
             "fileObject": {
@@ -6316,7 +6317,7 @@
           "@id": "file_28_pasthistoryoffset",
           "name": "pasthistoryoffset",
           "description": "Column 'pasthistoryoffset' from pastHistory.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_28_source_pasthistoryoffset",
             "fileObject": {
@@ -6332,7 +6333,7 @@
           "@id": "file_28_pasthistoryenteredoffset",
           "name": "pasthistoryenteredoffset",
           "description": "Column 'pasthistoryenteredoffset' from pastHistory.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_28_source_pasthistoryenteredoffset",
             "fileObject": {
@@ -6413,14 +6414,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_29",
       "name": "medication",
-      "description": "Records from medication.csv.gz (1000 rows)",
+      "description": "Records from medication.csv.gz (75604 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_29_medicationid",
           "name": "medicationid",
           "description": "Column 'medicationid' from medication.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_medicationid",
             "fileObject": {
@@ -6436,7 +6437,7 @@
           "@id": "file_29_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from medication.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_patientunitstayid",
             "fileObject": {
@@ -6452,7 +6453,7 @@
           "@id": "file_29_drugorderoffset",
           "name": "drugorderoffset",
           "description": "Column 'drugorderoffset' from medication.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_drugorderoffset",
             "fileObject": {
@@ -6468,7 +6469,7 @@
           "@id": "file_29_drugstartoffset",
           "name": "drugstartoffset",
           "description": "Column 'drugstartoffset' from medication.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_drugstartoffset",
             "fileObject": {
@@ -6532,7 +6533,7 @@
           "@id": "file_29_drughiclseqno",
           "name": "drughiclseqno",
           "description": "Column 'drughiclseqno' from medication.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_drughiclseqno",
             "fileObject": {
@@ -6628,7 +6629,7 @@
           "@id": "file_29_drugstopoffset",
           "name": "drugstopoffset",
           "description": "Column 'drugstopoffset' from medication.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_drugstopoffset",
             "fileObject": {
@@ -6644,7 +6645,7 @@
           "@id": "file_29_gtc",
           "name": "gtc",
           "description": "Column 'gtc' from medication.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_gtc",
             "fileObject": {
@@ -6661,14 +6662,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_30",
       "name": "intakeOutput",
-      "description": "Records from intakeOutput.csv.gz (1000 rows)",
+      "description": "Records from intakeOutput.csv.gz (100466 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_30_intakeoutputid",
           "name": "intakeoutputid",
           "description": "Column 'intakeoutputid' from intakeOutput.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_intakeoutputid",
             "fileObject": {
@@ -6684,7 +6685,7 @@
           "@id": "file_30_patientunitstayid",
           "name": "patientunitstayid",
           "description": "Column 'patientunitstayid' from intakeOutput.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_patientunitstayid",
             "fileObject": {
@@ -6700,7 +6701,7 @@
           "@id": "file_30_intakeoutputoffset",
           "name": "intakeoutputoffset",
           "description": "Column 'intakeoutputoffset' from intakeOutput.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_intakeoutputoffset",
             "fileObject": {
@@ -6716,7 +6717,7 @@
           "@id": "file_30_intaketotal",
           "name": "intaketotal",
           "description": "Column 'intaketotal' from intakeOutput.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_intaketotal",
             "fileObject": {
@@ -6732,7 +6733,7 @@
           "@id": "file_30_outputtotal",
           "name": "outputtotal",
           "description": "Column 'outputtotal' from intakeOutput.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_outputtotal",
             "fileObject": {
@@ -6748,7 +6749,7 @@
           "@id": "file_30_dialysistotal",
           "name": "dialysistotal",
           "description": "Column 'dialysistotal' from intakeOutput.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_dialysistotal",
             "fileObject": {
@@ -6764,7 +6765,7 @@
           "@id": "file_30_nettotal",
           "name": "nettotal",
           "description": "Column 'nettotal' from intakeOutput.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_nettotal",
             "fileObject": {
@@ -6780,7 +6781,7 @@
           "@id": "file_30_intakeoutputentryoffset",
           "name": "intakeoutputentryoffset",
           "description": "Column 'intakeoutputentryoffset' from intakeOutput.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_intakeoutputentryoffset",
             "fileObject": {
@@ -6828,7 +6829,7 @@
           "@id": "file_30_cellvaluenumeric",
           "name": "cellvaluenumeric",
           "description": "Column 'cellvaluenumeric' from intakeOutput.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_cellvaluenumeric",
             "fileObject": {
@@ -6844,7 +6845,7 @@
           "@id": "file_30_cellvaluetext",
           "name": "cellvaluetext",
           "description": "Column 'cellvaluetext' from intakeOutput.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_cellvaluetext",
             "fileObject": {

--- a/tests/data/output/mimiciv_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant.jsonld
@@ -38,6 +38,7 @@
     "regex": "cr:regex",
     "repeated": "cr:repeated",
     "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
     "sc": "https://schema.org/",
     "separator": "cr:separator",
     "source": "cr:source",
@@ -390,7 +391,7 @@
           "@id": "file_0_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from demo_subject_id.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_subject_id",
             "fileObject": {
@@ -407,7 +408,7 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_1",
       "name": "poe",
-      "description": "Records from poe.csv.gz (1000 rows)",
+      "description": "Records from poe.csv.gz (45154 rows)",
       "field": [
         {
           "@type": "cr:Field",
@@ -430,7 +431,7 @@
           "@id": "file_1_poe_seq",
           "name": "poe_seq",
           "description": "Column 'poe_seq' from poe.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_poe_seq",
             "fileObject": {
@@ -446,7 +447,7 @@
           "@id": "file_1_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from poe.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_subject_id",
             "fileObject": {
@@ -462,7 +463,7 @@
           "@id": "file_1_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from poe.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_hadm_id",
             "fileObject": {
@@ -478,7 +479,7 @@
           "@id": "file_1_ordertime",
           "name": "ordertime",
           "description": "Column 'ordertime' from poe.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_1_source_ordertime",
             "fileObject": {
@@ -607,7 +608,7 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_2",
       "name": "d_hcpcs",
-      "description": "Records from d_hcpcs.csv.gz (1000 rows)",
+      "description": "Records from d_hcpcs.csv.gz (89200 rows)",
       "field": [
         {
           "@type": "cr:Field",
@@ -630,7 +631,7 @@
           "@id": "file_2_category",
           "name": "category",
           "description": "Column 'category' from d_hcpcs.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_category",
             "fileObject": {
@@ -679,7 +680,7 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_3",
       "name": "poe_detail",
-      "description": "Records from poe_detail.csv.gz (1000 rows)",
+      "description": "Records from poe_detail.csv.gz (3795 rows)",
       "field": [
         {
           "@type": "cr:Field",
@@ -702,7 +703,7 @@
           "@id": "file_3_poe_seq",
           "name": "poe_seq",
           "description": "Column 'poe_seq' from poe_detail.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_poe_seq",
             "fileObject": {
@@ -718,7 +719,7 @@
           "@id": "file_3_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from poe_detail.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_subject_id",
             "fileObject": {
@@ -774,7 +775,7 @@
           "@id": "file_4_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from patients.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_subject_id",
             "fileObject": {
@@ -806,7 +807,7 @@
           "@id": "file_4_anchor_age",
           "name": "anchor_age",
           "description": "Column 'anchor_age' from patients.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_anchor_age",
             "fileObject": {
@@ -822,7 +823,7 @@
           "@id": "file_4_anchor_year",
           "name": "anchor_year",
           "description": "Column 'anchor_year' from patients.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_anchor_year",
             "fileObject": {
@@ -854,7 +855,7 @@
           "@id": "file_4_dod",
           "name": "dod",
           "description": "Column 'dod' from patients.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "sc:Date",
           "source": {
             "@id": "file_4_source_dod",
             "fileObject": {
@@ -871,14 +872,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_5",
       "name": "diagnoses_icd",
-      "description": "Records from diagnoses_icd.csv.gz (1000 rows)",
+      "description": "Records from diagnoses_icd.csv.gz (4506 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_5_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from diagnoses_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_subject_id",
             "fileObject": {
@@ -894,7 +895,7 @@
           "@id": "file_5_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from diagnoses_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_hadm_id",
             "fileObject": {
@@ -910,7 +911,7 @@
           "@id": "file_5_seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from diagnoses_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_seq_num",
             "fileObject": {
@@ -942,7 +943,7 @@
           "@id": "file_5_icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from diagnoses_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_icd_version",
             "fileObject": {
@@ -959,14 +960,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_6",
       "name": "emar_detail",
-      "description": "Records from emar_detail.csv.gz (1000 rows)",
+      "description": "Records from emar_detail.csv.gz (72018 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_6_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from emar_detail.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_subject_id",
             "fileObject": {
@@ -998,7 +999,7 @@
           "@id": "file_6_emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from emar_detail.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_emar_seq",
             "fileObject": {
@@ -1014,7 +1015,7 @@
           "@id": "file_6_parent_field_ordinal",
           "name": "parent_field_ordinal",
           "description": "Column 'parent_field_ordinal' from emar_detail.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_parent_field_ordinal",
             "fileObject": {
@@ -1046,7 +1047,7 @@
           "@id": "file_6_pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from emar_detail.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_pharmacy_id",
             "fileObject": {
@@ -1190,7 +1191,7 @@
           "@id": "file_6_product_amount_given",
           "name": "product_amount_given",
           "description": "Column 'product_amount_given' from emar_detail.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_product_amount_given",
             "fileObject": {
@@ -1270,7 +1271,7 @@
           "@id": "file_6_prior_infusion_rate",
           "name": "prior_infusion_rate",
           "description": "Column 'prior_infusion_rate' from emar_detail.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_prior_infusion_rate",
             "fileObject": {
@@ -1286,7 +1287,7 @@
           "@id": "file_6_infusion_rate",
           "name": "infusion_rate",
           "description": "Column 'infusion_rate' from emar_detail.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_6_source_infusion_rate",
             "fileObject": {
@@ -1318,7 +1319,7 @@
           "@id": "file_6_infusion_rate_adjustment_amount",
           "name": "infusion_rate_adjustment_amount",
           "description": "Column 'infusion_rate_adjustment_amount' from emar_detail.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_infusion_rate_adjustment_amount",
             "fileObject": {
@@ -1495,7 +1496,7 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_7",
       "name": "provider",
-      "description": "Records from provider.csv.gz (1000 rows)",
+      "description": "Records from provider.csv.gz (40508 rows)",
       "field": [
         {
           "@type": "cr:Field",
@@ -1519,14 +1520,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_8",
       "name": "prescriptions",
-      "description": "Records from prescriptions.csv.gz (1000 rows)",
+      "description": "Records from prescriptions.csv.gz (18087 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_8_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from prescriptions.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_subject_id",
             "fileObject": {
@@ -1542,7 +1543,7 @@
           "@id": "file_8_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from prescriptions.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_hadm_id",
             "fileObject": {
@@ -1558,7 +1559,7 @@
           "@id": "file_8_pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from prescriptions.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_pharmacy_id",
             "fileObject": {
@@ -1590,7 +1591,7 @@
           "@id": "file_8_poe_seq",
           "name": "poe_seq",
           "description": "Column 'poe_seq' from prescriptions.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_poe_seq",
             "fileObject": {
@@ -1622,7 +1623,7 @@
           "@id": "file_8_starttime",
           "name": "starttime",
           "description": "Column 'starttime' from prescriptions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_8_source_starttime",
             "fileObject": {
@@ -1638,7 +1639,7 @@
           "@id": "file_8_stoptime",
           "name": "stoptime",
           "description": "Column 'stoptime' from prescriptions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_8_source_stoptime",
             "fileObject": {
@@ -1718,7 +1719,7 @@
           "@id": "file_8_ndc",
           "name": "ndc",
           "description": "Column 'ndc' from prescriptions.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_ndc",
             "fileObject": {
@@ -1798,7 +1799,7 @@
           "@id": "file_8_form_val_disp",
           "name": "form_val_disp",
           "description": "Column 'form_val_disp' from prescriptions.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "sc:Text",
           "source": {
             "@id": "file_8_source_form_val_disp",
             "fileObject": {
@@ -1830,7 +1831,7 @@
           "@id": "file_8_doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from prescriptions.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_doses_per_24_hrs",
             "fileObject": {
@@ -1870,7 +1871,7 @@
           "@id": "file_9_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from drgcodes.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_subject_id",
             "fileObject": {
@@ -1886,7 +1887,7 @@
           "@id": "file_9_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from drgcodes.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_hadm_id",
             "fileObject": {
@@ -1918,7 +1919,7 @@
           "@id": "file_9_drg_code",
           "name": "drg_code",
           "description": "Column 'drg_code' from drgcodes.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_drg_code",
             "fileObject": {
@@ -1950,7 +1951,7 @@
           "@id": "file_9_drg_severity",
           "name": "drg_severity",
           "description": "Column 'drg_severity' from drgcodes.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_drg_severity",
             "fileObject": {
@@ -1966,7 +1967,7 @@
           "@id": "file_9_drg_mortality",
           "name": "drg_mortality",
           "description": "Column 'drg_mortality' from drgcodes.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_drg_mortality",
             "fileObject": {
@@ -1983,7 +1984,7 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_10",
       "name": "d_icd_diagnoses",
-      "description": "Records from d_icd_diagnoses.csv.gz (1000 rows)",
+      "description": "Records from d_icd_diagnoses.csv.gz (109775 rows)",
       "field": [
         {
           "@type": "cr:Field",
@@ -2006,7 +2007,7 @@
           "@id": "file_10_icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from d_icd_diagnoses.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_10_source_icd_version",
             "fileObject": {
@@ -2039,14 +2040,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_11",
       "name": "d_labitems",
-      "description": "Records from d_labitems.csv.gz (1000 rows)",
+      "description": "Records from d_labitems.csv.gz (1622 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_11_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from d_labitems.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_itemid",
             "fileObject": {
@@ -2111,14 +2112,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_12",
       "name": "transfers",
-      "description": "Records from transfers.csv.gz (1000 rows)",
+      "description": "Records from transfers.csv.gz (1190 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_12_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from transfers.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_subject_id",
             "fileObject": {
@@ -2134,7 +2135,7 @@
           "@id": "file_12_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from transfers.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_hadm_id",
             "fileObject": {
@@ -2150,7 +2151,7 @@
           "@id": "file_12_transfer_id",
           "name": "transfer_id",
           "description": "Column 'transfer_id' from transfers.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_transfer_id",
             "fileObject": {
@@ -2198,7 +2199,7 @@
           "@id": "file_12_intime",
           "name": "intime",
           "description": "Column 'intime' from transfers.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_12_source_intime",
             "fileObject": {
@@ -2214,7 +2215,7 @@
           "@id": "file_12_outtime",
           "name": "outtime",
           "description": "Column 'outtime' from transfers.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_12_source_outtime",
             "fileObject": {
@@ -2238,7 +2239,7 @@
           "@id": "file_13_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from admissions.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_subject_id",
             "fileObject": {
@@ -2254,7 +2255,7 @@
           "@id": "file_13_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from admissions.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_hadm_id",
             "fileObject": {
@@ -2270,7 +2271,7 @@
           "@id": "file_13_admittime",
           "name": "admittime",
           "description": "Column 'admittime' from admissions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_13_source_admittime",
             "fileObject": {
@@ -2286,7 +2287,7 @@
           "@id": "file_13_dischtime",
           "name": "dischtime",
           "description": "Column 'dischtime' from admissions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_13_source_dischtime",
             "fileObject": {
@@ -2302,7 +2303,7 @@
           "@id": "file_13_deathtime",
           "name": "deathtime",
           "description": "Column 'deathtime' from admissions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_13_source_deathtime",
             "fileObject": {
@@ -2446,7 +2447,7 @@
           "@id": "file_13_edregtime",
           "name": "edregtime",
           "description": "Column 'edregtime' from admissions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_13_source_edregtime",
             "fileObject": {
@@ -2462,7 +2463,7 @@
           "@id": "file_13_edouttime",
           "name": "edouttime",
           "description": "Column 'edouttime' from admissions.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_13_source_edouttime",
             "fileObject": {
@@ -2478,7 +2479,7 @@
           "@id": "file_13_hospital_expire_flag",
           "name": "hospital_expire_flag",
           "description": "Column 'hospital_expire_flag' from admissions.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_hospital_expire_flag",
             "fileObject": {
@@ -2495,14 +2496,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_14",
       "name": "labevents",
-      "description": "Records from labevents.csv.gz (1000 rows)",
+      "description": "Records from labevents.csv.gz (107727 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_14_labevent_id",
           "name": "labevent_id",
           "description": "Column 'labevent_id' from labevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_labevent_id",
             "fileObject": {
@@ -2518,7 +2519,7 @@
           "@id": "file_14_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from labevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_subject_id",
             "fileObject": {
@@ -2534,7 +2535,7 @@
           "@id": "file_14_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from labevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_hadm_id",
             "fileObject": {
@@ -2550,7 +2551,7 @@
           "@id": "file_14_specimen_id",
           "name": "specimen_id",
           "description": "Column 'specimen_id' from labevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_specimen_id",
             "fileObject": {
@@ -2566,7 +2567,7 @@
           "@id": "file_14_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from labevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_itemid",
             "fileObject": {
@@ -2598,7 +2599,7 @@
           "@id": "file_14_charttime",
           "name": "charttime",
           "description": "Column 'charttime' from labevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_14_source_charttime",
             "fileObject": {
@@ -2614,7 +2615,7 @@
           "@id": "file_14_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from labevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_14_source_storetime",
             "fileObject": {
@@ -2646,7 +2647,7 @@
           "@id": "file_14_valuenum",
           "name": "valuenum",
           "description": "Column 'valuenum' from labevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_14_source_valuenum",
             "fileObject": {
@@ -2678,7 +2679,7 @@
           "@id": "file_14_ref_range_lower",
           "name": "ref_range_lower",
           "description": "Column 'ref_range_lower' from labevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_14_source_ref_range_lower",
             "fileObject": {
@@ -2694,7 +2695,7 @@
           "@id": "file_14_ref_range_upper",
           "name": "ref_range_upper",
           "description": "Column 'ref_range_upper' from labevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_14_source_ref_range_upper",
             "fileObject": {
@@ -2759,14 +2760,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_15",
       "name": "pharmacy",
-      "description": "Records from pharmacy.csv.gz (1000 rows)",
+      "description": "Records from pharmacy.csv.gz (15306 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_15_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from pharmacy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_subject_id",
             "fileObject": {
@@ -2782,7 +2783,7 @@
           "@id": "file_15_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from pharmacy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_hadm_id",
             "fileObject": {
@@ -2798,7 +2799,7 @@
           "@id": "file_15_pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from pharmacy.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_pharmacy_id",
             "fileObject": {
@@ -2830,7 +2831,7 @@
           "@id": "file_15_starttime",
           "name": "starttime",
           "description": "Column 'starttime' from pharmacy.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_15_source_starttime",
             "fileObject": {
@@ -2846,7 +2847,7 @@
           "@id": "file_15_stoptime",
           "name": "stoptime",
           "description": "Column 'stoptime' from pharmacy.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_15_source_stoptime",
             "fileObject": {
@@ -2910,7 +2911,7 @@
           "@id": "file_15_entertime",
           "name": "entertime",
           "description": "Column 'entertime' from pharmacy.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_15_source_entertime",
             "fileObject": {
@@ -2926,7 +2927,7 @@
           "@id": "file_15_verifiedtime",
           "name": "verifiedtime",
           "description": "Column 'verifiedtime' from pharmacy.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_15_source_verifiedtime",
             "fileObject": {
@@ -3022,7 +3023,7 @@
           "@id": "file_15_lockout_interval",
           "name": "lockout_interval",
           "description": "Column 'lockout_interval' from pharmacy.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_lockout_interval",
             "fileObject": {
@@ -3038,7 +3039,7 @@
           "@id": "file_15_basal_rate",
           "name": "basal_rate",
           "description": "Column 'basal_rate' from pharmacy.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_15_source_basal_rate",
             "fileObject": {
@@ -3054,7 +3055,7 @@
           "@id": "file_15_one_hr_max",
           "name": "one_hr_max",
           "description": "Column 'one_hr_max' from pharmacy.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_15_source_one_hr_max",
             "fileObject": {
@@ -3070,7 +3071,7 @@
           "@id": "file_15_doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from pharmacy.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_doses_per_24_hrs",
             "fileObject": {
@@ -3086,7 +3087,7 @@
           "@id": "file_15_duration",
           "name": "duration",
           "description": "Column 'duration' from pharmacy.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_duration",
             "fileObject": {
@@ -3118,7 +3119,7 @@
           "@id": "file_15_expiration_value",
           "name": "expiration_value",
           "description": "Column 'expiration_value' from pharmacy.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_15_source_expiration_value",
             "fileObject": {
@@ -3206,7 +3207,7 @@
           "@id": "file_16_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from procedures_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_subject_id",
             "fileObject": {
@@ -3222,7 +3223,7 @@
           "@id": "file_16_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from procedures_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_hadm_id",
             "fileObject": {
@@ -3238,7 +3239,7 @@
           "@id": "file_16_seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from procedures_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_seq_num",
             "fileObject": {
@@ -3286,7 +3287,7 @@
           "@id": "file_16_icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from procedures_icd.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_icd_version",
             "fileObject": {
@@ -3310,7 +3311,7 @@
           "@id": "file_17_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from hcpcsevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_subject_id",
             "fileObject": {
@@ -3326,7 +3327,7 @@
           "@id": "file_17_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from hcpcsevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_hadm_id",
             "fileObject": {
@@ -3374,7 +3375,7 @@
           "@id": "file_17_seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from hcpcsevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_seq_num",
             "fileObject": {
@@ -3414,7 +3415,7 @@
           "@id": "file_18_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from services.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_subject_id",
             "fileObject": {
@@ -3430,7 +3431,7 @@
           "@id": "file_18_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from services.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_hadm_id",
             "fileObject": {
@@ -3446,7 +3447,7 @@
           "@id": "file_18_transfertime",
           "name": "transfertime",
           "description": "Column 'transfertime' from services.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_18_source_transfertime",
             "fileObject": {
@@ -3495,14 +3496,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_19",
       "name": "d_icd_procedures",
-      "description": "Records from d_icd_procedures.csv.gz (1000 rows)",
+      "description": "Records from d_icd_procedures.csv.gz (85257 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_19_icd_code",
           "name": "icd_code",
           "description": "Column 'icd_code' from d_icd_procedures.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "sc:Text",
           "source": {
             "@id": "file_19_source_icd_code",
             "fileObject": {
@@ -3518,7 +3519,7 @@
           "@id": "file_19_icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from d_icd_procedures.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_icd_version",
             "fileObject": {
@@ -3551,14 +3552,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_20",
       "name": "omr",
-      "description": "Records from omr.csv.gz (1000 rows)",
+      "description": "Records from omr.csv.gz (2964 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_20_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from omr.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_subject_id",
             "fileObject": {
@@ -3590,7 +3591,7 @@
           "@id": "file_20_seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from omr.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_seq_num",
             "fileObject": {
@@ -3639,14 +3640,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_21",
       "name": "emar",
-      "description": "Records from emar.csv.gz (1000 rows)",
+      "description": "Records from emar.csv.gz (35835 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_21_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from emar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_subject_id",
             "fileObject": {
@@ -3662,7 +3663,7 @@
           "@id": "file_21_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from emar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_hadm_id",
             "fileObject": {
@@ -3694,7 +3695,7 @@
           "@id": "file_21_emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from emar.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_emar_seq",
             "fileObject": {
@@ -3726,7 +3727,7 @@
           "@id": "file_21_pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from emar.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_pharmacy_id",
             "fileObject": {
@@ -3758,7 +3759,7 @@
           "@id": "file_21_charttime",
           "name": "charttime",
           "description": "Column 'charttime' from emar.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_21_source_charttime",
             "fileObject": {
@@ -3806,7 +3807,7 @@
           "@id": "file_21_scheduletime",
           "name": "scheduletime",
           "description": "Column 'scheduletime' from emar.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_21_source_scheduletime",
             "fileObject": {
@@ -3822,7 +3823,7 @@
           "@id": "file_21_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from emar.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_21_source_storetime",
             "fileObject": {
@@ -3839,14 +3840,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_22",
       "name": "microbiologyevents",
-      "description": "Records from microbiologyevents.csv.gz (1000 rows)",
+      "description": "Records from microbiologyevents.csv.gz (2899 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_22_microevent_id",
           "name": "microevent_id",
           "description": "Column 'microevent_id' from microbiologyevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_microevent_id",
             "fileObject": {
@@ -3862,7 +3863,7 @@
           "@id": "file_22_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from microbiologyevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_subject_id",
             "fileObject": {
@@ -3878,7 +3879,7 @@
           "@id": "file_22_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from microbiologyevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_hadm_id",
             "fileObject": {
@@ -3894,7 +3895,7 @@
           "@id": "file_22_micro_specimen_id",
           "name": "micro_specimen_id",
           "description": "Column 'micro_specimen_id' from microbiologyevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_micro_specimen_id",
             "fileObject": {
@@ -3926,7 +3927,7 @@
           "@id": "file_22_chartdate",
           "name": "chartdate",
           "description": "Column 'chartdate' from microbiologyevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_22_source_chartdate",
             "fileObject": {
@@ -3942,7 +3943,7 @@
           "@id": "file_22_charttime",
           "name": "charttime",
           "description": "Column 'charttime' from microbiologyevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_22_source_charttime",
             "fileObject": {
@@ -3958,7 +3959,7 @@
           "@id": "file_22_spec_itemid",
           "name": "spec_itemid",
           "description": "Column 'spec_itemid' from microbiologyevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_spec_itemid",
             "fileObject": {
@@ -3990,7 +3991,7 @@
           "@id": "file_22_test_seq",
           "name": "test_seq",
           "description": "Column 'test_seq' from microbiologyevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_test_seq",
             "fileObject": {
@@ -4006,7 +4007,7 @@
           "@id": "file_22_storedate",
           "name": "storedate",
           "description": "Column 'storedate' from microbiologyevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_22_source_storedate",
             "fileObject": {
@@ -4022,7 +4023,7 @@
           "@id": "file_22_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from microbiologyevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_22_source_storetime",
             "fileObject": {
@@ -4038,7 +4039,7 @@
           "@id": "file_22_test_itemid",
           "name": "test_itemid",
           "description": "Column 'test_itemid' from microbiologyevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_test_itemid",
             "fileObject": {
@@ -4070,7 +4071,7 @@
           "@id": "file_22_org_itemid",
           "name": "org_itemid",
           "description": "Column 'org_itemid' from microbiologyevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_org_itemid",
             "fileObject": {
@@ -4102,7 +4103,7 @@
           "@id": "file_22_isolate_num",
           "name": "isolate_num",
           "description": "Column 'isolate_num' from microbiologyevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_isolate_num",
             "fileObject": {
@@ -4134,7 +4135,7 @@
           "@id": "file_22_ab_itemid",
           "name": "ab_itemid",
           "description": "Column 'ab_itemid' from microbiologyevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_22_source_ab_itemid",
             "fileObject": {
@@ -4198,7 +4199,7 @@
           "@id": "file_22_dilution_value",
           "name": "dilution_value",
           "description": "Column 'dilution_value' from microbiologyevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_22_source_dilution_value",
             "fileObject": {
@@ -4247,14 +4248,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_23",
       "name": "datetimeevents",
-      "description": "Records from datetimeevents.csv.gz (1000 rows)",
+      "description": "Records from datetimeevents.csv.gz (15280 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_23_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from datetimeevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_subject_id",
             "fileObject": {
@@ -4270,7 +4271,7 @@
           "@id": "file_23_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from datetimeevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_hadm_id",
             "fileObject": {
@@ -4286,7 +4287,7 @@
           "@id": "file_23_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from datetimeevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_stay_id",
             "fileObject": {
@@ -4302,7 +4303,7 @@
           "@id": "file_23_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from datetimeevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_caregiver_id",
             "fileObject": {
@@ -4318,7 +4319,7 @@
           "@id": "file_23_charttime",
           "name": "charttime",
           "description": "Column 'charttime' from datetimeevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_23_source_charttime",
             "fileObject": {
@@ -4334,7 +4335,7 @@
           "@id": "file_23_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from datetimeevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_23_source_storetime",
             "fileObject": {
@@ -4350,7 +4351,7 @@
           "@id": "file_23_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from datetimeevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_itemid",
             "fileObject": {
@@ -4366,7 +4367,7 @@
           "@id": "file_23_value",
           "name": "value",
           "description": "Column 'value' from datetimeevents.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_23_source_value",
             "fileObject": {
@@ -4398,7 +4399,7 @@
           "@id": "file_23_warning",
           "name": "warning",
           "description": "Column 'warning' from datetimeevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_23_source_warning",
             "fileObject": {
@@ -4415,14 +4416,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_24",
       "name": "caregiver",
-      "description": "Records from caregiver.csv.gz (1000 rows)",
+      "description": "Records from caregiver.csv.gz (15468 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_24_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from caregiver.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_24_source_caregiver_id",
             "fileObject": {
@@ -4439,14 +4440,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_25",
       "name": "ingredientevents",
-      "description": "Records from ingredientevents.csv.gz (1000 rows)",
+      "description": "Records from ingredientevents.csv.gz (25728 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_25_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_subject_id",
             "fileObject": {
@@ -4462,7 +4463,7 @@
           "@id": "file_25_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_hadm_id",
             "fileObject": {
@@ -4478,7 +4479,7 @@
           "@id": "file_25_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_stay_id",
             "fileObject": {
@@ -4494,7 +4495,7 @@
           "@id": "file_25_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_caregiver_id",
             "fileObject": {
@@ -4510,7 +4511,7 @@
           "@id": "file_25_starttime",
           "name": "starttime",
           "description": "Column 'starttime' from ingredientevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_25_source_starttime",
             "fileObject": {
@@ -4526,7 +4527,7 @@
           "@id": "file_25_endtime",
           "name": "endtime",
           "description": "Column 'endtime' from ingredientevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_25_source_endtime",
             "fileObject": {
@@ -4542,7 +4543,7 @@
           "@id": "file_25_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from ingredientevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_25_source_storetime",
             "fileObject": {
@@ -4558,7 +4559,7 @@
           "@id": "file_25_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_itemid",
             "fileObject": {
@@ -4574,7 +4575,7 @@
           "@id": "file_25_amount",
           "name": "amount",
           "description": "Column 'amount' from ingredientevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_25_source_amount",
             "fileObject": {
@@ -4606,7 +4607,7 @@
           "@id": "file_25_rate",
           "name": "rate",
           "description": "Column 'rate' from ingredientevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_25_source_rate",
             "fileObject": {
@@ -4638,7 +4639,7 @@
           "@id": "file_25_orderid",
           "name": "orderid",
           "description": "Column 'orderid' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_orderid",
             "fileObject": {
@@ -4654,7 +4655,7 @@
           "@id": "file_25_linkorderid",
           "name": "linkorderid",
           "description": "Column 'linkorderid' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_linkorderid",
             "fileObject": {
@@ -4686,7 +4687,7 @@
           "@id": "file_25_originalamount",
           "name": "originalamount",
           "description": "Column 'originalamount' from ingredientevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_25_source_originalamount",
             "fileObject": {
@@ -4702,7 +4703,7 @@
           "@id": "file_25_originalrate",
           "name": "originalrate",
           "description": "Column 'originalrate' from ingredientevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_25_source_originalrate",
             "fileObject": {
@@ -4719,14 +4720,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_26",
       "name": "inputevents",
-      "description": "Records from inputevents.csv.gz (1000 rows)",
+      "description": "Records from inputevents.csv.gz (20404 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_26_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_subject_id",
             "fileObject": {
@@ -4742,7 +4743,7 @@
           "@id": "file_26_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_hadm_id",
             "fileObject": {
@@ -4758,7 +4759,7 @@
           "@id": "file_26_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_stay_id",
             "fileObject": {
@@ -4774,7 +4775,7 @@
           "@id": "file_26_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_caregiver_id",
             "fileObject": {
@@ -4790,7 +4791,7 @@
           "@id": "file_26_starttime",
           "name": "starttime",
           "description": "Column 'starttime' from inputevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_26_source_starttime",
             "fileObject": {
@@ -4806,7 +4807,7 @@
           "@id": "file_26_endtime",
           "name": "endtime",
           "description": "Column 'endtime' from inputevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_26_source_endtime",
             "fileObject": {
@@ -4822,7 +4823,7 @@
           "@id": "file_26_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from inputevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_26_source_storetime",
             "fileObject": {
@@ -4838,7 +4839,7 @@
           "@id": "file_26_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_itemid",
             "fileObject": {
@@ -4854,7 +4855,7 @@
           "@id": "file_26_amount",
           "name": "amount",
           "description": "Column 'amount' from inputevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_26_source_amount",
             "fileObject": {
@@ -4886,7 +4887,7 @@
           "@id": "file_26_rate",
           "name": "rate",
           "description": "Column 'rate' from inputevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_26_source_rate",
             "fileObject": {
@@ -4918,7 +4919,7 @@
           "@id": "file_26_orderid",
           "name": "orderid",
           "description": "Column 'orderid' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_orderid",
             "fileObject": {
@@ -4934,7 +4935,7 @@
           "@id": "file_26_linkorderid",
           "name": "linkorderid",
           "description": "Column 'linkorderid' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_linkorderid",
             "fileObject": {
@@ -5014,7 +5015,7 @@
           "@id": "file_26_patientweight",
           "name": "patientweight",
           "description": "Column 'patientweight' from inputevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_26_source_patientweight",
             "fileObject": {
@@ -5030,7 +5031,7 @@
           "@id": "file_26_totalamount",
           "name": "totalamount",
           "description": "Column 'totalamount' from inputevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_26_source_totalamount",
             "fileObject": {
@@ -5062,7 +5063,7 @@
           "@id": "file_26_isopenbag",
           "name": "isopenbag",
           "description": "Column 'isopenbag' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_isopenbag",
             "fileObject": {
@@ -5078,7 +5079,7 @@
           "@id": "file_26_continueinnextdept",
           "name": "continueinnextdept",
           "description": "Column 'continueinnextdept' from inputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_26_source_continueinnextdept",
             "fileObject": {
@@ -5110,7 +5111,7 @@
           "@id": "file_26_originalamount",
           "name": "originalamount",
           "description": "Column 'originalamount' from inputevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_26_source_originalamount",
             "fileObject": {
@@ -5126,7 +5127,7 @@
           "@id": "file_26_originalrate",
           "name": "originalrate",
           "description": "Column 'originalrate' from inputevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_26_source_originalrate",
             "fileObject": {
@@ -5143,14 +5144,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_27",
       "name": "procedureevents",
-      "description": "Records from procedureevents.csv.gz (1000 rows)",
+      "description": "Records from procedureevents.csv.gz (1468 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_27_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_subject_id",
             "fileObject": {
@@ -5166,7 +5167,7 @@
           "@id": "file_27_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_hadm_id",
             "fileObject": {
@@ -5182,7 +5183,7 @@
           "@id": "file_27_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_stay_id",
             "fileObject": {
@@ -5198,7 +5199,7 @@
           "@id": "file_27_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from procedureevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_caregiver_id",
             "fileObject": {
@@ -5214,7 +5215,7 @@
           "@id": "file_27_starttime",
           "name": "starttime",
           "description": "Column 'starttime' from procedureevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_27_source_starttime",
             "fileObject": {
@@ -5230,7 +5231,7 @@
           "@id": "file_27_endtime",
           "name": "endtime",
           "description": "Column 'endtime' from procedureevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_27_source_endtime",
             "fileObject": {
@@ -5246,7 +5247,7 @@
           "@id": "file_27_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from procedureevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_27_source_storetime",
             "fileObject": {
@@ -5262,7 +5263,7 @@
           "@id": "file_27_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_itemid",
             "fileObject": {
@@ -5278,7 +5279,7 @@
           "@id": "file_27_value",
           "name": "value",
           "description": "Column 'value' from procedureevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_27_source_value",
             "fileObject": {
@@ -5342,7 +5343,7 @@
           "@id": "file_27_orderid",
           "name": "orderid",
           "description": "Column 'orderid' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_orderid",
             "fileObject": {
@@ -5358,7 +5359,7 @@
           "@id": "file_27_linkorderid",
           "name": "linkorderid",
           "description": "Column 'linkorderid' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_linkorderid",
             "fileObject": {
@@ -5406,7 +5407,7 @@
           "@id": "file_27_patientweight",
           "name": "patientweight",
           "description": "Column 'patientweight' from procedureevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_27_source_patientweight",
             "fileObject": {
@@ -5422,7 +5423,7 @@
           "@id": "file_27_isopenbag",
           "name": "isopenbag",
           "description": "Column 'isopenbag' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_isopenbag",
             "fileObject": {
@@ -5438,7 +5439,7 @@
           "@id": "file_27_continueinnextdept",
           "name": "continueinnextdept",
           "description": "Column 'continueinnextdept' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_continueinnextdept",
             "fileObject": {
@@ -5470,7 +5471,7 @@
           "@id": "file_27_ORIGINALAMOUNT",
           "name": "ORIGINALAMOUNT",
           "description": "Column 'ORIGINALAMOUNT' from procedureevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_27_source_ORIGINALAMOUNT",
             "fileObject": {
@@ -5486,7 +5487,7 @@
           "@id": "file_27_ORIGINALRATE",
           "name": "ORIGINALRATE",
           "description": "Column 'ORIGINALRATE' from procedureevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_27_source_ORIGINALRATE",
             "fileObject": {
@@ -5503,14 +5504,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_28",
       "name": "d_items",
-      "description": "Records from d_items.csv.gz (1000 rows)",
+      "description": "Records from d_items.csv.gz (4014 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_28_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from d_items.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_28_source_itemid",
             "fileObject": {
@@ -5622,7 +5623,7 @@
           "@id": "file_28_lownormalvalue",
           "name": "lownormalvalue",
           "description": "Column 'lownormalvalue' from d_items.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_28_source_lownormalvalue",
             "fileObject": {
@@ -5638,7 +5639,7 @@
           "@id": "file_28_highnormalvalue",
           "name": "highnormalvalue",
           "description": "Column 'highnormalvalue' from d_items.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_28_source_highnormalvalue",
             "fileObject": {
@@ -5655,14 +5656,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_29",
       "name": "chartevents",
-      "description": "Records from chartevents.csv.gz (1000 rows)",
+      "description": "Records from chartevents.csv.gz (668862 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_29_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from chartevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_subject_id",
             "fileObject": {
@@ -5678,7 +5679,7 @@
           "@id": "file_29_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from chartevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_hadm_id",
             "fileObject": {
@@ -5694,7 +5695,7 @@
           "@id": "file_29_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from chartevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_stay_id",
             "fileObject": {
@@ -5710,7 +5711,7 @@
           "@id": "file_29_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from chartevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_caregiver_id",
             "fileObject": {
@@ -5726,7 +5727,7 @@
           "@id": "file_29_charttime",
           "name": "charttime",
           "description": "Column 'charttime' from chartevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_29_source_charttime",
             "fileObject": {
@@ -5742,7 +5743,7 @@
           "@id": "file_29_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from chartevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_29_source_storetime",
             "fileObject": {
@@ -5758,7 +5759,7 @@
           "@id": "file_29_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from chartevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_itemid",
             "fileObject": {
@@ -5790,7 +5791,7 @@
           "@id": "file_29_valuenum",
           "name": "valuenum",
           "description": "Column 'valuenum' from chartevents.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_29_source_valuenum",
             "fileObject": {
@@ -5822,7 +5823,7 @@
           "@id": "file_29_warning",
           "name": "warning",
           "description": "Column 'warning' from chartevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_29_source_warning",
             "fileObject": {
@@ -5846,7 +5847,7 @@
           "@id": "file_30_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from icustays.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_subject_id",
             "fileObject": {
@@ -5862,7 +5863,7 @@
           "@id": "file_30_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from icustays.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_hadm_id",
             "fileObject": {
@@ -5878,7 +5879,7 @@
           "@id": "file_30_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from icustays.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_30_source_stay_id",
             "fileObject": {
@@ -5926,7 +5927,7 @@
           "@id": "file_30_intime",
           "name": "intime",
           "description": "Column 'intime' from icustays.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_30_source_intime",
             "fileObject": {
@@ -5942,7 +5943,7 @@
           "@id": "file_30_outtime",
           "name": "outtime",
           "description": "Column 'outtime' from icustays.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_30_source_outtime",
             "fileObject": {
@@ -5958,7 +5959,7 @@
           "@id": "file_30_los",
           "name": "los",
           "description": "Column 'los' from icustays.csv.gz",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_30_source_los",
             "fileObject": {
@@ -5975,14 +5976,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_31",
       "name": "outputevents",
-      "description": "Records from outputevents.csv.gz (1000 rows)",
+      "description": "Records from outputevents.csv.gz (9362 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_31_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from outputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_31_source_subject_id",
             "fileObject": {
@@ -5998,7 +5999,7 @@
           "@id": "file_31_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from outputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_31_source_hadm_id",
             "fileObject": {
@@ -6014,7 +6015,7 @@
           "@id": "file_31_stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from outputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_31_source_stay_id",
             "fileObject": {
@@ -6030,7 +6031,7 @@
           "@id": "file_31_caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from outputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_31_source_caregiver_id",
             "fileObject": {
@@ -6046,7 +6047,7 @@
           "@id": "file_31_charttime",
           "name": "charttime",
           "description": "Column 'charttime' from outputevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_31_source_charttime",
             "fileObject": {
@@ -6062,7 +6063,7 @@
           "@id": "file_31_storetime",
           "name": "storetime",
           "description": "Column 'storetime' from outputevents.csv.gz",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_31_source_storetime",
             "fileObject": {
@@ -6078,7 +6079,7 @@
           "@id": "file_31_itemid",
           "name": "itemid",
           "description": "Column 'itemid' from outputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_31_source_itemid",
             "fileObject": {
@@ -6094,7 +6095,7 @@
           "@id": "file_31_value",
           "name": "value",
           "description": "Column 'value' from outputevents.csv.gz",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_31_source_value",
             "fileObject": {

--- a/tests/data/output/mimiciv_demo_meds_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_meds_croissant.jsonld
@@ -38,6 +38,7 @@
     "regex": "cr:regex",
     "repeated": "cr:repeated",
     "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
     "sc": "https://schema.org/",
     "separator": "cr:separator",
     "source": "cr:source",
@@ -48,7 +49,7 @@
   "name": "MIMIC-IV demo data in the Medical Event Data Standard (MEDS)",
   "description": "MEDS demo of MIMIC-IV represented as Parquet event streams",
   "conformsTo": "http://mlcommons.org/croissant/1.0",
-  "citeAs": "Dataset Creator. (2025). MIMIC-IV demo data in the Medical Event Data Standard (MEDS) Dataset. Generated with automated type inference.",
+  "citeAs": "Dataset Creator. (2026). MIMIC-IV demo data in the Medical Event Data Standard (MEDS) Dataset. Generated with automated type inference.",
   "creator": [
     {
       "@type": "sc:Person",
@@ -104,7 +105,7 @@
           "@id": "file_0_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_subject_id",
             "fileObject": {
@@ -120,7 +121,7 @@
           "@id": "file_0_time",
           "name": "time",
           "description": "Column 'time' from 0.parquet",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_0_source_time",
             "fileObject": {
@@ -152,7 +153,7 @@
           "@id": "file_0_numeric_value",
           "name": "numeric_value",
           "description": "Column 'numeric_value' from 0.parquet",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float32",
           "source": {
             "@id": "file_0_source_numeric_value",
             "fileObject": {
@@ -232,7 +233,7 @@
           "@id": "file_0_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_hadm_id",
             "fileObject": {
@@ -248,7 +249,7 @@
           "@id": "file_0_drg_severity",
           "name": "drg_severity",
           "description": "Column 'drg_severity' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_drg_severity",
             "fileObject": {
@@ -264,7 +265,7 @@
           "@id": "file_0_drg_mortality",
           "name": "drg_mortality",
           "description": "Column 'drg_mortality' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_drg_mortality",
             "fileObject": {
@@ -296,7 +297,7 @@
           "@id": "file_0_emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_emar_seq",
             "fileObject": {
@@ -376,7 +377,7 @@
           "@id": "file_0_doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_doses_per_24_hrs",
             "fileObject": {
@@ -408,7 +409,7 @@
           "@id": "file_0_icustay_id",
           "name": "icustay_id",
           "description": "Column 'icustay_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_icustay_id",
             "fileObject": {
@@ -424,7 +425,7 @@
           "@id": "file_0_order_id",
           "name": "order_id",
           "description": "Column 'order_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_order_id",
             "fileObject": {
@@ -440,7 +441,7 @@
           "@id": "file_0_link_order_id",
           "name": "link_order_id",
           "description": "Column 'link_order_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_link_order_id",
             "fileObject": {
@@ -512,7 +513,7 @@
           "@id": "file_1_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_subject_id",
             "fileObject": {
@@ -528,7 +529,7 @@
           "@id": "file_1_time",
           "name": "time",
           "description": "Column 'time' from 0.parquet",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_1_source_time",
             "fileObject": {
@@ -560,7 +561,7 @@
           "@id": "file_1_numeric_value",
           "name": "numeric_value",
           "description": "Column 'numeric_value' from 0.parquet",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float32",
           "source": {
             "@id": "file_1_source_numeric_value",
             "fileObject": {
@@ -640,7 +641,7 @@
           "@id": "file_1_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_hadm_id",
             "fileObject": {
@@ -656,7 +657,7 @@
           "@id": "file_1_drg_severity",
           "name": "drg_severity",
           "description": "Column 'drg_severity' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_drg_severity",
             "fileObject": {
@@ -672,7 +673,7 @@
           "@id": "file_1_drg_mortality",
           "name": "drg_mortality",
           "description": "Column 'drg_mortality' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_drg_mortality",
             "fileObject": {
@@ -704,7 +705,7 @@
           "@id": "file_1_emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_emar_seq",
             "fileObject": {
@@ -784,7 +785,7 @@
           "@id": "file_1_doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_doses_per_24_hrs",
             "fileObject": {
@@ -816,7 +817,7 @@
           "@id": "file_1_icustay_id",
           "name": "icustay_id",
           "description": "Column 'icustay_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_icustay_id",
             "fileObject": {
@@ -832,7 +833,7 @@
           "@id": "file_1_order_id",
           "name": "order_id",
           "description": "Column 'order_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_order_id",
             "fileObject": {
@@ -848,7 +849,7 @@
           "@id": "file_1_link_order_id",
           "name": "link_order_id",
           "description": "Column 'link_order_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_link_order_id",
             "fileObject": {
@@ -920,7 +921,7 @@
           "@id": "file_2_subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_subject_id",
             "fileObject": {
@@ -936,7 +937,7 @@
           "@id": "file_2_time",
           "name": "time",
           "description": "Column 'time' from 0.parquet",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_2_source_time",
             "fileObject": {
@@ -968,7 +969,7 @@
           "@id": "file_2_numeric_value",
           "name": "numeric_value",
           "description": "Column 'numeric_value' from 0.parquet",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float32",
           "source": {
             "@id": "file_2_source_numeric_value",
             "fileObject": {
@@ -1048,7 +1049,7 @@
           "@id": "file_2_hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_hadm_id",
             "fileObject": {
@@ -1064,7 +1065,7 @@
           "@id": "file_2_drg_severity",
           "name": "drg_severity",
           "description": "Column 'drg_severity' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_drg_severity",
             "fileObject": {
@@ -1080,7 +1081,7 @@
           "@id": "file_2_drg_mortality",
           "name": "drg_mortality",
           "description": "Column 'drg_mortality' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_drg_mortality",
             "fileObject": {
@@ -1112,7 +1113,7 @@
           "@id": "file_2_emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_emar_seq",
             "fileObject": {
@@ -1192,7 +1193,7 @@
           "@id": "file_2_doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_doses_per_24_hrs",
             "fileObject": {
@@ -1224,7 +1225,7 @@
           "@id": "file_2_icustay_id",
           "name": "icustay_id",
           "description": "Column 'icustay_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_icustay_id",
             "fileObject": {
@@ -1240,7 +1241,7 @@
           "@id": "file_2_order_id",
           "name": "order_id",
           "description": "Column 'order_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_order_id",
             "fileObject": {
@@ -1256,7 +1257,7 @@
           "@id": "file_2_link_order_id",
           "name": "link_order_id",
           "description": "Column 'link_order_id' from 0.parquet",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_link_order_id",
             "fileObject": {

--- a/tests/data/output/mimiciv_demo_omop_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_omop_croissant.jsonld
@@ -38,6 +38,7 @@
     "regex": "cr:regex",
     "repeated": "cr:repeated",
     "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
     "sc": "https://schema.org/",
     "separator": "cr:separator",
     "source": "cr:source",
@@ -343,7 +344,7 @@
           "@id": "file_0_vocabulary_concept_id",
           "name": "vocabulary_concept_id",
           "description": "Column 'vocabulary_concept_id' from 2b_vocabulary.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_0_source_vocabulary_concept_id",
             "fileObject": {
@@ -367,7 +368,7 @@
           "@id": "file_1_observation_period_id",
           "name": "observation_period_id",
           "description": "Column 'observation_period_id' from observation_period.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_observation_period_id",
             "fileObject": {
@@ -383,7 +384,7 @@
           "@id": "file_1_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from observation_period.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_person_id",
             "fileObject": {
@@ -431,7 +432,7 @@
           "@id": "file_1_period_type_concept_id",
           "name": "period_type_concept_id",
           "description": "Column 'period_type_concept_id' from observation_period.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_1_source_period_type_concept_id",
             "fileObject": {
@@ -448,14 +449,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_2",
       "name": "drug_exposure",
-      "description": "Records from drug_exposure.csv (1000 rows)",
+      "description": "Records from drug_exposure.csv (18229 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_2_drug_exposure_id",
           "name": "drug_exposure_id",
           "description": "Column 'drug_exposure_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_drug_exposure_id",
             "fileObject": {
@@ -471,7 +472,7 @@
           "@id": "file_2_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_person_id",
             "fileObject": {
@@ -487,7 +488,7 @@
           "@id": "file_2_drug_concept_id",
           "name": "drug_concept_id",
           "description": "Column 'drug_concept_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_drug_concept_id",
             "fileObject": {
@@ -519,7 +520,7 @@
           "@id": "file_2_drug_exposure_start_datetime",
           "name": "drug_exposure_start_datetime",
           "description": "Column 'drug_exposure_start_datetime' from drug_exposure.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_2_source_drug_exposure_start_datetime",
             "fileObject": {
@@ -551,7 +552,7 @@
           "@id": "file_2_drug_exposure_end_datetime",
           "name": "drug_exposure_end_datetime",
           "description": "Column 'drug_exposure_end_datetime' from drug_exposure.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_2_source_drug_exposure_end_datetime",
             "fileObject": {
@@ -583,7 +584,7 @@
           "@id": "file_2_drug_type_concept_id",
           "name": "drug_type_concept_id",
           "description": "Column 'drug_type_concept_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_drug_type_concept_id",
             "fileObject": {
@@ -631,7 +632,7 @@
           "@id": "file_2_quantity",
           "name": "quantity",
           "description": "Column 'quantity' from drug_exposure.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_2_source_quantity",
             "fileObject": {
@@ -679,7 +680,7 @@
           "@id": "file_2_route_concept_id",
           "name": "route_concept_id",
           "description": "Column 'route_concept_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_route_concept_id",
             "fileObject": {
@@ -727,7 +728,7 @@
           "@id": "file_2_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_visit_occurrence_id",
             "fileObject": {
@@ -775,7 +776,7 @@
           "@id": "file_2_drug_source_concept_id",
           "name": "drug_source_concept_id",
           "description": "Column 'drug_source_concept_id' from drug_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_2_source_drug_source_concept_id",
             "fileObject": {
@@ -831,7 +832,7 @@
           "@id": "file_3_care_site_id",
           "name": "care_site_id",
           "description": "Column 'care_site_id' from care_site.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_care_site_id",
             "fileObject": {
@@ -863,7 +864,7 @@
           "@id": "file_3_place_of_service_concept_id",
           "name": "place_of_service_concept_id",
           "description": "Column 'place_of_service_concept_id' from care_site.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_place_of_service_concept_id",
             "fileObject": {
@@ -879,7 +880,7 @@
           "@id": "file_3_location_id",
           "name": "location_id",
           "description": "Column 'location_id' from care_site.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_3_source_location_id",
             "fileObject": {
@@ -928,14 +929,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_4",
       "name": "2b_concept",
-      "description": "Records from 2b_concept.csv (1000 rows)",
+      "description": "Records from 2b_concept.csv (3885 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_4_concept_id",
           "name": "concept_id",
           "description": "Column 'concept_id' from 2b_concept.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_4_source_concept_id",
             "fileObject": {
@@ -1103,7 +1104,7 @@
           "@id": "file_5_specimen_id",
           "name": "specimen_id",
           "description": "Column 'specimen_id' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_specimen_id",
             "fileObject": {
@@ -1119,7 +1120,7 @@
           "@id": "file_5_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_person_id",
             "fileObject": {
@@ -1135,7 +1136,7 @@
           "@id": "file_5_specimen_concept_id",
           "name": "specimen_concept_id",
           "description": "Column 'specimen_concept_id' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_specimen_concept_id",
             "fileObject": {
@@ -1151,7 +1152,7 @@
           "@id": "file_5_specimen_type_concept_id",
           "name": "specimen_type_concept_id",
           "description": "Column 'specimen_type_concept_id' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_specimen_type_concept_id",
             "fileObject": {
@@ -1183,7 +1184,7 @@
           "@id": "file_5_specimen_datetime",
           "name": "specimen_datetime",
           "description": "Column 'specimen_datetime' from specimen.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_5_source_specimen_datetime",
             "fileObject": {
@@ -1231,7 +1232,7 @@
           "@id": "file_5_anatomic_site_concept_id",
           "name": "anatomic_site_concept_id",
           "description": "Column 'anatomic_site_concept_id' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_anatomic_site_concept_id",
             "fileObject": {
@@ -1247,7 +1248,7 @@
           "@id": "file_5_disease_status_concept_id",
           "name": "disease_status_concept_id",
           "description": "Column 'disease_status_concept_id' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_disease_status_concept_id",
             "fileObject": {
@@ -1279,7 +1280,7 @@
           "@id": "file_5_specimen_source_value",
           "name": "specimen_source_value",
           "description": "Column 'specimen_source_value' from specimen.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_5_source_specimen_source_value",
             "fileObject": {
@@ -1351,7 +1352,7 @@
           "@id": "file_6_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from death.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_person_id",
             "fileObject": {
@@ -1383,7 +1384,7 @@
           "@id": "file_6_death_datetime",
           "name": "death_datetime",
           "description": "Column 'death_datetime' from death.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_6_source_death_datetime",
             "fileObject": {
@@ -1399,7 +1400,7 @@
           "@id": "file_6_death_type_concept_id",
           "name": "death_type_concept_id",
           "description": "Column 'death_type_concept_id' from death.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_death_type_concept_id",
             "fileObject": {
@@ -1415,7 +1416,7 @@
           "@id": "file_6_cause_concept_id",
           "name": "cause_concept_id",
           "description": "Column 'cause_concept_id' from death.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_cause_concept_id",
             "fileObject": {
@@ -1447,7 +1448,7 @@
           "@id": "file_6_cause_source_concept_id",
           "name": "cause_source_concept_id",
           "description": "Column 'cause_source_concept_id' from death.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_6_source_cause_source_concept_id",
             "fileObject": {
@@ -1464,14 +1465,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_7",
       "name": "device_exposure",
-      "description": "Records from device_exposure.csv (1000 rows)",
+      "description": "Records from device_exposure.csv (3855 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_7_device_exposure_id",
           "name": "device_exposure_id",
           "description": "Column 'device_exposure_id' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_device_exposure_id",
             "fileObject": {
@@ -1487,7 +1488,7 @@
           "@id": "file_7_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_person_id",
             "fileObject": {
@@ -1503,7 +1504,7 @@
           "@id": "file_7_device_concept_id",
           "name": "device_concept_id",
           "description": "Column 'device_concept_id' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_device_concept_id",
             "fileObject": {
@@ -1535,7 +1536,7 @@
           "@id": "file_7_device_exposure_start_datetime",
           "name": "device_exposure_start_datetime",
           "description": "Column 'device_exposure_start_datetime' from device_exposure.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_7_source_device_exposure_start_datetime",
             "fileObject": {
@@ -1567,7 +1568,7 @@
           "@id": "file_7_device_exposure_end_datetime",
           "name": "device_exposure_end_datetime",
           "description": "Column 'device_exposure_end_datetime' from device_exposure.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_7_source_device_exposure_end_datetime",
             "fileObject": {
@@ -1583,7 +1584,7 @@
           "@id": "file_7_device_type_concept_id",
           "name": "device_type_concept_id",
           "description": "Column 'device_type_concept_id' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_device_type_concept_id",
             "fileObject": {
@@ -1615,7 +1616,7 @@
           "@id": "file_7_quantity",
           "name": "quantity",
           "description": "Column 'quantity' from device_exposure.csv",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_quantity",
             "fileObject": {
@@ -1647,7 +1648,7 @@
           "@id": "file_7_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_visit_occurrence_id",
             "fileObject": {
@@ -1679,7 +1680,7 @@
           "@id": "file_7_device_source_value",
           "name": "device_source_value",
           "description": "Column 'device_source_value' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_device_source_value",
             "fileObject": {
@@ -1695,7 +1696,7 @@
           "@id": "file_7_device_source_concept_id",
           "name": "device_source_concept_id",
           "description": "Column 'device_source_concept_id' from device_exposure.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_7_source_device_source_concept_id",
             "fileObject": {
@@ -1712,14 +1713,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_8",
       "name": "fact_relationship",
-      "description": "Records from fact_relationship.csv (1000 rows)",
+      "description": "Records from fact_relationship.csv (1752 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_8_domain_concept_id_1",
           "name": "domain_concept_id_1",
           "description": "Column 'domain_concept_id_1' from fact_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_domain_concept_id_1",
             "fileObject": {
@@ -1735,7 +1736,7 @@
           "@id": "file_8_fact_id_1",
           "name": "fact_id_1",
           "description": "Column 'fact_id_1' from fact_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_fact_id_1",
             "fileObject": {
@@ -1751,7 +1752,7 @@
           "@id": "file_8_domain_concept_id_2",
           "name": "domain_concept_id_2",
           "description": "Column 'domain_concept_id_2' from fact_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_domain_concept_id_2",
             "fileObject": {
@@ -1767,7 +1768,7 @@
           "@id": "file_8_fact_id_2",
           "name": "fact_id_2",
           "description": "Column 'fact_id_2' from fact_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_fact_id_2",
             "fileObject": {
@@ -1783,7 +1784,7 @@
           "@id": "file_8_relationship_concept_id",
           "name": "relationship_concept_id",
           "description": "Column 'relationship_concept_id' from fact_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_8_source_relationship_concept_id",
             "fileObject": {
@@ -1807,7 +1808,7 @@
           "@id": "file_9_dose_era_id",
           "name": "dose_era_id",
           "description": "Column 'dose_era_id' from dose_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_dose_era_id",
             "fileObject": {
@@ -1823,7 +1824,7 @@
           "@id": "file_9_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from dose_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_person_id",
             "fileObject": {
@@ -1839,7 +1840,7 @@
           "@id": "file_9_drug_concept_id",
           "name": "drug_concept_id",
           "description": "Column 'drug_concept_id' from dose_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_drug_concept_id",
             "fileObject": {
@@ -1855,7 +1856,7 @@
           "@id": "file_9_unit_concept_id",
           "name": "unit_concept_id",
           "description": "Column 'unit_concept_id' from dose_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_9_source_unit_concept_id",
             "fileObject": {
@@ -1871,7 +1872,7 @@
           "@id": "file_9_dose_value",
           "name": "dose_value",
           "description": "Column 'dose_value' from dose_era.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_9_source_dose_value",
             "fileObject": {
@@ -1927,7 +1928,7 @@
           "@id": "file_10_location_id",
           "name": "location_id",
           "description": "Column 'location_id' from location.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_10_source_location_id",
             "fileObject": {
@@ -2056,14 +2057,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_11",
       "name": "measurement",
-      "description": "Records from measurement.csv (1000 rows)",
+      "description": "Records from measurement.csv (338550 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_11_measurement_id",
           "name": "measurement_id",
           "description": "Column 'measurement_id' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_measurement_id",
             "fileObject": {
@@ -2079,7 +2080,7 @@
           "@id": "file_11_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_person_id",
             "fileObject": {
@@ -2095,7 +2096,7 @@
           "@id": "file_11_measurement_concept_id",
           "name": "measurement_concept_id",
           "description": "Column 'measurement_concept_id' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_measurement_concept_id",
             "fileObject": {
@@ -2127,7 +2128,7 @@
           "@id": "file_11_measurement_datetime",
           "name": "measurement_datetime",
           "description": "Column 'measurement_datetime' from measurement.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_11_source_measurement_datetime",
             "fileObject": {
@@ -2159,7 +2160,7 @@
           "@id": "file_11_measurement_type_concept_id",
           "name": "measurement_type_concept_id",
           "description": "Column 'measurement_type_concept_id' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_measurement_type_concept_id",
             "fileObject": {
@@ -2175,7 +2176,7 @@
           "@id": "file_11_operator_concept_id",
           "name": "operator_concept_id",
           "description": "Column 'operator_concept_id' from measurement.csv",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_operator_concept_id",
             "fileObject": {
@@ -2191,7 +2192,7 @@
           "@id": "file_11_value_as_number",
           "name": "value_as_number",
           "description": "Column 'value_as_number' from measurement.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_value_as_number",
             "fileObject": {
@@ -2207,7 +2208,7 @@
           "@id": "file_11_value_as_concept_id",
           "name": "value_as_concept_id",
           "description": "Column 'value_as_concept_id' from measurement.csv",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_value_as_concept_id",
             "fileObject": {
@@ -2223,7 +2224,7 @@
           "@id": "file_11_unit_concept_id",
           "name": "unit_concept_id",
           "description": "Column 'unit_concept_id' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_unit_concept_id",
             "fileObject": {
@@ -2239,7 +2240,7 @@
           "@id": "file_11_range_low",
           "name": "range_low",
           "description": "Column 'range_low' from measurement.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_range_low",
             "fileObject": {
@@ -2255,7 +2256,7 @@
           "@id": "file_11_range_high",
           "name": "range_high",
           "description": "Column 'range_high' from measurement.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Float64",
           "source": {
             "@id": "file_11_source_range_high",
             "fileObject": {
@@ -2287,7 +2288,7 @@
           "@id": "file_11_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_visit_occurrence_id",
             "fileObject": {
@@ -2303,7 +2304,7 @@
           "@id": "file_11_visit_detail_id",
           "name": "visit_detail_id",
           "description": "Column 'visit_detail_id' from measurement.csv",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_visit_detail_id",
             "fileObject": {
@@ -2319,7 +2320,7 @@
           "@id": "file_11_measurement_source_value",
           "name": "measurement_source_value",
           "description": "Column 'measurement_source_value' from measurement.csv",
-          "dataType": "sc:Integer",
+          "dataType": "sc:Text",
           "source": {
             "@id": "file_11_source_measurement_source_value",
             "fileObject": {
@@ -2335,7 +2336,7 @@
           "@id": "file_11_measurement_source_concept_id",
           "name": "measurement_source_concept_id",
           "description": "Column 'measurement_source_concept_id' from measurement.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_11_source_measurement_source_concept_id",
             "fileObject": {
@@ -2367,7 +2368,7 @@
           "@id": "file_11_value_source_value",
           "name": "value_source_value",
           "description": "Column 'value_source_value' from measurement.csv",
-          "dataType": "sc:Float",
+          "dataType": "sc:Text",
           "source": {
             "@id": "file_11_source_value_source_value",
             "fileObject": {
@@ -2384,14 +2385,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_12",
       "name": "condition_occurrence",
-      "description": "Records from condition_occurrence.csv (1000 rows)",
+      "description": "Records from condition_occurrence.csv (16441 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_12_condition_occurrence_id",
           "name": "condition_occurrence_id",
           "description": "Column 'condition_occurrence_id' from condition_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_condition_occurrence_id",
             "fileObject": {
@@ -2407,7 +2408,7 @@
           "@id": "file_12_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from condition_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_person_id",
             "fileObject": {
@@ -2423,7 +2424,7 @@
           "@id": "file_12_condition_concept_id",
           "name": "condition_concept_id",
           "description": "Column 'condition_concept_id' from condition_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_condition_concept_id",
             "fileObject": {
@@ -2455,7 +2456,7 @@
           "@id": "file_12_condition_start_datetime",
           "name": "condition_start_datetime",
           "description": "Column 'condition_start_datetime' from condition_occurrence.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_12_source_condition_start_datetime",
             "fileObject": {
@@ -2487,7 +2488,7 @@
           "@id": "file_12_condition_end_datetime",
           "name": "condition_end_datetime",
           "description": "Column 'condition_end_datetime' from condition_occurrence.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_12_source_condition_end_datetime",
             "fileObject": {
@@ -2503,7 +2504,7 @@
           "@id": "file_12_condition_type_concept_id",
           "name": "condition_type_concept_id",
           "description": "Column 'condition_type_concept_id' from condition_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_condition_type_concept_id",
             "fileObject": {
@@ -2551,7 +2552,7 @@
           "@id": "file_12_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from condition_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_visit_occurrence_id",
             "fileObject": {
@@ -2599,7 +2600,7 @@
           "@id": "file_12_condition_source_concept_id",
           "name": "condition_source_concept_id",
           "description": "Column 'condition_source_concept_id' from condition_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_12_source_condition_source_concept_id",
             "fileObject": {
@@ -2648,14 +2649,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_13",
       "name": "2b_concept_relationship",
-      "description": "Records from 2b_concept_relationship.csv (1000 rows)",
+      "description": "Records from 2b_concept_relationship.csv (7716 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_13_concept_id_1",
           "name": "concept_id_1",
           "description": "Column 'concept_id_1' from 2b_concept_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_concept_id_1",
             "fileObject": {
@@ -2671,7 +2672,7 @@
           "@id": "file_13_concept_id_2",
           "name": "concept_id_2",
           "description": "Column 'concept_id_2' from 2b_concept_relationship.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_13_source_concept_id_2",
             "fileObject": {
@@ -2752,14 +2753,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_14",
       "name": "drug_era",
-      "description": "Records from drug_era.csv (1000 rows)",
+      "description": "Records from drug_era.csv (7931 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_14_drug_era_id",
           "name": "drug_era_id",
           "description": "Column 'drug_era_id' from drug_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_drug_era_id",
             "fileObject": {
@@ -2775,7 +2776,7 @@
           "@id": "file_14_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from drug_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_person_id",
             "fileObject": {
@@ -2791,7 +2792,7 @@
           "@id": "file_14_drug_concept_id",
           "name": "drug_concept_id",
           "description": "Column 'drug_concept_id' from drug_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_drug_concept_id",
             "fileObject": {
@@ -2839,7 +2840,7 @@
           "@id": "file_14_drug_exposure_count",
           "name": "drug_exposure_count",
           "description": "Column 'drug_exposure_count' from drug_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_drug_exposure_count",
             "fileObject": {
@@ -2855,7 +2856,7 @@
           "@id": "file_14_gap_days",
           "name": "gap_days",
           "description": "Column 'gap_days' from drug_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_14_source_gap_days",
             "fileObject": {
@@ -3047,7 +3048,7 @@
           "@id": "file_16_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from visit_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_visit_occurrence_id",
             "fileObject": {
@@ -3063,7 +3064,7 @@
           "@id": "file_16_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from visit_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_person_id",
             "fileObject": {
@@ -3079,7 +3080,7 @@
           "@id": "file_16_visit_concept_id",
           "name": "visit_concept_id",
           "description": "Column 'visit_concept_id' from visit_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_visit_concept_id",
             "fileObject": {
@@ -3111,7 +3112,7 @@
           "@id": "file_16_visit_start_datetime",
           "name": "visit_start_datetime",
           "description": "Column 'visit_start_datetime' from visit_occurrence.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_16_source_visit_start_datetime",
             "fileObject": {
@@ -3143,7 +3144,7 @@
           "@id": "file_16_visit_end_datetime",
           "name": "visit_end_datetime",
           "description": "Column 'visit_end_datetime' from visit_occurrence.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_16_source_visit_end_datetime",
             "fileObject": {
@@ -3159,7 +3160,7 @@
           "@id": "file_16_visit_type_concept_id",
           "name": "visit_type_concept_id",
           "description": "Column 'visit_type_concept_id' from visit_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_visit_type_concept_id",
             "fileObject": {
@@ -3223,7 +3224,7 @@
           "@id": "file_16_visit_source_concept_id",
           "name": "visit_source_concept_id",
           "description": "Column 'visit_source_concept_id' from visit_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_visit_source_concept_id",
             "fileObject": {
@@ -3239,7 +3240,7 @@
           "@id": "file_16_admitting_source_concept_id",
           "name": "admitting_source_concept_id",
           "description": "Column 'admitting_source_concept_id' from visit_occurrence.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_admitting_source_concept_id",
             "fileObject": {
@@ -3271,7 +3272,7 @@
           "@id": "file_16_discharge_to_concept_id",
           "name": "discharge_to_concept_id",
           "description": "Column 'discharge_to_concept_id' from visit_occurrence.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_discharge_to_concept_id",
             "fileObject": {
@@ -3303,7 +3304,7 @@
           "@id": "file_16_preceding_visit_occurrence_id",
           "name": "preceding_visit_occurrence_id",
           "description": "Column 'preceding_visit_occurrence_id' from visit_occurrence.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_16_source_preceding_visit_occurrence_id",
             "fileObject": {
@@ -3327,7 +3328,7 @@
           "@id": "file_17_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_person_id",
             "fileObject": {
@@ -3343,7 +3344,7 @@
           "@id": "file_17_gender_concept_id",
           "name": "gender_concept_id",
           "description": "Column 'gender_concept_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_gender_concept_id",
             "fileObject": {
@@ -3359,7 +3360,7 @@
           "@id": "file_17_year_of_birth",
           "name": "year_of_birth",
           "description": "Column 'year_of_birth' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_year_of_birth",
             "fileObject": {
@@ -3423,7 +3424,7 @@
           "@id": "file_17_race_concept_id",
           "name": "race_concept_id",
           "description": "Column 'race_concept_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_race_concept_id",
             "fileObject": {
@@ -3439,7 +3440,7 @@
           "@id": "file_17_ethnicity_concept_id",
           "name": "ethnicity_concept_id",
           "description": "Column 'ethnicity_concept_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_ethnicity_concept_id",
             "fileObject": {
@@ -3503,7 +3504,7 @@
           "@id": "file_17_person_source_value",
           "name": "person_source_value",
           "description": "Column 'person_source_value' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_person_source_value",
             "fileObject": {
@@ -3535,7 +3536,7 @@
           "@id": "file_17_gender_source_concept_id",
           "name": "gender_source_concept_id",
           "description": "Column 'gender_source_concept_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_gender_source_concept_id",
             "fileObject": {
@@ -3567,7 +3568,7 @@
           "@id": "file_17_race_source_concept_id",
           "name": "race_source_concept_id",
           "description": "Column 'race_source_concept_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_race_source_concept_id",
             "fileObject": {
@@ -3599,7 +3600,7 @@
           "@id": "file_17_ethnicity_source_concept_id",
           "name": "ethnicity_source_concept_id",
           "description": "Column 'ethnicity_source_concept_id' from person.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_17_source_ethnicity_source_concept_id",
             "fileObject": {
@@ -3616,14 +3617,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_18",
       "name": "observation",
-      "description": "Records from observation.csv (1000 rows)",
+      "description": "Records from observation.csv (31390 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_18_observation_id",
           "name": "observation_id",
           "description": "Column 'observation_id' from observation.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_observation_id",
             "fileObject": {
@@ -3639,7 +3640,7 @@
           "@id": "file_18_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from observation.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_person_id",
             "fileObject": {
@@ -3655,7 +3656,7 @@
           "@id": "file_18_observation_concept_id",
           "name": "observation_concept_id",
           "description": "Column 'observation_concept_id' from observation.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_observation_concept_id",
             "fileObject": {
@@ -3687,7 +3688,7 @@
           "@id": "file_18_observation_datetime",
           "name": "observation_datetime",
           "description": "Column 'observation_datetime' from observation.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_18_source_observation_datetime",
             "fileObject": {
@@ -3703,7 +3704,7 @@
           "@id": "file_18_observation_type_concept_id",
           "name": "observation_type_concept_id",
           "description": "Column 'observation_type_concept_id' from observation.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_observation_type_concept_id",
             "fileObject": {
@@ -3719,7 +3720,7 @@
           "@id": "file_18_value_as_number",
           "name": "value_as_number",
           "description": "Column 'value_as_number' from observation.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_value_as_number",
             "fileObject": {
@@ -3751,7 +3752,7 @@
           "@id": "file_18_value_as_concept_id",
           "name": "value_as_concept_id",
           "description": "Column 'value_as_concept_id' from observation.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_value_as_concept_id",
             "fileObject": {
@@ -3815,7 +3816,7 @@
           "@id": "file_18_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from observation.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_visit_occurrence_id",
             "fileObject": {
@@ -3863,7 +3864,7 @@
           "@id": "file_18_observation_source_concept_id",
           "name": "observation_source_concept_id",
           "description": "Column 'observation_source_concept_id' from observation.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_18_source_observation_source_concept_id",
             "fileObject": {
@@ -3912,14 +3913,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_19",
       "name": "visit_detail",
-      "description": "Records from visit_detail.csv (1000 rows)",
+      "description": "Records from visit_detail.csv (14479 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_19_visit_detail_id",
           "name": "visit_detail_id",
           "description": "Column 'visit_detail_id' from visit_detail.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_visit_detail_id",
             "fileObject": {
@@ -3935,7 +3936,7 @@
           "@id": "file_19_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from visit_detail.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_person_id",
             "fileObject": {
@@ -3951,7 +3952,7 @@
           "@id": "file_19_visit_detail_concept_id",
           "name": "visit_detail_concept_id",
           "description": "Column 'visit_detail_concept_id' from visit_detail.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_visit_detail_concept_id",
             "fileObject": {
@@ -3983,7 +3984,7 @@
           "@id": "file_19_visit_detail_start_datetime",
           "name": "visit_detail_start_datetime",
           "description": "Column 'visit_detail_start_datetime' from visit_detail.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_19_source_visit_detail_start_datetime",
             "fileObject": {
@@ -4015,7 +4016,7 @@
           "@id": "file_19_visit_detail_end_datetime",
           "name": "visit_detail_end_datetime",
           "description": "Column 'visit_detail_end_datetime' from visit_detail.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_19_source_visit_detail_end_datetime",
             "fileObject": {
@@ -4031,7 +4032,7 @@
           "@id": "file_19_visit_detail_type_concept_id",
           "name": "visit_detail_type_concept_id",
           "description": "Column 'visit_detail_type_concept_id' from visit_detail.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_visit_detail_type_concept_id",
             "fileObject": {
@@ -4063,7 +4064,7 @@
           "@id": "file_19_care_site_id",
           "name": "care_site_id",
           "description": "Column 'care_site_id' from visit_detail.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_care_site_id",
             "fileObject": {
@@ -4079,7 +4080,7 @@
           "@id": "file_19_admitting_source_concept_id",
           "name": "admitting_source_concept_id",
           "description": "Column 'admitting_source_concept_id' from visit_detail.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_admitting_source_concept_id",
             "fileObject": {
@@ -4095,7 +4096,7 @@
           "@id": "file_19_discharge_to_concept_id",
           "name": "discharge_to_concept_id",
           "description": "Column 'discharge_to_concept_id' from visit_detail.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_discharge_to_concept_id",
             "fileObject": {
@@ -4111,7 +4112,7 @@
           "@id": "file_19_preceding_visit_detail_id",
           "name": "preceding_visit_detail_id",
           "description": "Column 'preceding_visit_detail_id' from visit_detail.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_preceding_visit_detail_id",
             "fileObject": {
@@ -4143,7 +4144,7 @@
           "@id": "file_19_visit_detail_source_concept_id",
           "name": "visit_detail_source_concept_id",
           "description": "Column 'visit_detail_source_concept_id' from visit_detail.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_visit_detail_source_concept_id",
             "fileObject": {
@@ -4207,7 +4208,7 @@
           "@id": "file_19_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from visit_detail.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_19_source_visit_occurrence_id",
             "fileObject": {
@@ -4224,14 +4225,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_20",
       "name": "procedure_occurrence",
-      "description": "Records from procedure_occurrence.csv (1000 rows)",
+      "description": "Records from procedure_occurrence.csv (18447 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_20_procedure_occurrence_id",
           "name": "procedure_occurrence_id",
           "description": "Column 'procedure_occurrence_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_procedure_occurrence_id",
             "fileObject": {
@@ -4247,7 +4248,7 @@
           "@id": "file_20_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_person_id",
             "fileObject": {
@@ -4263,7 +4264,7 @@
           "@id": "file_20_procedure_concept_id",
           "name": "procedure_concept_id",
           "description": "Column 'procedure_concept_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_procedure_concept_id",
             "fileObject": {
@@ -4295,7 +4296,7 @@
           "@id": "file_20_procedure_datetime",
           "name": "procedure_datetime",
           "description": "Column 'procedure_datetime' from procedure_occurrence.csv",
-          "dataType": "sc:Date",
+          "dataType": "sc:DateTime",
           "source": {
             "@id": "file_20_source_procedure_datetime",
             "fileObject": {
@@ -4311,7 +4312,7 @@
           "@id": "file_20_procedure_type_concept_id",
           "name": "procedure_type_concept_id",
           "description": "Column 'procedure_type_concept_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_procedure_type_concept_id",
             "fileObject": {
@@ -4327,7 +4328,7 @@
           "@id": "file_20_modifier_concept_id",
           "name": "modifier_concept_id",
           "description": "Column 'modifier_concept_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_modifier_concept_id",
             "fileObject": {
@@ -4343,7 +4344,7 @@
           "@id": "file_20_quantity",
           "name": "quantity",
           "description": "Column 'quantity' from procedure_occurrence.csv",
-          "dataType": "sc:Float",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_quantity",
             "fileObject": {
@@ -4375,7 +4376,7 @@
           "@id": "file_20_visit_occurrence_id",
           "name": "visit_occurrence_id",
           "description": "Column 'visit_occurrence_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_visit_occurrence_id",
             "fileObject": {
@@ -4423,7 +4424,7 @@
           "@id": "file_20_procedure_source_concept_id",
           "name": "procedure_source_concept_id",
           "description": "Column 'procedure_source_concept_id' from procedure_occurrence.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_20_source_procedure_source_concept_id",
             "fileObject": {
@@ -4456,14 +4457,14 @@
       "@type": "cr:RecordSet",
       "@id": "recordset_21",
       "name": "condition_era",
-      "description": "Records from condition_era.csv (1000 rows)",
+      "description": "Records from condition_era.csv (3771 rows)",
       "field": [
         {
           "@type": "cr:Field",
           "@id": "file_21_condition_era_id",
           "name": "condition_era_id",
           "description": "Column 'condition_era_id' from condition_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_condition_era_id",
             "fileObject": {
@@ -4479,7 +4480,7 @@
           "@id": "file_21_person_id",
           "name": "person_id",
           "description": "Column 'person_id' from condition_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_person_id",
             "fileObject": {
@@ -4495,7 +4496,7 @@
           "@id": "file_21_condition_concept_id",
           "name": "condition_concept_id",
           "description": "Column 'condition_concept_id' from condition_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_condition_concept_id",
             "fileObject": {
@@ -4543,7 +4544,7 @@
           "@id": "file_21_condition_occurrence_count",
           "name": "condition_occurrence_count",
           "description": "Column 'condition_occurrence_count' from condition_era.csv",
-          "dataType": "sc:Integer",
+          "dataType": "cr:Int64",
           "source": {
             "@id": "file_21_source_condition_occurrence_count",
             "fileObject": {

--- a/tests/data/output/mitdb_wfdb_croissant.jsonld
+++ b/tests/data/output/mitdb_wfdb_croissant.jsonld
@@ -38,6 +38,7 @@
     "regex": "cr:regex",
     "repeated": "cr:repeated",
     "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
     "sc": "https://schema.org/",
     "separator": "cr:separator",
     "source": "cr:source",

--- a/tests/test_csv_handler.py
+++ b/tests/test_csv_handler.py
@@ -31,9 +31,9 @@ def test_csv_handler_extract_metadata(tmp_path: Path) -> None:
     assert metadata["columns"] == ["id", "name", "age"]
 
     column_types = metadata["column_types"]
-    assert column_types["id"] == "sc:Integer"
+    assert column_types["id"] == "cr:Int64"
     assert column_types["name"] == "sc:Text"
-    assert column_types["age"] == "sc:Integer"
+    assert column_types["age"] == "cr:Int64"
 
 
 def test_csv_handler_empty_file(tmp_path: Path) -> None:
@@ -42,7 +42,7 @@ def test_csv_handler_empty_file(tmp_path: Path) -> None:
     empty_csv.write_text("")
 
     handler = CSVHandler()
-    with pytest.raises(ValueError, match="CSV file contains no data"):
+    with pytest.raises(ValueError):
         handler.extract_metadata(empty_csv)
 
 
@@ -57,5 +57,5 @@ def test_csv_handler_data_types(tmp_path: Path) -> None:
 
     column_types = metadata["column_types"]
     assert column_types["bool_col"] == "sc:Boolean"
-    assert column_types["float_col"] == "sc:Float"
+    assert column_types["float_col"] == "cr:Float64"
     assert column_types["text_col"] == "sc:Text"


### PR DESCRIPTION
## Summary

Unify type inference for CSV and Parquet on top of PyArrow, remove pandas-based heuristics, and regenerate the demo Croissant files to use precise Croissant data types that match Hugging Face’s behavior (e.g. `cr:Int64`, `cr:Float32`, `sc:DateTime`) while staying on the stable Croissant 1.0 spec.

## What changed

- **Shared Arrow → Croissant type mapping**
  - New helpers in `handlers/utils.py`:
    - `map_arrow_type(arrow_type: pa.DataType) -> str`
    - `infer_column_types_from_arrow_schema(schema: pa.Schema) -> Dict[str, str]`
  - Maps Arrow types to Croissant:
    - Integers → `cr:Int8/16/32/64`, `cr:UInt8/16/32/64` (via `bit_width` and signedness).
    - Floats → `cr:Float16/32/64`, all other float widths (e.g. float8) → `sc:Float`.
    - Timestamps → `sc:DateTime`, dates → `sc:Date`, times → `sc:Time`.
    - Booleans → `sc:Boolean`, text/binary → `sc:Text`, null and exotic types → `sc:Text`.
  - Removed pandas- and regex-based CSV inference (`infer_column_types`, `analyze_data_sample`, datetime patterns).

- **CSV handler (`CSVHandler`)**
  - Switched from `pandas.read_csv(nrows=1000)` to `pyarrow.csv.read_csv` with custom timestamp parsers for common clinical formats.
  - Now reads the full file and reports the true row count (no more hard-coded 1000-row sample in descriptions).
  - Uses `infer_column_types_from_arrow_schema(table.schema)` so CSV and Parquet share one type system.
  - Simplified error handling:
    - `FileNotFoundError` if the file is missing.
    - `ArrowInvalid` and `UnicodeDecodeError` are translated to clear `ValueError` messages around parsing/encoding.
    - Empty file raises `ValueError("CSV file is empty: ...")`, not wrapped again.

- **Parquet handler (`ParquetHandler`)**
  - Replaced a local `_map_arrow_type_to_croissant` with `infer_column_types_from_arrow_schema(schema)`.
  - Ensures CSV and Parquet produce identical Croissant types for the same Arrow schemas.

- **Dependencies**
  - `mlcroissant >= 1.0.20` (was `>= 1.0.0`) so `sc:DateTime` and `cr:Int*/Float*` are understood and validated correctly.
  - Removed `pandas` from direct dependencies; it remains available transitively via `wfdb` for WFDB use cases.
  - Core tabular path (CSV and Parquet) is now PyArrow-first.

- **Generated Croissant outputs**
  - All `tests/data/output/*.jsonld` regenerated:
    - `sc:Integer` → `cr:Int64` where Arrow uses 64-bit integers.
    - `sc:Float` → `cr:Float32` or `cr:Float64` depending on Arrow schema.
    - Time columns that are true timestamps are now `sc:DateTime` instead of `sc:Date`.
    - Row counts in descriptions now reflect full CSV sizes, not 1000 rows.
  - `@context` now includes `"samplingRate": "cr:samplingRate"` as provided by `mlcroissant` 1.0.20+ 

## Croissant 1.0 vs 1.1

- Generated metadata continues to declare `conformsTo: "http://mlcommons.org/croissant/1.0"`.
- The types we emit (`cr:Int64`, `cr:Float32/64`, `sc:DateTime`, etc.) are defined in the current Croissant namespace and valid for both 1.0 and the 1.1 draft.
- Hugging Face’s `croissant` endpoint writes `conformsTo` 1.1 by default, but for the tabular features we use there is no behavioral difference.
- Staying on 1.0 keeps us aligned with the ratified spec while still matching HF’s type precision and structure for datasets 