### PR TITLE
feat: warn on missing Croissant spec-required fields and clarify dev …

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ This project uses [uv](https://docs.astral.sh/uv/) for environment and dependenc
 
 ## Usage
 
-After installation, you can use the `croissant-maker` CLI:
+After `uv sync`, run the CLI directly by activating the venv first, or prefix with `uv run`:
 
 ```bash
+source .venv/bin/activate   # once per terminal session — then just use `croissant-maker` directly
+# or without activating:
 uv run croissant-maker --help
 ```
 
 ### Generate Croissant Metadata
 
 ```bash
-uv run croissant-maker --input /path/to/dataset --creator "Your Name" --output my-metadata.jsonld
+croissant-maker --input /path/to/dataset --creator "Your Name" --output my-metadata.jsonld
 ```
 
 ### Metadata Override Options
@@ -44,7 +46,7 @@ uv run croissant-maker --input /path/to/dataset --creator "Your Name" --output m
 You can override default metadata fields:
 
 ```bash
-uv run croissant-maker --input /path/to/dataset \
+croissant-maker --input /path/to/dataset \
   --name "My Dataset" \
   --description "A machine learning dataset" \
   --creator "John Doe,john@example.com,https://john.com" \
@@ -73,7 +75,7 @@ uv run croissant-maker --input /path/to/dataset \
 Validation checks that the file can be loaded by `mlcroissant` and conforms to the basic structure of the specification.
 
 ```bash
-uv run croissant-maker validate my-metadata.jsonld
+croissant-maker validate my-metadata.jsonld
 ```
 
 ## Testing

--- a/src/croissant_maker/__main__.py
+++ b/src/croissant_maker/__main__.py
@@ -32,6 +32,32 @@ def _get_default_output_name(input_path: str) -> str:
     return f"{dataset_name}-croissant.jsonld"
 
 
+# Croissant spec: these CLI flags map to fields that *must* be specified for every dataset.
+# https://docs.mlcommons.org/croissant/docs/croissant-spec.html
+# The tool generates defaults for all of them, but warns when user hasn't explicitly set them.
+_SPEC_REQUIRED_FLAGS = {
+    "creator": "--creator",
+    "description": "--description",
+    "url": "--url",
+    "license": "--license",
+    "date_published": "--date-published",
+}
+
+
+def _warn_missing_spec_fields(**provided: object) -> None:
+    """Warn about spec-required fields that were not explicitly provided."""
+    missing = [
+        flag for key, flag in _SPEC_REQUIRED_FLAGS.items() if not provided.get(key)
+    ]
+    if missing:
+        typer.echo(
+            f"\nWarning: {', '.join(missing)} are required by the Croissant spec but were not provided.\n"
+            "  The tool used defaults — review them before publishing.\n"
+            "  See: https://docs.mlcommons.org/croissant/docs/croissant-spec.html",
+            err=True,
+        )
+
+
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
@@ -216,6 +242,14 @@ def main(
             typer.echo(
                 f"Tip: Run `croissant-maker validate {output}` to validate later"
             )
+
+        _warn_missing_spec_fields(
+            creator=creator,
+            description=description,
+            url=url,
+            license=license,
+            date_published=date_published,
+        )
 
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,6 +158,61 @@ def test_invalid_date_format(csv_dataset: Path, tmp_path: Path) -> None:
     assert "Expected ISO format like '2023-12-15'" in result.stderr
 
 
+def test_spec_warnings_when_fields_missing(csv_dataset: Path, tmp_path: Path) -> None:
+    """Test that missing spec-required fields produce a warning on stderr."""
+    output = tmp_path / "output.jsonld"
+
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Alice Smith",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Warning:" in result.stderr
+    assert "--description" in result.stderr
+    assert "--url" in result.stderr
+    assert "--license" in result.stderr
+    assert "--date-published" in result.stderr
+    assert "--creator" not in result.stderr  # was provided, should not appear
+
+
+def test_no_spec_warnings_when_all_fields_provided(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """Test that no warning appears when all spec-required fields are explicitly provided."""
+    output = tmp_path / "output.jsonld"
+
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Alice Smith",
+            "--description",
+            "A test dataset",
+            "--url",
+            "https://example.com",
+            "--license",
+            "MIT",
+            "--date-published",
+            "2024-01-01",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Warning:" not in result.stderr
+
+
 def test_help_and_version() -> None:
     """Test help and version commands."""
     # Help


### PR DESCRIPTION
## Summary                                                                                                                                                                                            
                                                                                                                                                                                                        
  - Adds a warning after successful generation listing any Croissant spec-required flags (`--creator`, `--description`, `--url`, `--license`, `--date-published`) that were not explicitly provided,    
  with a link to the spec. The tool still generates defaults for all of them — the warning prompts review before publishing.                                                                            
  - Updates README Usage section to show `croissant-maker` directly (post-activation) alongside `uv run` as the dev alternative, so the commands match what end users will see after PyPI install.      
                                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                                          
              
  - [X] All existing tests pass                                                                                                                                                                      
  - [X] Warning appears on stderr after generation when spec fields are omitted                                                                                                                       
  - [X] Warning correctly omits fields that were explicitly provided           
  - [X] README usage examples are accurate    