### PR TITLE
Added RAI metadata support with PROV-O, using a YAML interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ Validation checks that the file can be loaded by `mlcroissant` and conforms to t
 croissant-baker validate my-metadata.jsonld
 ```
 
+### Responsible AI (RAI) Metadata
+
+Croissant Baker supports the [RAI extension](https://github.com/mlcommons/croissant/blob/main/docs/croissant-rai-spec.md) for documenting fairness, lineage, and data collection activities. RAI attributes can be described in a YAML config file and injected into the Croissant JSON-LD output.
+
+**Generate metadata with RAI in one step:**
+
+```bash
+croissant-baker --input /path/to/dataset \
+  --creator "Jane Doe" \
+  --rai-config rai.yaml \
+  --output my-metadata.jsonld
+```
+
+**Or apply RAI to an existing Croissant file:**
+
+```bash
+croissant-baker rai-apply my-metadata.jsonld --rai-config rai.yaml
+```
+
+The YAML config covers three areas:
+
+| Section | What it documents |
+|---|---|
+| `ai_fairness` | Data limitations, bias, sensitive information, use cases, social impact, synthetic data flag |
+| `lineage` | Source datasets and downstream assets usage |
+| `activities` | Data collection, annotation, and preprocessing steps with agents and platforms |
+
+See [`tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml`](tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml) for a complete example using the MIMIC-IV Demo dataset.
+
 ## Testing
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyarrow>=15.0.0",
     "pillow>=11.0.0",
     "tifffile>=2024.1.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/rai-example.yaml
+++ b/rai-example.yaml
@@ -1,0 +1,165 @@
+# RAI metadata for a Croissant dataset
+#
+# This file covers the Responsible AI (RAI) extension of the MLCommons Croissant
+# specification (http://mlcommons.org/croissant/RAI/) and the W3C PROV-O ontology
+# (https://www.w3.org/TR/prov-o/) for dataset-level provenance.
+#
+# Usage:
+#   When generating a new Croissant file:
+#     croissant-maker --input ./my-dataset --creator "Name" --rai-config rai.yaml
+#
+#   When enriching an existing Croissant file:
+#     croissant-maker rai-apply dataset-croissant.jsonld --rai-config rai.yaml
+#
+# All fields are optional. Remove or leave blank any section that does not apply.
+# Fields left blank are omitted from the generated Croissant file.
+#
+# OUTPUT STRUCTURE
+# ----------------
+# ai_fairness fields      → direct rai: properties on the dataset node
+# lineage.source_datasets → prov:wasDerivedFrom on the dataset node
+# lineage.models          → rai:usedBy on the dataset node
+# activities              → prov:wasGeneratedBy (list of prov:Activity)
+#   each activity carries optional agents (prov:wasAssociatedWith)
+#   and optional platforms (rai:usedPlatform)
+# ----------------------------------------------------------------------------
+
+
+# ── AI Safety and Fairness ────────────────────────────────────────────────────
+#
+# These fields are written as direct rai: properties on the dataset node.
+# Each is a free-text field that requires deliberate authorship.
+
+ai_fairness:
+
+  # rai:dataLimitations
+  # Document the dataset's boundaries, known failure modes, and use cases that
+  # should be strictly avoided. Be specific rather than generic.
+  data_limitations: >
+    Dataset originates from a single academic medical centre in the northeastern
+    United States. Findings may not generalise to other hospital systems,
+    countries, or patient demographics. Not intended for direct clinical
+    decision-making.
+
+  # rai:dataBias
+  # Detail specific skews, representational gaps, and known biases — including
+  # the geographic or demographic background of annotators, institutional norms
+  # of the source, and amplified biases in any synthetic data.
+  data_bias: >
+    The patient population skews toward English-speaking adults; paediatric
+    and non-English-speaking patients are under-represented. Annotator pool
+    consisted of clinical experts from a single US institution.
+
+  # rai:personalSensitiveInformation
+  # Explicitly disclose any personal or sensitive information (health, location,
+  # political beliefs, etc.), the legal/ethical basis for inclusion, any
+  # privacy-preserving measures applied, and residual risks.
+  personal_sensitive_information: >
+    The dataset contains de-identified patient health records including
+    diagnoses, procedures, and medications. Re-identification risk has been
+    minimised via HIPAA Safe Harbor procedures. Access is restricted to
+    credentialed researchers who have signed a data use agreement.
+
+  # rai:dataUseCases
+  # Specify the intended tasks and the evidence that proves the dataset is valid
+  # for those tasks. Explicitly list out-of-scope uses that have not been tested.
+  data_use_cases: >
+    Benchmarking clinical natural language processing and machine learning
+    models. Supporting research into hospital readmission, mortality prediction,
+    and clinical decision support. Not intended for direct clinical use.
+
+  # rai:socialImpact
+  # Articulate what new capabilities the dataset enables, who benefits, potential
+  # harms, affected groups, and concrete mitigation steps (licensing, access
+  # controls, usage agreements).
+  social_impact: >
+    This dataset enables research that could improve clinical AI tools and
+    patient outcomes. However, models trained on biased data risk perpetuating
+    health disparities if deployed without careful evaluation. Access is
+    restricted via a data use agreement to mitigate misuse.
+
+  # rai:hasSyntheticData
+  # Set to true if the dataset includes any synthetically generated content.
+  # If true, document the generation process in the activities section below.
+  has_synthetic_data: false
+
+
+# ── Data Lifecycle / Lineage ──────────────────────────────────────────────────
+
+lineage:
+
+  # prov:wasDerivedFrom — datasets this dataset was derived from.
+  # url is required; all other fields are optional.
+  source_datasets:
+    - url: https://physionet.org/content/mimiciii/
+      name: MIMIC-III
+      organisation: PhysioNet
+      license: PhysioNet Credentialed Health Data License 1.5.0
+
+  # rai:usedBy — models or assets that have used this dataset (e.g. for training
+  # or evaluation). url is required; name and id are optional.
+  models: []
+  # models:
+  #   - url: https://huggingface.co/my-org/my-model
+  #     name: My Clinical NLP Model
+  #     id: MODEL-001
+
+
+# ── Activities ────────────────────────────────────────────────────────────────
+#
+# Document each major step in the dataset's creation as a prov:Activity.
+# Each activity is written into prov:wasGeneratedBy on the dataset node.
+#
+# type — one of: data_collection | data_annotation | data_preprocessing
+#
+# collection_types — only for data_collection activities. One or more of:
+#   surveys | interviews | observations | experiments | web_scraping |
+#   crowdsourcing | existing_datasets | simulations | other
+#
+# agents — the humans or automated systems that performed the activity.
+#   is_synthetic: true  → automated / AI agent
+#   is_synthetic: false → human agent (team, crowd workers, domain experts)
+#
+# platforms — tools or systems used during the activity (annotation tools,
+#   data collection systems, processing pipelines, etc.)
+
+activities:
+
+  - id: ACT-001
+    type: data_collection
+    description: >
+      Retrospective electronic health records collected during routine clinical
+      care at Beth Israel Deaconess Medical Center between 2011 and 2019.
+    start_at: "2011-01-01"
+    end_at: "2019-12-31"
+    collection_types:
+      - observations
+      - existing_datasets
+    agents:
+      - name: Beth Israel Deaconess Medical Center Clinical Team
+        url: https://www.bidmc.org
+        description: >
+          Clinical staff who generated the source EHR records as part of
+          routine patient care. No specific demographic data was collected
+          about the care providers.
+        is_synthetic: false
+    platforms:
+      - name: Hospital Electronic Health Record System
+        description: >
+          Institutional EHR system used for routine clinical documentation,
+          from which the raw data was extracted.
+
+  - id: ACT-002
+    type: data_preprocessing
+    description: >
+      Patient identifiers were removed using the HIPAA Safe Harbor method.
+      Dates were shifted by a random per-patient offset (up to 365 days)
+      while preserving relative temporal relationships. Free-text fields
+      were scrubbed with a custom NER-based de-identification model.
+    agents:
+      - name: PhysioNet de-identification and curation pipeline
+        url: https://physionet.org
+        description: >
+          Automated pipeline combining rule-based Safe Harbor de-identification
+          with a trained NER model for free-text scrubbing.
+        is_synthetic: true

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -1,15 +1,18 @@
 """Command-line interface for Croissant Baker."""
 
 import csv
+import json
+import tempfile
 import typer
 from pathlib import Path
 import importlib.metadata
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from typing import Optional, List
 
-from croissant_baker.metadata_generator import MetadataGenerator
+from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
 from croissant_baker.files import discover_files
 from croissant_baker.handlers.registry import find_handler
+import mlcroissant as mlc
 
 # Create the Typer application instance
 app = typer.Typer(
@@ -18,6 +21,65 @@ app = typer.Typer(
     add_completion=False,
     rich_markup_mode="markdown",
 )
+
+
+def _save_dict(metadata_dict: dict, output_path: str, validate: bool) -> None:
+    """
+    Save a pre-computed metadata dict to a JSON-LD file, with optional validation.
+
+    This function exists because MetadataGenerator.save_metadata() always calls
+    generate_metadata() internally, regenerating the dict from scratch. That makes
+    it unusable once the dict has already been built and modified — for example,
+    after RAI attributes have been injected via inject_rai(). This function takes
+    the already-computed dict and handles the save + validation step directly,
+    keeping MetadataGenerator unchanged.
+
+    It is used in two places:
+      - The main generate command, when --rai-config is provided (or not, to keep
+        a single consistent save path after generate_metadata() is called once).
+      - The rai-apply command, which loads an existing .jsonld, injects RAI, and
+        saves it back without invoking MetadataGenerator at all.
+
+    Args:
+        metadata_dict: Already-computed Croissant metadata dict (may include RAI).
+        output_path:   Path where the JSON-LD file should be written.
+        validate:      When True, validates via mlcroissant before writing.
+
+    Raises:
+        ValueError: If mlcroissant validation fails.
+    """
+    output_file = Path(output_path)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    if validate:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonld", delete=False
+        ) as tmp:
+            json.dump(
+                metadata_dict,
+                tmp,
+                indent=2,
+                ensure_ascii=False,
+                default=serialize_datetime,
+            )
+            tmp_path = tmp.name
+        try:
+            mlc.Dataset(tmp_path)
+            _write_jsonld(metadata_dict, output_file)
+        except Exception as e:
+            raise ValueError(f"Validation failed: {e}")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+    else:
+        _write_jsonld(metadata_dict, output_file)
+
+
+def _write_jsonld(metadata_dict: dict, output_file: Path) -> None:
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(
+            metadata_dict, f, indent=2, ensure_ascii=False, default=serialize_datetime
+        )
+        f.write("\n")
 
 
 def _get_version() -> str:
@@ -109,6 +171,13 @@ def main(
         "--count-csv-rows",
         help="Count exact row numbers for CSV files (slow for large datasets)",
     ),
+    rai_config: Optional[Path] = typer.Option(
+        None,
+        "--rai-config",
+        help="Path to a RAI config YAML file (see rai-example.yaml for the template)",
+        exists=True,
+        dir_okay=False,
+    ),
     include: Optional[List[str]] = typer.Option(
         None,
         "--include",
@@ -141,6 +210,9 @@ def main(
         typer.echo("")
         typer.echo("Usage: croissant-baker --input <dataset-path> [--output <file>]")
         typer.echo("       croissant-baker validate <file>")
+        typer.echo(
+            "       croissant-baker rai-apply <file.jsonld> --rai-config rai.yaml"
+        )
         typer.echo("       croissant-baker --version")
         typer.echo("       croissant-baker --help")
         return
@@ -258,19 +330,23 @@ def main(
             progress.update(metadata_progress, description="Generating metadata...")
             metadata_dict = generator.generate_metadata()
 
-            # Save and optionally validate
-            output_file = Path(output)
-            output_file.parent.mkdir(parents=True, exist_ok=True)
+            # Inject RAI attributes when a config file is provided
+            if rai_config:
+                from croissant_baker.rai import inject_rai, load_rai_config
 
+                rai = load_rai_config(rai_config)
+                metadata_dict = inject_rai(metadata_dict, rai)
+
+            # Save and optionally validate
             if validate:
                 progress.update(
                     metadata_progress, description="Validating and saving..."
                 )
-                generator.save_metadata(output, validate=True)
+                _save_dict(metadata_dict, output, validate=True)
                 progress.update(metadata_progress, description="Validation completed!")
             else:
                 progress.update(metadata_progress, description="Saving metadata...")
-                generator.save_metadata(output, validate=False)
+                _save_dict(metadata_dict, output, validate=False)
                 progress.update(metadata_progress, description="Save completed!")
 
         # Show results
@@ -296,6 +372,56 @@ def main(
             license=license,
             date_published=date_published,
         )
+
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as e:
+        typer.echo(f"Unexpected error: {e}", err=True)
+        raise typer.Exit(code=1)
+
+
+@app.command(name="rai-apply")
+def rai_apply(
+    file_path: str = typer.Argument(..., help="Croissant metadata file to update"),
+    rai_config: Path = typer.Option(
+        ...,
+        "--rai-config",
+        help="RAI config YAML file",
+        exists=True,
+        dir_okay=False,
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output path (defaults to overwriting the input file)",
+    ),
+    validate: bool = typer.Option(
+        True, "--validate/--no-validate", help="Validate after applying RAI attributes"
+    ),
+) -> None:
+    """Apply RAI attributes from a config YAML to an existing Croissant file."""
+    from croissant_baker.rai import inject_rai, load_rai_config
+
+    input_path = Path(file_path)
+    if not input_path.is_file():
+        typer.echo(f"Error: '{file_path}' is not a file", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        with open(input_path, encoding="utf-8") as fh:
+            metadata_dict = json.load(fh)
+
+        rai = load_rai_config(rai_config)
+        metadata_dict = inject_rai(metadata_dict, rai)
+
+        dest = str(Path(output) if output else input_path)
+        _save_dict(metadata_dict, dest, validate=validate)
+
+        typer.echo(f"RAI attributes applied and saved to: {dest}")
+        if not validate:
+            typer.echo(f"Tip: Run `croissant-baker validate {dest}` to validate later")
 
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/croissant_baker/rai/__init__.py
+++ b/src/croissant_baker/rai/__init__.py
@@ -1,0 +1,7 @@
+"""RAI metadata support for Croissant Maker."""
+
+from croissant_baker.rai.injector import inject_rai
+from croissant_baker.rai.loader import load_rai_config
+from croissant_baker.rai.schema import RAIConfig
+
+__all__ = ["load_rai_config", "inject_rai", "RAIConfig"]

--- a/src/croissant_baker/rai/injector.py
+++ b/src/croissant_baker/rai/injector.py
@@ -1,0 +1,150 @@
+"""Inject RAI and PROV-O attributes into a Croissant JSON-LD metadata dict."""
+
+from __future__ import annotations
+
+from croissant_baker.rai.schema import Activity, RAIConfig
+
+_PROV_NS = "http://www.w3.org/ns/prov#"
+
+_ACTIVITY_LABELS = {
+    "data_collection": "Data Collection",
+    "data_annotation": "Data Annotation",
+    "data_preprocessing": "Data Preprocessing",
+}
+
+
+def inject_rai(metadata: dict, config: RAIConfig) -> dict:
+    """
+    Inject RAI and PROV-O attributes into a Croissant metadata dict.
+
+    Mutates and returns the dict. Fields that are None/empty are skipped.
+    The prov: namespace is added to @context automatically when needed.
+
+    Structure:
+    - AI Safety and Fairness fields are direct rai: properties on the dataset.
+    - Source datasets → prov:wasDerivedFrom.
+    - Models that used this dataset → rai:usedBy.
+    - Activities → prov:wasGeneratedBy (list of prov:Activity), each with
+      optional prov:wasAssociatedWith (agents) and rai:usedPlatform (platforms).
+    """
+    _ensure_prov_context(metadata, config)
+
+    # AI Safety and Fairness
+    af = config.ai_fairness
+    if af.data_limitations:
+        metadata["rai:dataLimitations"] = af.data_limitations
+    if af.data_bias:
+        metadata["rai:dataBias"] = af.data_bias
+    if af.personal_sensitive_information:
+        metadata["rai:personalSensitiveInformation"] = af.personal_sensitive_information
+    if af.data_use_cases:
+        metadata["rai:dataUseCases"] = af.data_use_cases
+    if af.social_impact:
+        metadata["rai:socialImpact"] = af.social_impact
+    if af.has_synthetic_data is not None:
+        metadata["rai:hasSyntheticData"] = af.has_synthetic_data
+
+    # Lineage — source datasets
+    if config.lineage.source_datasets:
+        metadata["prov:wasDerivedFrom"] = [
+            _build_source_dataset(s) for s in config.lineage.source_datasets
+        ]
+
+    # Lineage — models that used this dataset
+    if config.lineage.models:
+        metadata["rai:usedBy"] = [
+            {
+                k: v
+                for k, v in {
+                    "url": m.url,
+                    "id": m.id,
+                    "name": m.name,
+                }.items()
+                if v
+            }
+            for m in config.lineage.models
+        ]
+
+    # Activities
+    activities = [_build_activity(act) for act in config.activities]
+    if activities:
+        metadata["prov:wasGeneratedBy"] = (
+            activities[0] if len(activities) == 1 else activities
+        )
+
+    return metadata
+
+
+def _build_source_dataset(s) -> dict:
+    node: dict = {
+        k: v
+        for k, v in {
+            "url": s.url,
+            "id": s.id,
+            "name": s.name,
+            "license": s.license,
+        }.items()
+        if v
+    }
+    if s.organisation:
+        node["prov:wasAssociatedWith"] = {
+            "@type": "prov:Organization",
+            "name": s.organisation,
+        }
+    return node
+
+
+def _build_activity(act: Activity) -> dict:
+    label = _ACTIVITY_LABELS.get(act.type, act.type)
+    node: dict = {
+        "@type": "prov:Activity",
+        "@id": act.id,
+        "prov:label": label,
+        "prov:type": label,
+    }
+
+    if act.description:
+        node["prov:description"] = act.description
+    if act.start_at:
+        node["prov:startedAtTime"] = act.start_at
+    if act.end_at:
+        node["prov:endedAtTime"] = act.end_at
+
+    if act.agents:
+        agent_nodes = []
+        for a in act.agents:
+            agent_type = "prov:SoftwareAgent" if a.is_synthetic else "prov:Agent"
+            agent: dict = {"@type": agent_type, "name": a.name}
+            if a.url:
+                agent["url"] = a.url
+            if a.description:
+                agent["prov:description"] = a.description
+            agent_nodes.append(agent)
+        node["prov:wasAssociatedWith"] = (
+            agent_nodes[0] if len(agent_nodes) == 1 else agent_nodes
+        )
+
+    if act.platforms:
+        platform_nodes = []
+        for p in act.platforms:
+            plat: dict = {"name": p.name}
+            if p.url:
+                plat["url"] = p.url
+            if p.description:
+                plat["prov:description"] = p.description
+            platform_nodes.append(plat)
+        node["rai:usedPlatform"] = (
+            platform_nodes[0] if len(platform_nodes) == 1 else platform_nodes
+        )
+
+    return node
+
+
+def _ensure_prov_context(metadata: dict, config: RAIConfig) -> None:
+    """Add prov: namespace to @context if any PROV-O output will be injected."""
+    needs_prov = bool(config.activities or config.lineage.source_datasets)
+    if not needs_prov:
+        return
+    ctx = metadata.get("@context")
+    if isinstance(ctx, dict) and "prov" not in ctx:
+        ctx["prov"] = _PROV_NS

--- a/src/croissant_baker/rai/loader.py
+++ b/src/croissant_baker/rai/loader.py
@@ -1,0 +1,121 @@
+"""Load and validate a RAI config YAML file into a RAIConfig dataclass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from croissant_baker.rai.schema import (
+    Activity,
+    Agent,
+    AIFairnessConfig,
+    LineageConfig,
+    ModelRef,
+    Platform,
+    RAIConfig,
+    SourceDataset,
+)
+
+
+def _str(value) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if s else None
+
+
+def load_rai_config(path: Path) -> RAIConfig:
+    """Load a RAI YAML config file and return a RAIConfig instance."""
+    with open(path, encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+
+    # AI Safety and Fairness
+    af_raw = raw.get("ai_fairness") or {}
+    ai_fairness = AIFairnessConfig(
+        data_limitations=_str(af_raw.get("data_limitations")),
+        data_bias=_str(af_raw.get("data_bias")),
+        personal_sensitive_information=_str(
+            af_raw.get("personal_sensitive_information")
+        ),
+        data_use_cases=_str(af_raw.get("data_use_cases")),
+        social_impact=_str(af_raw.get("social_impact")),
+        has_synthetic_data=bool(af_raw["has_synthetic_data"])
+        if "has_synthetic_data" in af_raw
+        else None,
+    )
+
+    # Lineage
+    ln_raw = raw.get("lineage") or {}
+
+    source_datasets = [
+        SourceDataset(
+            url=str(s.get("url", "")),
+            id=_str(s.get("id")),
+            name=_str(s.get("name")),
+            organisation=_str(s.get("organisation")),
+            license=_str(s.get("license")),
+        )
+        for s in (ln_raw.get("source_datasets") or [])
+        if s.get("url")
+    ]
+
+    models = [
+        ModelRef(
+            url=str(m.get("url", "")),
+            id=_str(m.get("id")),
+            name=_str(m.get("name")),
+        )
+        for m in (ln_raw.get("models") or [])
+        if m.get("url")
+    ]
+
+    lineage = LineageConfig(source_datasets=source_datasets, models=models)
+
+    # Activities
+    activities = []
+    for act_raw in raw.get("activities") or []:
+        agents = [
+            Agent(
+                name=str(a.get("name", "")),
+                url=_str(a.get("url")),
+                description=_str(a.get("description")),
+                is_synthetic=bool(a.get("is_synthetic", False)),
+            )
+            for a in (act_raw.get("agents") or [])
+            if a.get("name")
+        ]
+
+        platforms = [
+            Platform(
+                name=str(p.get("name", "")),
+                url=_str(p.get("url")),
+                description=_str(p.get("description")),
+            )
+            for p in (act_raw.get("platforms") or [])
+            if p.get("name")
+        ]
+
+        collection_types = [
+            str(t).strip() for t in (act_raw.get("collection_types") or []) if t
+        ]
+
+        activities.append(
+            Activity(
+                id=str(act_raw.get("id", "")),
+                type=str(act_raw.get("type", "")),
+                description=_str(act_raw.get("description")),
+                start_at=_str(act_raw.get("start_at")),
+                end_at=_str(act_raw.get("end_at")),
+                collection_types=collection_types,
+                agents=agents,
+                platforms=platforms,
+            )
+        )
+
+    return RAIConfig(
+        ai_fairness=ai_fairness,
+        lineage=lineage,
+        activities=activities,
+    )

--- a/src/croissant_baker/rai/schema.py
+++ b/src/croissant_baker/rai/schema.py
@@ -1,0 +1,84 @@
+"""RAI metadata schema — dataclass models for Responsible AI attributes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ── AI Safety and Fairness ────────────────────────────────────────────────────
+
+
+@dataclass
+class AIFairnessConfig:
+    data_limitations: Optional[str] = None
+    data_bias: Optional[str] = None
+    personal_sensitive_information: Optional[str] = None
+    data_use_cases: Optional[str] = None
+    social_impact: Optional[str] = None
+    has_synthetic_data: Optional[bool] = None
+
+
+# ── Data Lifecycle / Lineage ──────────────────────────────────────────────────
+
+
+@dataclass
+class SourceDataset:
+    url: str
+    id: Optional[str] = None
+    name: Optional[str] = None
+    organisation: Optional[str] = None
+    license: Optional[str] = None
+
+
+@dataclass
+class ModelRef:
+    url: str
+    id: Optional[str] = None
+    name: Optional[str] = None
+
+
+@dataclass
+class LineageConfig:
+    source_datasets: list[SourceDataset] = field(default_factory=list)
+    models: list[ModelRef] = field(default_factory=list)
+
+
+# ── Activities ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Agent:
+    name: str
+    url: Optional[str] = None
+    description: Optional[str] = None
+    is_synthetic: bool = False
+
+
+@dataclass
+class Platform:
+    name: str
+    url: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass
+class Activity:
+    id: str
+    type: str  # data_collection | data_annotation | data_preprocessing
+    description: Optional[str] = None
+    start_at: Optional[str] = None
+    end_at: Optional[str] = None
+    collection_types: list[str] = field(default_factory=list)
+    agents: list[Agent] = field(default_factory=list)
+    platforms: list[Platform] = field(default_factory=list)
+
+
+# ── Top-level config ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class RAIConfig:
+    ai_fairness: AIFairnessConfig = field(default_factory=AIFairnessConfig)
+    lineage: LineageConfig = field(default_factory=LineageConfig)
+    activities: list[Activity] = field(default_factory=list)

--- a/tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml
+++ b/tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml
@@ -1,0 +1,75 @@
+# RAI metadata for the MIMIC-IV Demo Dataset
+# Generated with croissant-maker rai-apply
+
+ai_fairness:
+
+  data_limitations: >
+    Data originates from a single academic medical centre in the northeastern
+    United States. Findings may not generalise to other hospital systems,
+    countries, or patient demographics. Not intended for direct clinical
+    decision-making.
+
+  data_bias: >
+    The patient population skews toward English-speaking adults; paediatric
+    and non-English-speaking patients are under-represented.
+
+  personal_sensitive_information: >
+    The dataset contains de-identified patient health records. Re-identification
+    risk has been minimised via HIPAA Safe Harbor procedures. Access is
+    restricted to credentialed researchers who have signed a data use agreement.
+
+  data_use_cases: >
+    Benchmarking clinical natural language processing and machine learning
+    models. Supporting research into hospital readmission, mortality
+    prediction, and clinical decision support. Not intended for direct
+    clinical decision-making.
+
+  social_impact: >
+    This dataset enables research that could improve clinical AI tools and
+    patient outcomes. However, models trained on biased data risk perpetuating
+    health disparities if deployed without careful evaluation.
+
+  has_synthetic_data: false
+
+
+lineage:
+
+  source_datasets:
+    - url: https://physionet.org/content/mimiciii/
+      name: MIMIC-III
+      organisation: PhysioNet
+
+  models: []
+
+
+activities:
+
+  - id: ACT-001
+    type: data_collection
+    description: >
+      Retrospective electronic health records collected during routine clinical
+      care at Beth Israel Deaconess Medical Center.
+    start_at: "2011-01-01"
+    end_at: "2019-12-31"
+    collection_types:
+      - observations
+      - existing_datasets
+    agents:
+      - name: Beth Israel Deaconess Medical Center Clinical Team
+        url: https://www.bidmc.org
+        is_synthetic: false
+
+  - id: ACT-002
+    type: data_preprocessing
+    description: >
+      Patient identifiers were removed using the HIPAA Safe Harbor method.
+      Dates were shifted by a random per-patient offset (up to 365 days)
+      while preserving relative temporal relationships. Free-text fields
+      were scrubbed with a custom NER-based de-identification model.
+    agents:
+      - name: PhysioNet de-identification and curation pipeline
+        url: https://physionet.org
+        description: >
+          Automated pipeline combining rule-based Safe Harbor de-identification
+          with a trained NER model for free-text scrubbing.
+        is_synthetic: true

--- a/tests/data/output/mimiciv_demo_croissant_rai.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant_rai.jsonld
@@ -1,0 +1,5832 @@
+{
+  "@context": {
+    "@language": "en",
+    "@vocab": "https://schema.org/",
+    "citeAs": "cr:citeAs",
+    "column": "cr:column",
+    "conformsTo": "dct:conformsTo",
+    "cr": "http://mlcommons.org/croissant/",
+    "rai": "http://mlcommons.org/croissant/RAI/",
+    "data": {
+      "@id": "cr:data",
+      "@type": "@json"
+    },
+    "dataType": {
+      "@id": "cr:dataType",
+      "@type": "@vocab"
+    },
+    "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
+    "examples": {
+      "@id": "cr:examples",
+      "@type": "@json"
+    },
+    "extract": "cr:extract",
+    "field": "cr:field",
+    "fileProperty": "cr:fileProperty",
+    "fileObject": "cr:fileObject",
+    "fileSet": "cr:fileSet",
+    "format": "cr:format",
+    "includes": "cr:includes",
+    "isLiveDataset": "cr:isLiveDataset",
+    "jsonPath": "cr:jsonPath",
+    "key": "cr:key",
+    "md5": "cr:md5",
+    "parentField": "cr:parentField",
+    "path": "cr:path",
+    "recordSet": "cr:recordSet",
+    "references": "cr:references",
+    "regex": "cr:regex",
+    "repeated": "cr:repeated",
+    "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
+    "sc": "https://schema.org/",
+    "separator": "cr:separator",
+    "source": "cr:source",
+    "subField": "cr:subField",
+    "transform": "cr:transform",
+    "prov": "http://www.w3.org/ns/prov#"
+  },
+  "@type": "sc:Dataset",
+  "name": "MIMIC-IV Demo Dataset",
+  "description": "Demo subset of MIMIC-IV, a freely accessible electronic health record dataset from Beth Israel Deaconess Medical Center (2008-2019)",
+  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "citeAs": "Johnson, A., Bulgarelli, L., Pollard, T., Horng, S., Celi, L. A., & Mark, R. (2023). MIMIC-IV (version 2.2). PhysioNet. https://doi.org/10.13026/6mm1-ek67",
+  "creator": [
+    {
+      "@type": "sc:Person",
+      "name": "Alistair Johnson",
+      "email": "aewj@mit.edu",
+      "url": "https://physionet.org/"
+    },
+    {
+      "@type": "sc:Person",
+      "name": "Lucas Bulgarelli",
+      "url": "https://mit.edu/"
+    },
+    {
+      "@type": "sc:Person",
+      "name": "Tom Pollard",
+      "email": "tpollard@mit.edu",
+      "url": "https://physionet.org/"
+    },
+    {
+      "@type": "sc:Person",
+      "name": "Steven Horng",
+      "url": "https://www.bidmc.org/"
+    },
+    {
+      "@type": "sc:Person",
+      "name": "Leo Anthony Celi",
+      "email": "lceli@mit.edu",
+      "url": "https://lcp.mit.edu/"
+    },
+    {
+      "@type": "sc:Person",
+      "name": "Roger Mark",
+      "url": "https://lcp.mit.edu/"
+    }
+  ],
+  "datePublished": "2023-01-06",
+  "license": "PhysioNet Restricted Health Data License 1.5.0",
+  "url": "https://physionet.org/content/mimic-iv-demo/",
+  "version": "2.2",
+  "distribution": [
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_0",
+      "name": "demo_subject_id.csv",
+      "contentSize": "911",
+      "contentUrl": "demo_subject_id.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "6e9ba177eefc70617ccc1782b9af716b23fbcf36c4c5143e275149d78ee83624"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_1",
+      "name": "emar.csv.gz",
+      "contentSize": "734347",
+      "contentUrl": "hosp/emar.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "f14a4b5597abcc2e8d62d291c7839347ef6260d4c548ea534ab62df6b2f49adc"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_2",
+      "name": "microbiologyevents.csv.gz",
+      "contentSize": "80991",
+      "contentUrl": "hosp/microbiologyevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "fa462443cc5777ebf9d833f71c67f2a89b4a074eb376320da70bed220e918ad4"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_3",
+      "name": "d_icd_diagnoses.csv.gz",
+      "contentSize": "1813533",
+      "contentUrl": "hosp/d_icd_diagnoses.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "0f715a3c4c5e44400305d4deb86ff648e499a3bfcb946f353e8b030022d3ec06"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_4",
+      "name": "omr.csv.gz",
+      "contentSize": "17339",
+      "contentUrl": "hosp/omr.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "6d7c69dbb2c79b9d1de7d1e68f3424ad248821d7c074dc6537d7290774af39b9"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_5",
+      "name": "d_labitems.csv.gz",
+      "contentSize": "13520",
+      "contentUrl": "hosp/d_labitems.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "72ea5f020469fd24543bd98ab3bd0a4f645a5a4b7802d9d52af20d736f9d76db"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_6",
+      "name": "hcpcsevents.csv.gz",
+      "contentSize": "963",
+      "contentUrl": "hosp/hcpcsevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "87f8af876aa6a608c6761068386e93e0c91b59ff2ce0d7a650fe8d5ba833247d"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_7",
+      "name": "services.csv.gz",
+      "contentSize": "5072",
+      "contentUrl": "hosp/services.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "28306d68e952fe2cc9ef6e60b0afda93c27d7a06bee8ef39e71ccc4de5ded793"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_8",
+      "name": "d_hcpcs.csv.gz",
+      "contentSize": "510070",
+      "contentUrl": "hosp/d_hcpcs.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "493ea7fe1d22afd5abd9138be8a4e50c776986feded6891143120d2bc724d881"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_9",
+      "name": "d_icd_procedures.csv.gz",
+      "contentSize": "1082613",
+      "contentUrl": "hosp/d_icd_procedures.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "a921a20fbf3220e2a7fe874d6392d671c1cc769a001ef0a7841b80eb01030bb6"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_10",
+      "name": "poe.csv.gz",
+      "contentSize": "611200",
+      "contentUrl": "hosp/poe.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "bf850e1519f2c3df8c706dc5e2afcb83e86e1d6e4afd7c01426b6b07d25cfeef"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_11",
+      "name": "transfers.csv.gz",
+      "contentSize": "23480",
+      "contentUrl": "hosp/transfers.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "41151539886d12d57159b65ffe4d7df5a7ef8ceb7cd113ea9a56fbfbfd78a87c"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_12",
+      "name": "emar_detail.csv.gz",
+      "contentSize": "692290",
+      "contentUrl": "hosp/emar_detail.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "8ca5a09f2fa2e0ad5d77121fd62bf5f58bad056713223d9758b4ecd03fa0a435"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_13",
+      "name": "prescriptions.csv.gz",
+      "contentSize": "606447",
+      "contentUrl": "hosp/prescriptions.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "33c392ba5b9299b08eca0a61911ba106f0aebdba26ed31b856bb9ffd49fe3654"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_14",
+      "name": "drgcodes.csv.gz",
+      "contentSize": "7459",
+      "contentUrl": "hosp/drgcodes.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "9ec47b7a49514cfe243236ca2eb5c5b517d2215d6589efb2bd80166883243537"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_15",
+      "name": "procedures_icd.csv.gz",
+      "contentSize": "6602",
+      "contentUrl": "hosp/procedures_icd.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "68f21dcba9ae0c4b7faa3ef38aa950a8ebeb6d167bc74416314dccdcf28674e0"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_16",
+      "name": "provider.csv.gz",
+      "contentSize": "151283",
+      "contentUrl": "hosp/provider.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "7a56a24cfe2fcd5ed1995c696417bf8f5c09088eb546503b07362c504228c63a"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_17",
+      "name": "poe_detail.csv.gz",
+      "contentSize": "26574",
+      "contentUrl": "hosp/poe_detail.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "7010cbc4d74e9a7c998be33c3736af301ebe2c6678969e25800d28e90a2b5825"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_18",
+      "name": "labevents.csv.gz",
+      "contentSize": "1963979",
+      "contentUrl": "hosp/labevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "d51a4cf1ea63245abe7d544b0d50a928e9ee2ec5eb9a5ce85500aed0bd6c6dfc"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_19",
+      "name": "pharmacy.csv.gz",
+      "contentSize": "503956",
+      "contentUrl": "hosp/pharmacy.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "3403865a279464b14d038a66b30ba3d609933f517262ea0402fef020046bd197"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_20",
+      "name": "patients.csv.gz",
+      "contentSize": "1083",
+      "contentUrl": "hosp/patients.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "59dcc6cd8450ddf03ad32cc7d76e41caa4c9633541715987f590c74835cf6fae"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_21",
+      "name": "admissions.csv.gz",
+      "contentSize": "11072",
+      "contentUrl": "hosp/admissions.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "910b9f160ffdf1e08ea673585393f347c773ccc87d66875c627584a903ae8493"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_22",
+      "name": "diagnoses_icd.csv.gz",
+      "contentSize": "24198",
+      "contentUrl": "hosp/diagnoses_icd.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "958565670c0b3903c0c12825366dc2bae8561d2d55f16feac0c949dd630ed3e4"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_23",
+      "name": "inputevents.csv.gz",
+      "contentSize": "788253",
+      "contentUrl": "icu/inputevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "69597dca47e554e16645ca505167e9f39b07c1724e915ba54ccfb40f5fa0078a"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_24",
+      "name": "datetimeevents.csv.gz",
+      "contentSize": "119448",
+      "contentUrl": "icu/datetimeevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "b9f05bb9b1c5aa52e9f25585853583a2e07046f22ed68419c20ef8daa8762da5"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_25",
+      "name": "ingredientevents.csv.gz",
+      "contentSize": "601205",
+      "contentUrl": "icu/ingredientevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "c9b0afdca936a9485422f72d227b3d1942125bb6d969eef57fdf0233458c6b23"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_26",
+      "name": "d_items.csv.gz",
+      "contentSize": "57073",
+      "contentUrl": "icu/d_items.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "1690467a822345226a041c1149237c418aa60098c6b699fb4cef64d73588a01f"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_27",
+      "name": "chartevents.csv.gz",
+      "contentSize": "5549389",
+      "contentUrl": "icu/chartevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "90f096ad3db847ed1aaec073f8d86053c51fea7b616d3b046410e030f083d560"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_28",
+      "name": "procedureevents.csv.gz",
+      "contentSize": "44817",
+      "contentUrl": "icu/procedureevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "37454f286dc1eee6cef666b4fdf91452eb8bea6bfc3cf98d4ad179ebb4a741fa"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_29",
+      "name": "outputevents.csv.gz",
+      "contentSize": "96413",
+      "contentUrl": "icu/outputevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "3bcf68adaa11070d6c24e13d4bfaaf718606cd33b0df7f28e0de240c357a869e"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_30",
+      "name": "icustays.csv.gz",
+      "contentSize": "5667",
+      "contentUrl": "icu/icustays.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "e05e81aa52a3022e522b6832a898101a69b84e64c17bb344d819e458d5bc21b3"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_31",
+      "name": "caregiver.csv.gz",
+      "contentSize": "43441",
+      "contentUrl": "icu/caregiver.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "88ee01d7f21aadee273e2d1ce65b0f14fe96fe87ab42e2b40c89aa8103ef6371"
+    }
+  ],
+  "recordSet": [
+    {
+      "@type": "cr:RecordSet",
+      "@id": "demo_subject_id",
+      "name": "demo_subject_id",
+      "description": "Records from demo_subject_id.csv",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "demo_subject_id/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from demo_subject_id.csv",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_0"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "emar",
+      "name": "emar",
+      "description": "Records from emar.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "emar/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from emar.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from emar.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/emar_id",
+          "name": "emar_id",
+          "description": "Column 'emar_id' from emar.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "emar_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/emar_seq",
+          "name": "emar_seq",
+          "description": "Column 'emar_seq' from emar.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "emar_seq"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/poe_id",
+          "name": "poe_id",
+          "description": "Column 'poe_id' from emar.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/pharmacy_id",
+          "name": "pharmacy_id",
+          "description": "Column 'pharmacy_id' from emar.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "pharmacy_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/enter_provider_id",
+          "name": "enter_provider_id",
+          "description": "Column 'enter_provider_id' from emar.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "enter_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from emar.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/medication",
+          "name": "medication",
+          "description": "Column 'medication' from emar.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "medication"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/event_txt",
+          "name": "event_txt",
+          "description": "Column 'event_txt' from emar.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "event_txt"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/scheduletime",
+          "name": "scheduletime",
+          "description": "Column 'scheduletime' from emar.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "scheduletime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from emar.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_1"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "microbiologyevents",
+      "name": "microbiologyevents",
+      "description": "Records from microbiologyevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/microevent_id",
+          "name": "microevent_id",
+          "description": "Column 'microevent_id' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "microevent_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/micro_specimen_id",
+          "name": "micro_specimen_id",
+          "description": "Column 'micro_specimen_id' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "micro_specimen_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/order_provider_id",
+          "name": "order_provider_id",
+          "description": "Column 'order_provider_id' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "order_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/chartdate",
+          "name": "chartdate",
+          "description": "Column 'chartdate' from microbiologyevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "chartdate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from microbiologyevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/spec_itemid",
+          "name": "spec_itemid",
+          "description": "Column 'spec_itemid' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "spec_itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/spec_type_desc",
+          "name": "spec_type_desc",
+          "description": "Column 'spec_type_desc' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "spec_type_desc"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/test_seq",
+          "name": "test_seq",
+          "description": "Column 'test_seq' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "test_seq"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/storedate",
+          "name": "storedate",
+          "description": "Column 'storedate' from microbiologyevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "storedate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from microbiologyevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/test_itemid",
+          "name": "test_itemid",
+          "description": "Column 'test_itemid' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "test_itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/test_name",
+          "name": "test_name",
+          "description": "Column 'test_name' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "test_name"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/org_itemid",
+          "name": "org_itemid",
+          "description": "Column 'org_itemid' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "org_itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/org_name",
+          "name": "org_name",
+          "description": "Column 'org_name' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "org_name"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/isolate_num",
+          "name": "isolate_num",
+          "description": "Column 'isolate_num' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "isolate_num"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/quantity",
+          "name": "quantity",
+          "description": "Column 'quantity' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "quantity"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/ab_itemid",
+          "name": "ab_itemid",
+          "description": "Column 'ab_itemid' from microbiologyevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "ab_itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/ab_name",
+          "name": "ab_name",
+          "description": "Column 'ab_name' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "ab_name"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/dilution_text",
+          "name": "dilution_text",
+          "description": "Column 'dilution_text' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "dilution_text"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/dilution_comparison",
+          "name": "dilution_comparison",
+          "description": "Column 'dilution_comparison' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "dilution_comparison"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/dilution_value",
+          "name": "dilution_value",
+          "description": "Column 'dilution_value' from microbiologyevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "dilution_value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/interpretation",
+          "name": "interpretation",
+          "description": "Column 'interpretation' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "interpretation"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "microbiologyevents/comments",
+          "name": "comments",
+          "description": "Column 'comments' from microbiologyevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_2"
+            },
+            "extract": {
+              "column": "comments"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "d_icd_diagnoses",
+      "name": "d_icd_diagnoses",
+      "description": "Records from d_icd_diagnoses.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "d_icd_diagnoses/icd_code",
+          "name": "icd_code",
+          "description": "Column 'icd_code' from d_icd_diagnoses.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_3"
+            },
+            "extract": {
+              "column": "icd_code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_icd_diagnoses/icd_version",
+          "name": "icd_version",
+          "description": "Column 'icd_version' from d_icd_diagnoses.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_3"
+            },
+            "extract": {
+              "column": "icd_version"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_icd_diagnoses/long_title",
+          "name": "long_title",
+          "description": "Column 'long_title' from d_icd_diagnoses.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_3"
+            },
+            "extract": {
+              "column": "long_title"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "omr",
+      "name": "omr",
+      "description": "Records from omr.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "omr/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from omr.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_4"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "omr/chartdate",
+          "name": "chartdate",
+          "description": "Column 'chartdate' from omr.csv.gz",
+          "dataType": "sc:Date",
+          "source": {
+            "fileObject": {
+              "@id": "file_4"
+            },
+            "extract": {
+              "column": "chartdate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "omr/seq_num",
+          "name": "seq_num",
+          "description": "Column 'seq_num' from omr.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_4"
+            },
+            "extract": {
+              "column": "seq_num"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "omr/result_name",
+          "name": "result_name",
+          "description": "Column 'result_name' from omr.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_4"
+            },
+            "extract": {
+              "column": "result_name"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "omr/result_value",
+          "name": "result_value",
+          "description": "Column 'result_value' from omr.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_4"
+            },
+            "extract": {
+              "column": "result_value"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "d_labitems",
+      "name": "d_labitems",
+      "description": "Records from d_labitems.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from d_labitems.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/label",
+          "name": "label",
+          "description": "Column 'label' from d_labitems.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "label"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/fluid",
+          "name": "fluid",
+          "description": "Column 'fluid' from d_labitems.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "fluid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/category",
+          "name": "category",
+          "description": "Column 'category' from d_labitems.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "category"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "hcpcsevents",
+      "name": "hcpcsevents",
+      "description": "Records from hcpcsevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "hcpcsevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from hcpcsevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "hcpcsevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from hcpcsevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "hcpcsevents/chartdate",
+          "name": "chartdate",
+          "description": "Column 'chartdate' from hcpcsevents.csv.gz",
+          "dataType": "sc:Date",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "chartdate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "hcpcsevents/hcpcs_cd",
+          "name": "hcpcs_cd",
+          "description": "Column 'hcpcs_cd' from hcpcsevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "hcpcs_cd"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "hcpcsevents/seq_num",
+          "name": "seq_num",
+          "description": "Column 'seq_num' from hcpcsevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "seq_num"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "hcpcsevents/short_description",
+          "name": "short_description",
+          "description": "Column 'short_description' from hcpcsevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "short_description"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "services",
+      "name": "services",
+      "description": "Records from services.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "services/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from services.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_7"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "services/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from services.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_7"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "services/transfertime",
+          "name": "transfertime",
+          "description": "Column 'transfertime' from services.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_7"
+            },
+            "extract": {
+              "column": "transfertime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "services/prev_service",
+          "name": "prev_service",
+          "description": "Column 'prev_service' from services.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_7"
+            },
+            "extract": {
+              "column": "prev_service"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "services/curr_service",
+          "name": "curr_service",
+          "description": "Column 'curr_service' from services.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_7"
+            },
+            "extract": {
+              "column": "curr_service"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "d_hcpcs",
+      "name": "d_hcpcs",
+      "description": "Records from d_hcpcs.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "d_hcpcs/code",
+          "name": "code",
+          "description": "Column 'code' from d_hcpcs.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_hcpcs/category",
+          "name": "category",
+          "description": "Column 'category' from d_hcpcs.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "category"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_hcpcs/long_description",
+          "name": "long_description",
+          "description": "Column 'long_description' from d_hcpcs.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "long_description"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_hcpcs/short_description",
+          "name": "short_description",
+          "description": "Column 'short_description' from d_hcpcs.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "short_description"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "d_icd_procedures",
+      "name": "d_icd_procedures",
+      "description": "Records from d_icd_procedures.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "d_icd_procedures/icd_code",
+          "name": "icd_code",
+          "description": "Column 'icd_code' from d_icd_procedures.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_9"
+            },
+            "extract": {
+              "column": "icd_code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_icd_procedures/icd_version",
+          "name": "icd_version",
+          "description": "Column 'icd_version' from d_icd_procedures.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_9"
+            },
+            "extract": {
+              "column": "icd_version"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_icd_procedures/long_title",
+          "name": "long_title",
+          "description": "Column 'long_title' from d_icd_procedures.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_9"
+            },
+            "extract": {
+              "column": "long_title"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "poe",
+      "name": "poe",
+      "description": "Records from poe.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "poe/poe_id",
+          "name": "poe_id",
+          "description": "Column 'poe_id' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/poe_seq",
+          "name": "poe_seq",
+          "description": "Column 'poe_seq' from poe.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "poe_seq"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from poe.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from poe.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/ordertime",
+          "name": "ordertime",
+          "description": "Column 'ordertime' from poe.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "ordertime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/order_type",
+          "name": "order_type",
+          "description": "Column 'order_type' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "order_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/order_subtype",
+          "name": "order_subtype",
+          "description": "Column 'order_subtype' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "order_subtype"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/transaction_type",
+          "name": "transaction_type",
+          "description": "Column 'transaction_type' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "transaction_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/discontinue_of_poe_id",
+          "name": "discontinue_of_poe_id",
+          "description": "Column 'discontinue_of_poe_id' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "discontinue_of_poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/discontinued_by_poe_id",
+          "name": "discontinued_by_poe_id",
+          "description": "Column 'discontinued_by_poe_id' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "discontinued_by_poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/order_provider_id",
+          "name": "order_provider_id",
+          "description": "Column 'order_provider_id' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "order_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe/order_status",
+          "name": "order_status",
+          "description": "Column 'order_status' from poe.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_10"
+            },
+            "extract": {
+              "column": "order_status"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "transfers",
+      "name": "transfers",
+      "description": "Records from transfers.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from transfers.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from transfers.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/transfer_id",
+          "name": "transfer_id",
+          "description": "Column 'transfer_id' from transfers.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "transfer_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/eventtype",
+          "name": "eventtype",
+          "description": "Column 'eventtype' from transfers.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "eventtype"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/careunit",
+          "name": "careunit",
+          "description": "Column 'careunit' from transfers.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "careunit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/intime",
+          "name": "intime",
+          "description": "Column 'intime' from transfers.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "intime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "transfers/outtime",
+          "name": "outtime",
+          "description": "Column 'outtime' from transfers.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_11"
+            },
+            "extract": {
+              "column": "outtime"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "emar_detail",
+      "name": "emar_detail",
+      "description": "Records from emar_detail.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from emar_detail.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/emar_id",
+          "name": "emar_id",
+          "description": "Column 'emar_id' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "emar_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/emar_seq",
+          "name": "emar_seq",
+          "description": "Column 'emar_seq' from emar_detail.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "emar_seq"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/parent_field_ordinal",
+          "name": "parent_field_ordinal",
+          "description": "Column 'parent_field_ordinal' from emar_detail.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "parent_field_ordinal"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/administration_type",
+          "name": "administration_type",
+          "description": "Column 'administration_type' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "administration_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/pharmacy_id",
+          "name": "pharmacy_id",
+          "description": "Column 'pharmacy_id' from emar_detail.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "pharmacy_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/barcode_type",
+          "name": "barcode_type",
+          "description": "Column 'barcode_type' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "barcode_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/reason_for_no_barcode",
+          "name": "reason_for_no_barcode",
+          "description": "Column 'reason_for_no_barcode' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "reason_for_no_barcode"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/complete_dose_not_given",
+          "name": "complete_dose_not_given",
+          "description": "Column 'complete_dose_not_given' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "complete_dose_not_given"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/dose_due",
+          "name": "dose_due",
+          "description": "Column 'dose_due' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "dose_due"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/dose_due_unit",
+          "name": "dose_due_unit",
+          "description": "Column 'dose_due_unit' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "dose_due_unit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/dose_given",
+          "name": "dose_given",
+          "description": "Column 'dose_given' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "dose_given"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/dose_given_unit",
+          "name": "dose_given_unit",
+          "description": "Column 'dose_given_unit' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "dose_given_unit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/will_remainder_of_dose_be_given",
+          "name": "will_remainder_of_dose_be_given",
+          "description": "Column 'will_remainder_of_dose_be_given' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "will_remainder_of_dose_be_given"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/product_amount_given",
+          "name": "product_amount_given",
+          "description": "Column 'product_amount_given' from emar_detail.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "product_amount_given"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/product_unit",
+          "name": "product_unit",
+          "description": "Column 'product_unit' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "product_unit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/product_code",
+          "name": "product_code",
+          "description": "Column 'product_code' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "product_code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/product_description",
+          "name": "product_description",
+          "description": "Column 'product_description' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "product_description"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/product_description_other",
+          "name": "product_description_other",
+          "description": "Column 'product_description_other' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "product_description_other"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/prior_infusion_rate",
+          "name": "prior_infusion_rate",
+          "description": "Column 'prior_infusion_rate' from emar_detail.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "prior_infusion_rate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/infusion_rate",
+          "name": "infusion_rate",
+          "description": "Column 'infusion_rate' from emar_detail.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "infusion_rate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/infusion_rate_adjustment",
+          "name": "infusion_rate_adjustment",
+          "description": "Column 'infusion_rate_adjustment' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "infusion_rate_adjustment"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/infusion_rate_adjustment_amount",
+          "name": "infusion_rate_adjustment_amount",
+          "description": "Column 'infusion_rate_adjustment_amount' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "infusion_rate_adjustment_amount"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/infusion_rate_unit",
+          "name": "infusion_rate_unit",
+          "description": "Column 'infusion_rate_unit' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "infusion_rate_unit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/route",
+          "name": "route",
+          "description": "Column 'route' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "route"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/infusion_complete",
+          "name": "infusion_complete",
+          "description": "Column 'infusion_complete' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "infusion_complete"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/completion_interval",
+          "name": "completion_interval",
+          "description": "Column 'completion_interval' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "completion_interval"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/new_iv_bag_hung",
+          "name": "new_iv_bag_hung",
+          "description": "Column 'new_iv_bag_hung' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "new_iv_bag_hung"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/continued_infusion_in_other_location",
+          "name": "continued_infusion_in_other_location",
+          "description": "Column 'continued_infusion_in_other_location' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "continued_infusion_in_other_location"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/restart_interval",
+          "name": "restart_interval",
+          "description": "Column 'restart_interval' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "restart_interval"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/side",
+          "name": "side",
+          "description": "Column 'side' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "side"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/site",
+          "name": "site",
+          "description": "Column 'site' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "site"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/non_formulary_visual_verification",
+          "name": "non_formulary_visual_verification",
+          "description": "Column 'non_formulary_visual_verification' from emar_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_12"
+            },
+            "extract": {
+              "column": "non_formulary_visual_verification"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "prescriptions",
+      "name": "prescriptions",
+      "description": "Records from prescriptions.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/pharmacy_id",
+          "name": "pharmacy_id",
+          "description": "Column 'pharmacy_id' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "pharmacy_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/poe_id",
+          "name": "poe_id",
+          "description": "Column 'poe_id' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/poe_seq",
+          "name": "poe_seq",
+          "description": "Column 'poe_seq' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "poe_seq"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/order_provider_id",
+          "name": "order_provider_id",
+          "description": "Column 'order_provider_id' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "order_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/starttime",
+          "name": "starttime",
+          "description": "Column 'starttime' from prescriptions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "starttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/stoptime",
+          "name": "stoptime",
+          "description": "Column 'stoptime' from prescriptions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "stoptime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/drug_type",
+          "name": "drug_type",
+          "description": "Column 'drug_type' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "drug_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/drug",
+          "name": "drug",
+          "description": "Column 'drug' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "drug"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/formulary_drug_cd",
+          "name": "formulary_drug_cd",
+          "description": "Column 'formulary_drug_cd' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "formulary_drug_cd"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/gsn",
+          "name": "gsn",
+          "description": "Column 'gsn' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "gsn"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/ndc",
+          "name": "ndc",
+          "description": "Column 'ndc' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "ndc"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/prod_strength",
+          "name": "prod_strength",
+          "description": "Column 'prod_strength' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "prod_strength"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/form_rx",
+          "name": "form_rx",
+          "description": "Column 'form_rx' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "form_rx"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/dose_val_rx",
+          "name": "dose_val_rx",
+          "description": "Column 'dose_val_rx' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "dose_val_rx"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/dose_unit_rx",
+          "name": "dose_unit_rx",
+          "description": "Column 'dose_unit_rx' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "dose_unit_rx"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/form_val_disp",
+          "name": "form_val_disp",
+          "description": "Column 'form_val_disp' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "form_val_disp"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/form_unit_disp",
+          "name": "form_unit_disp",
+          "description": "Column 'form_unit_disp' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "form_unit_disp"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/doses_per_24_hrs",
+          "name": "doses_per_24_hrs",
+          "description": "Column 'doses_per_24_hrs' from prescriptions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "doses_per_24_hrs"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "prescriptions/route",
+          "name": "route",
+          "description": "Column 'route' from prescriptions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_13"
+            },
+            "extract": {
+              "column": "route"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "drgcodes",
+      "name": "drgcodes",
+      "description": "Records from drgcodes.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from drgcodes.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from drgcodes.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/drg_type",
+          "name": "drg_type",
+          "description": "Column 'drg_type' from drgcodes.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "drg_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/drg_code",
+          "name": "drg_code",
+          "description": "Column 'drg_code' from drgcodes.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "drg_code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/description",
+          "name": "description",
+          "description": "Column 'description' from drgcodes.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "description"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/drg_severity",
+          "name": "drg_severity",
+          "description": "Column 'drg_severity' from drgcodes.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "drg_severity"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drgcodes/drg_mortality",
+          "name": "drg_mortality",
+          "description": "Column 'drg_mortality' from drgcodes.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_14"
+            },
+            "extract": {
+              "column": "drg_mortality"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "procedures_icd",
+      "name": "procedures_icd",
+      "description": "Records from procedures_icd.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "procedures_icd/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from procedures_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_15"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedures_icd/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from procedures_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_15"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedures_icd/seq_num",
+          "name": "seq_num",
+          "description": "Column 'seq_num' from procedures_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_15"
+            },
+            "extract": {
+              "column": "seq_num"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedures_icd/chartdate",
+          "name": "chartdate",
+          "description": "Column 'chartdate' from procedures_icd.csv.gz",
+          "dataType": "sc:Date",
+          "source": {
+            "fileObject": {
+              "@id": "file_15"
+            },
+            "extract": {
+              "column": "chartdate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedures_icd/icd_code",
+          "name": "icd_code",
+          "description": "Column 'icd_code' from procedures_icd.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_15"
+            },
+            "extract": {
+              "column": "icd_code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedures_icd/icd_version",
+          "name": "icd_version",
+          "description": "Column 'icd_version' from procedures_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_15"
+            },
+            "extract": {
+              "column": "icd_version"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "provider",
+      "name": "provider",
+      "description": "Records from provider.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "provider/provider_id",
+          "name": "provider_id",
+          "description": "Column 'provider_id' from provider.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_16"
+            },
+            "extract": {
+              "column": "provider_id"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "poe_detail",
+      "name": "poe_detail",
+      "description": "Records from poe_detail.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "poe_detail/poe_id",
+          "name": "poe_id",
+          "description": "Column 'poe_id' from poe_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_17"
+            },
+            "extract": {
+              "column": "poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe_detail/poe_seq",
+          "name": "poe_seq",
+          "description": "Column 'poe_seq' from poe_detail.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_17"
+            },
+            "extract": {
+              "column": "poe_seq"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe_detail/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from poe_detail.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_17"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe_detail/field_name",
+          "name": "field_name",
+          "description": "Column 'field_name' from poe_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_17"
+            },
+            "extract": {
+              "column": "field_name"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "poe_detail/field_value",
+          "name": "field_value",
+          "description": "Column 'field_value' from poe_detail.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_17"
+            },
+            "extract": {
+              "column": "field_value"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "labevents",
+      "name": "labevents",
+      "description": "Records from labevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/labevent_id",
+          "name": "labevent_id",
+          "description": "Column 'labevent_id' from labevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "labevent_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from labevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from labevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/specimen_id",
+          "name": "specimen_id",
+          "description": "Column 'specimen_id' from labevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "specimen_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from labevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/order_provider_id",
+          "name": "order_provider_id",
+          "description": "Column 'order_provider_id' from labevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "order_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from labevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from labevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/value",
+          "name": "value",
+          "description": "Column 'value' from labevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/valuenum",
+          "name": "valuenum",
+          "description": "Column 'valuenum' from labevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "valuenum"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/valueuom",
+          "name": "valueuom",
+          "description": "Column 'valueuom' from labevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "valueuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/ref_range_lower",
+          "name": "ref_range_lower",
+          "description": "Column 'ref_range_lower' from labevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "ref_range_lower"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/ref_range_upper",
+          "name": "ref_range_upper",
+          "description": "Column 'ref_range_upper' from labevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "ref_range_upper"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/flag",
+          "name": "flag",
+          "description": "Column 'flag' from labevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "flag"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/priority",
+          "name": "priority",
+          "description": "Column 'priority' from labevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "priority"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/comments",
+          "name": "comments",
+          "description": "Column 'comments' from labevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_18"
+            },
+            "extract": {
+              "column": "comments"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "pharmacy",
+      "name": "pharmacy",
+      "description": "Records from pharmacy.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/pharmacy_id",
+          "name": "pharmacy_id",
+          "description": "Column 'pharmacy_id' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "pharmacy_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/poe_id",
+          "name": "poe_id",
+          "description": "Column 'poe_id' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "poe_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/starttime",
+          "name": "starttime",
+          "description": "Column 'starttime' from pharmacy.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "starttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/stoptime",
+          "name": "stoptime",
+          "description": "Column 'stoptime' from pharmacy.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "stoptime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/medication",
+          "name": "medication",
+          "description": "Column 'medication' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "medication"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/proc_type",
+          "name": "proc_type",
+          "description": "Column 'proc_type' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "proc_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/status",
+          "name": "status",
+          "description": "Column 'status' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "status"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/entertime",
+          "name": "entertime",
+          "description": "Column 'entertime' from pharmacy.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "entertime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/verifiedtime",
+          "name": "verifiedtime",
+          "description": "Column 'verifiedtime' from pharmacy.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "verifiedtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/route",
+          "name": "route",
+          "description": "Column 'route' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "route"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/frequency",
+          "name": "frequency",
+          "description": "Column 'frequency' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "frequency"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/disp_sched",
+          "name": "disp_sched",
+          "description": "Column 'disp_sched' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "disp_sched"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/infusion_type",
+          "name": "infusion_type",
+          "description": "Column 'infusion_type' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "infusion_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/sliding_scale",
+          "name": "sliding_scale",
+          "description": "Column 'sliding_scale' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "sliding_scale"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/lockout_interval",
+          "name": "lockout_interval",
+          "description": "Column 'lockout_interval' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "lockout_interval"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/basal_rate",
+          "name": "basal_rate",
+          "description": "Column 'basal_rate' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "basal_rate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/one_hr_max",
+          "name": "one_hr_max",
+          "description": "Column 'one_hr_max' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "one_hr_max"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/doses_per_24_hrs",
+          "name": "doses_per_24_hrs",
+          "description": "Column 'doses_per_24_hrs' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "doses_per_24_hrs"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/duration",
+          "name": "duration",
+          "description": "Column 'duration' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "duration"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/duration_interval",
+          "name": "duration_interval",
+          "description": "Column 'duration_interval' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "duration_interval"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/expiration_value",
+          "name": "expiration_value",
+          "description": "Column 'expiration_value' from pharmacy.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "expiration_value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/expiration_unit",
+          "name": "expiration_unit",
+          "description": "Column 'expiration_unit' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "expiration_unit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/expirationdate",
+          "name": "expirationdate",
+          "description": "Column 'expirationdate' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "expirationdate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/dispensation",
+          "name": "dispensation",
+          "description": "Column 'dispensation' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "dispensation"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "pharmacy/fill_quantity",
+          "name": "fill_quantity",
+          "description": "Column 'fill_quantity' from pharmacy.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_19"
+            },
+            "extract": {
+              "column": "fill_quantity"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "patients",
+      "name": "patients",
+      "description": "Records from patients.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "patients/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from patients.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_20"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "patients/gender",
+          "name": "gender",
+          "description": "Column 'gender' from patients.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_20"
+            },
+            "extract": {
+              "column": "gender"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "patients/anchor_age",
+          "name": "anchor_age",
+          "description": "Column 'anchor_age' from patients.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_20"
+            },
+            "extract": {
+              "column": "anchor_age"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "patients/anchor_year",
+          "name": "anchor_year",
+          "description": "Column 'anchor_year' from patients.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_20"
+            },
+            "extract": {
+              "column": "anchor_year"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "patients/anchor_year_group",
+          "name": "anchor_year_group",
+          "description": "Column 'anchor_year_group' from patients.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_20"
+            },
+            "extract": {
+              "column": "anchor_year_group"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "patients/dod",
+          "name": "dod",
+          "description": "Column 'dod' from patients.csv.gz",
+          "dataType": "sc:Date",
+          "source": {
+            "fileObject": {
+              "@id": "file_20"
+            },
+            "extract": {
+              "column": "dod"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "admissions",
+      "name": "admissions",
+      "description": "Records from admissions.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from admissions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from admissions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/admittime",
+          "name": "admittime",
+          "description": "Column 'admittime' from admissions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "admittime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/dischtime",
+          "name": "dischtime",
+          "description": "Column 'dischtime' from admissions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "dischtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/deathtime",
+          "name": "deathtime",
+          "description": "Column 'deathtime' from admissions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "deathtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/admission_type",
+          "name": "admission_type",
+          "description": "Column 'admission_type' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "admission_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/admit_provider_id",
+          "name": "admit_provider_id",
+          "description": "Column 'admit_provider_id' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "admit_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/admission_location",
+          "name": "admission_location",
+          "description": "Column 'admission_location' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "admission_location"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/discharge_location",
+          "name": "discharge_location",
+          "description": "Column 'discharge_location' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "discharge_location"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/insurance",
+          "name": "insurance",
+          "description": "Column 'insurance' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "insurance"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/language",
+          "name": "language",
+          "description": "Column 'language' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "language"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/marital_status",
+          "name": "marital_status",
+          "description": "Column 'marital_status' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "marital_status"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/race",
+          "name": "race",
+          "description": "Column 'race' from admissions.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "race"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/edregtime",
+          "name": "edregtime",
+          "description": "Column 'edregtime' from admissions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "edregtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/edouttime",
+          "name": "edouttime",
+          "description": "Column 'edouttime' from admissions.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "edouttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "admissions/hospital_expire_flag",
+          "name": "hospital_expire_flag",
+          "description": "Column 'hospital_expire_flag' from admissions.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_21"
+            },
+            "extract": {
+              "column": "hospital_expire_flag"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "diagnoses_icd",
+      "name": "diagnoses_icd",
+      "description": "Records from diagnoses_icd.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "diagnoses_icd/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from diagnoses_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_22"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "diagnoses_icd/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from diagnoses_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_22"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "diagnoses_icd/seq_num",
+          "name": "seq_num",
+          "description": "Column 'seq_num' from diagnoses_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_22"
+            },
+            "extract": {
+              "column": "seq_num"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "diagnoses_icd/icd_code",
+          "name": "icd_code",
+          "description": "Column 'icd_code' from diagnoses_icd.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_22"
+            },
+            "extract": {
+              "column": "icd_code"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "diagnoses_icd/icd_version",
+          "name": "icd_version",
+          "description": "Column 'icd_version' from diagnoses_icd.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_22"
+            },
+            "extract": {
+              "column": "icd_version"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "inputevents",
+      "name": "inputevents",
+      "description": "Records from inputevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/starttime",
+          "name": "starttime",
+          "description": "Column 'starttime' from inputevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "starttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/endtime",
+          "name": "endtime",
+          "description": "Column 'endtime' from inputevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "endtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from inputevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/amount",
+          "name": "amount",
+          "description": "Column 'amount' from inputevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "amount"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/amountuom",
+          "name": "amountuom",
+          "description": "Column 'amountuom' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "amountuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/rate",
+          "name": "rate",
+          "description": "Column 'rate' from inputevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "rate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/rateuom",
+          "name": "rateuom",
+          "description": "Column 'rateuom' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "rateuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/orderid",
+          "name": "orderid",
+          "description": "Column 'orderid' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "orderid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/linkorderid",
+          "name": "linkorderid",
+          "description": "Column 'linkorderid' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "linkorderid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/ordercategoryname",
+          "name": "ordercategoryname",
+          "description": "Column 'ordercategoryname' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "ordercategoryname"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/secondaryordercategoryname",
+          "name": "secondaryordercategoryname",
+          "description": "Column 'secondaryordercategoryname' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "secondaryordercategoryname"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/ordercomponenttypedescription",
+          "name": "ordercomponenttypedescription",
+          "description": "Column 'ordercomponenttypedescription' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "ordercomponenttypedescription"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/ordercategorydescription",
+          "name": "ordercategorydescription",
+          "description": "Column 'ordercategorydescription' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "ordercategorydescription"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/patientweight",
+          "name": "patientweight",
+          "description": "Column 'patientweight' from inputevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "patientweight"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/totalamount",
+          "name": "totalamount",
+          "description": "Column 'totalamount' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "totalamount"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/totalamountuom",
+          "name": "totalamountuom",
+          "description": "Column 'totalamountuom' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "totalamountuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/isopenbag",
+          "name": "isopenbag",
+          "description": "Column 'isopenbag' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "isopenbag"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/continueinnextdept",
+          "name": "continueinnextdept",
+          "description": "Column 'continueinnextdept' from inputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "continueinnextdept"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/statusdescription",
+          "name": "statusdescription",
+          "description": "Column 'statusdescription' from inputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "statusdescription"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/originalamount",
+          "name": "originalamount",
+          "description": "Column 'originalamount' from inputevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "originalamount"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "inputevents/originalrate",
+          "name": "originalrate",
+          "description": "Column 'originalrate' from inputevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_23"
+            },
+            "extract": {
+              "column": "originalrate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "datetimeevents",
+      "name": "datetimeevents",
+      "description": "Records from datetimeevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from datetimeevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from datetimeevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from datetimeevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from datetimeevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from datetimeevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from datetimeevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from datetimeevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/value",
+          "name": "value",
+          "description": "Column 'value' from datetimeevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/valueuom",
+          "name": "valueuom",
+          "description": "Column 'valueuom' from datetimeevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "valueuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "datetimeevents/warning",
+          "name": "warning",
+          "description": "Column 'warning' from datetimeevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_24"
+            },
+            "extract": {
+              "column": "warning"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "ingredientevents",
+      "name": "ingredientevents",
+      "description": "Records from ingredientevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/starttime",
+          "name": "starttime",
+          "description": "Column 'starttime' from ingredientevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "starttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/endtime",
+          "name": "endtime",
+          "description": "Column 'endtime' from ingredientevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "endtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from ingredientevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/amount",
+          "name": "amount",
+          "description": "Column 'amount' from ingredientevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "amount"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/amountuom",
+          "name": "amountuom",
+          "description": "Column 'amountuom' from ingredientevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "amountuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/rate",
+          "name": "rate",
+          "description": "Column 'rate' from ingredientevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "rate"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/rateuom",
+          "name": "rateuom",
+          "description": "Column 'rateuom' from ingredientevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "rateuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/orderid",
+          "name": "orderid",
+          "description": "Column 'orderid' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "orderid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/linkorderid",
+          "name": "linkorderid",
+          "description": "Column 'linkorderid' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "linkorderid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/statusdescription",
+          "name": "statusdescription",
+          "description": "Column 'statusdescription' from ingredientevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "statusdescription"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/originalamount",
+          "name": "originalamount",
+          "description": "Column 'originalamount' from ingredientevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "originalamount"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "ingredientevents/originalrate",
+          "name": "originalrate",
+          "description": "Column 'originalrate' from ingredientevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_25"
+            },
+            "extract": {
+              "column": "originalrate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "d_items",
+      "name": "d_items",
+      "description": "Records from d_items.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from d_items.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/label",
+          "name": "label",
+          "description": "Column 'label' from d_items.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "label"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/abbreviation",
+          "name": "abbreviation",
+          "description": "Column 'abbreviation' from d_items.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "abbreviation"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/linksto",
+          "name": "linksto",
+          "description": "Column 'linksto' from d_items.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "linksto"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/category",
+          "name": "category",
+          "description": "Column 'category' from d_items.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "category"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/unitname",
+          "name": "unitname",
+          "description": "Column 'unitname' from d_items.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "unitname"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/param_type",
+          "name": "param_type",
+          "description": "Column 'param_type' from d_items.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "param_type"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/lownormalvalue",
+          "name": "lownormalvalue",
+          "description": "Column 'lownormalvalue' from d_items.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "lownormalvalue"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_items/highnormalvalue",
+          "name": "highnormalvalue",
+          "description": "Column 'highnormalvalue' from d_items.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_26"
+            },
+            "extract": {
+              "column": "highnormalvalue"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "chartevents",
+      "name": "chartevents",
+      "description": "Records from chartevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from chartevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from chartevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from chartevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from chartevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from chartevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from chartevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from chartevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/value",
+          "name": "value",
+          "description": "Column 'value' from chartevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/valuenum",
+          "name": "valuenum",
+          "description": "Column 'valuenum' from chartevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "valuenum"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/valueuom",
+          "name": "valueuom",
+          "description": "Column 'valueuom' from chartevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "valueuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "chartevents/warning",
+          "name": "warning",
+          "description": "Column 'warning' from chartevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_27"
+            },
+            "extract": {
+              "column": "warning"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "procedureevents",
+      "name": "procedureevents",
+      "description": "Records from procedureevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/starttime",
+          "name": "starttime",
+          "description": "Column 'starttime' from procedureevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "starttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/endtime",
+          "name": "endtime",
+          "description": "Column 'endtime' from procedureevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "endtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from procedureevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/value",
+          "name": "value",
+          "description": "Column 'value' from procedureevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/valueuom",
+          "name": "valueuom",
+          "description": "Column 'valueuom' from procedureevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "valueuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/location",
+          "name": "location",
+          "description": "Column 'location' from procedureevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "location"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/locationcategory",
+          "name": "locationcategory",
+          "description": "Column 'locationcategory' from procedureevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "locationcategory"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/orderid",
+          "name": "orderid",
+          "description": "Column 'orderid' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "orderid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/linkorderid",
+          "name": "linkorderid",
+          "description": "Column 'linkorderid' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "linkorderid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/ordercategoryname",
+          "name": "ordercategoryname",
+          "description": "Column 'ordercategoryname' from procedureevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "ordercategoryname"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/ordercategorydescription",
+          "name": "ordercategorydescription",
+          "description": "Column 'ordercategorydescription' from procedureevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "ordercategorydescription"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/patientweight",
+          "name": "patientweight",
+          "description": "Column 'patientweight' from procedureevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "patientweight"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/isopenbag",
+          "name": "isopenbag",
+          "description": "Column 'isopenbag' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "isopenbag"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/continueinnextdept",
+          "name": "continueinnextdept",
+          "description": "Column 'continueinnextdept' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "continueinnextdept"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/statusdescription",
+          "name": "statusdescription",
+          "description": "Column 'statusdescription' from procedureevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "statusdescription"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/ORIGINALAMOUNT",
+          "name": "ORIGINALAMOUNT",
+          "description": "Column 'ORIGINALAMOUNT' from procedureevents.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "ORIGINALAMOUNT"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "procedureevents/ORIGINALRATE",
+          "name": "ORIGINALRATE",
+          "description": "Column 'ORIGINALRATE' from procedureevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_28"
+            },
+            "extract": {
+              "column": "ORIGINALRATE"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "outputevents",
+      "name": "outputevents",
+      "description": "Records from outputevents.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from outputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from outputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from outputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from outputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from outputevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from outputevents.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from outputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/value",
+          "name": "value",
+          "description": "Column 'value' from outputevents.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "outputevents/valueuom",
+          "name": "valueuom",
+          "description": "Column 'valueuom' from outputevents.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_29"
+            },
+            "extract": {
+              "column": "valueuom"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "icustays",
+      "name": "icustays",
+      "description": "Records from icustays.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from icustays.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from icustays.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/stay_id",
+          "name": "stay_id",
+          "description": "Column 'stay_id' from icustays.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "stay_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/first_careunit",
+          "name": "first_careunit",
+          "description": "Column 'first_careunit' from icustays.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "first_careunit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/last_careunit",
+          "name": "last_careunit",
+          "description": "Column 'last_careunit' from icustays.csv.gz",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "last_careunit"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/intime",
+          "name": "intime",
+          "description": "Column 'intime' from icustays.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "intime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/outtime",
+          "name": "outtime",
+          "description": "Column 'outtime' from icustays.csv.gz",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "outtime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "icustays/los",
+          "name": "los",
+          "description": "Column 'los' from icustays.csv.gz",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_30"
+            },
+            "extract": {
+              "column": "los"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "caregiver",
+      "name": "caregiver",
+      "description": "Records from caregiver.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "caregiver/caregiver_id",
+          "name": "caregiver_id",
+          "description": "Column 'caregiver_id' from caregiver.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_31"
+            },
+            "extract": {
+              "column": "caregiver_id"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "rai:dataLimitations": "Data originates from a single academic medical centre in the northeastern United States. Findings may not generalise to other hospital systems, countries, or patient demographics. Not intended for direct clinical decision-making.",
+  "rai:dataBias": "The patient population skews toward English-speaking adults; paediatric and non-English-speaking patients are under-represented.",
+  "rai:personalSensitiveInformation": "The dataset contains de-identified patient health records. Re-identification risk has been minimised via HIPAA Safe Harbor procedures. Access is restricted to credentialed researchers who have signed a data use agreement.",
+  "rai:dataUseCases": "Benchmarking clinical natural language processing and machine learning models. Supporting research into hospital readmission, mortality prediction, and clinical decision support. Not intended for direct clinical decision-making.",
+  "rai:socialImpact": "This dataset enables research that could improve clinical AI tools and patient outcomes. However, models trained on biased data risk perpetuating health disparities if deployed without careful evaluation.",
+  "rai:hasSyntheticData": false,
+  "prov:wasDerivedFrom": [
+    {
+      "url": "https://physionet.org/content/mimiciii/",
+      "name": "MIMIC-III",
+      "prov:wasAssociatedWith": {
+        "@type": "prov:Organization",
+        "name": "PhysioNet"
+      }
+    }
+  ],
+  "prov:wasGeneratedBy": [
+    {
+      "@type": "prov:Activity",
+      "@id": "ACT-001",
+      "prov:label": "Data Collection",
+      "prov:type": "Data Collection",
+      "prov:description": "Retrospective electronic health records collected during routine clinical care at Beth Israel Deaconess Medical Center.",
+      "prov:startedAtTime": "2011-01-01",
+      "prov:endedAtTime": "2019-12-31",
+      "prov:wasAssociatedWith": {
+        "@type": "prov:Agent",
+        "name": "Beth Israel Deaconess Medical Center Clinical Team",
+        "url": "https://www.bidmc.org"
+      }
+    },
+    {
+      "@type": "prov:Activity",
+      "@id": "ACT-002",
+      "prov:label": "Data Preprocessing",
+      "prov:type": "Data Preprocessing",
+      "prov:description": "Patient identifiers were removed using the HIPAA Safe Harbor method. Dates were shifted by a random per-patient offset (up to 365 days) while preserving relative temporal relationships. Free-text fields were scrubbed with a custom NER-based de-identification model.",
+      "prov:wasAssociatedWith": {
+        "@type": "prov:SoftwareAgent",
+        "name": "PhysioNet de-identification and curation pipeline",
+        "url": "https://physionet.org",
+        "prov:description": "Automated pipeline combining rule-based Safe Harbor de-identification with a trained NER model for free-text scrubbing."
+      }
+    }
+  ]
+}

--- a/tests/test_rai.py
+++ b/tests/test_rai.py
@@ -1,0 +1,95 @@
+"""Integration test for the RAI metadata extension."""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from croissant_baker.__main__ import app
+
+runner = CliRunner()
+
+_DATA = Path(__file__).parent / "data"
+RAI_YAML = (
+    _DATA / "input" / "mimiciv_demo" / "physionet.org" / "mimiciv_demo-rai-example.yaml"
+)
+EXPECTED = _DATA / "output" / "mimiciv_demo_croissant_rai.jsonld"
+MIMICIV_PATH = (
+    _DATA
+    / "input"
+    / "mimiciv_demo"
+    / "physionet.org"
+    / "files"
+    / "mimic-iv-demo"
+    / "2.2"
+)
+
+_RAI_PROV_KEYS = [
+    "prov:wasGeneratedBy",
+    "rai:dataLimitations",
+    "rai:dataBias",
+    "rai:personalSensitiveInformation",
+    "rai:dataUseCases",
+    "rai:socialImpact",
+    "prov:wasDerivedFrom",
+]
+
+
+@pytest.fixture
+def mimiciv_demo_path() -> Path:
+    if not MIMICIV_PATH.exists():
+        pytest.skip(f"MIMIC-IV demo dataset not found at {MIMICIV_PATH}")
+    return MIMICIV_PATH
+
+
+def test_rai_generation_matches_reference(
+    mimiciv_demo_path: Path, tmp_path: Path
+) -> None:
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "-i",
+            str(mimiciv_demo_path),
+            "-o",
+            str(output),
+            "--name",
+            "MIMIC-IV Demo Dataset",
+            "--description",
+            "Demo subset of MIMIC-IV, a freely accessible electronic health record dataset from Beth Israel Deaconess Medical Center (2008-2019)",
+            "--url",
+            "https://physionet.org/content/mimic-iv-demo/",
+            "--license",
+            "PhysioNet Restricted Health Data License 1.5.0",
+            "--dataset-version",
+            "2.2",
+            "--date-published",
+            "2023-01-06",
+            "--creator",
+            "Alistair Johnson,aewj@mit.edu,https://physionet.org/",
+            "--creator",
+            "Lucas Bulgarelli,,https://mit.edu/",
+            "--creator",
+            "Tom Pollard,tpollard@mit.edu,https://physionet.org/",
+            "--creator",
+            "Steven Horng,,https://www.bidmc.org/",
+            "--creator",
+            "Leo Anthony Celi,lceli@mit.edu,https://lcp.mit.edu/",
+            "--creator",
+            "Roger Mark,,https://lcp.mit.edu/",
+            "--citation",
+            "Johnson, A., Bulgarelli, L., Pollard, T., Horng, S., Celi, L. A., & Mark, R. (2023). MIMIC-IV (version 2.2). PhysioNet. https://doi.org/10.13026/6mm1-ek67",
+            "--no-validate",
+            "--rai-config",
+            str(RAI_YAML),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    generated = json.loads(output.read_text())
+    expected = json.loads(EXPECTED.read_text())
+
+    for key in _RAI_PROV_KEYS:
+        assert generated.get(key) == expected.get(key), f"Mismatch for {key}"


### PR DESCRIPTION
## Add RAI metadata extension with PROV-O provenance support

This PR aims to initiate discussion on how we can add Croissant RAI metadata support to croissant-maker and, more broadly, to the set of tools in this ecosystem (such as the editor). Let me know what you think!

### Motivation

RAI metadata presents a unique challenge compared to the rest of the Croissant spec:

- Most attributes live at the dataset level and cannot be automatically extrapolated from the data structure — fields like `rai:SocialImpact` or `rai:Biases` require deliberate authorship.
- Many natural-language attributes require critical thinking by dataset authors; some of the seed works the RAI spec is inspired by reflect this human judgement.
- Newer mechanisms, such as PROV-O provenance, allow us to organise this information in a more machine-readable way — and tools should support it. Note that the last published release of `mlcroissant` (1.0.22) does not yet include PROV-O support; this feature requires installing from the latest commit.

### Approach

This PR addresses the above by proposing a **YAML interface** that lets authors create their RAI annotations in a human-friendly format, while croissant-maker handles the translation into spec-compliant, machine-actionable Croissant JSON-LD.

To faciliatate the user's journey, a teamplate is provided at the root of the project (please, change it at your desire), and an example is proposed at _tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml_

###  How to use it
When generating a new Croissant file, pass --rai-config:

```bash
croissant-maker --input ./my-dataset --creator "Name" --rai-config rai.yaml
```

When enriching an existing Croissant file, use the new rai-apply subcommand:

```bash
croissant-maker rai-apply dataset.jsonld --rai-config rai.yaml
```

 or write to a separate file:

```bash
croissant-maker rai-apply dataset.jsonld --rai-config rai.yaml --output dataset-rai.jsonld
```

### Examples and templates

- `rai-example.yaml` — fully documented template with every supported field and inline comments explaining the RAI/PROV-O mapping
- `tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml` — real-world example using the MIMIC-IV demo dataset
- `tests/data/output/mimiciv_demo_croissant_rai.jsonld` — reference output showing the resulting Croissant JSON-LD

### Changes

- `src/croissant_maker/rai/` — new module with schema (Pydantic models), YAML loader, and injector
- `src/croissant_maker/__main__.py` — adds `--rai-config` flag to the generate command and the `rai-apply` subcommand
- `tests/test_rai.py` — integration test that runs the full pipeline against the MIMIC-IV demo and validates output against the reference file


### Broader discussion

- The YAML interface is intentionally designed as a decoupled layer: if other tools — such as form-based editors, Croissant Miner outputs, or a future web-based form — can produce this YAML, then croissant-maker can act as the backend that maps it to the spec in the correct form. This opens a few paths worth discussing:
- Form-based tools: a web form (conversations on this are ongoing) could allow users to fill in RAI fields interactively, exporting a YAML that croissant-maker then processes.
- Croissant Miner integration: if Miner can emit a partial YAML from what it can infer, authors only need to fill in the fields that require human judgement.
- Editor integration: the rai-apply subcommand means RAI metadata can be added to an existing Croissant file without regenerating it, which suits an editor workflow naturally.
