### PR TITLE
Add minimal working example to README in response to #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,23 @@ source .venv/bin/activate   # once per terminal session — then just use `crois
 uv run croissant-maker --help
 ```
 
+### Quick start
+
+Try it out on one of the bundled test datasets:
+
+```bash
+croissant-maker --input tests/data/input/mimiciv_demo_meds --creator "Jane Doe" --output example-metadata.jsonld
+```
+
+This scans the dataset, extracts metadata from the Parquet files it finds, and writes a Croissant JSON-LD file to `example-metadata.jsonld`. You can inspect the result or validate it:
+
+```bash
+croissant-maker validate example-metadata.jsonld
+```
+
 ### Generate Croissant Metadata
+
+Point the tool at your own dataset directory:
 
 ```bash
 croissant-maker --input /path/to/dataset --creator "Your Name" --output my-metadata.jsonld


### PR DESCRIPTION
As noted in https://github.com/MIT-LCP/croissant-maker/issues/44, at the moment we don't provide a minimal working example in the README for first-time users. In response, this pull request adds the following example:

```
# Make Croissant
croissant-maker --input tests/data/input/mimiciv_demo_meds --creator "Jane Doe" --output example-metadata.jsonld

# Prints:
# ❯ croissant-maker --input tests/data/input/mimiciv_demo_meds --creator "Jane Doe" --output example-metadata.jsonld
# ⠙ Validation completed!
# Success! Generated validated Croissant metadata
# Files: 5
# Record sets: 5
# Saved to: example-metadata.jsonld

# Warning: --description, --url, --license, --date-published are required by the Croissant spec but were not provided.
#   The tool used defaults — review them before publishing.
#   See: https://docs.mlcommons.org/croissant/docs/croissant-spec.html
```

```
# Validate Croissant
croissant-maker validate example-metadata.jsonld

# Prints:
# ❯ croissant-maker validate example-metadata.jsonld
# Validating: example-metadata.jsonld
# Valid! Croissant file passed validation
# Dataset: mimiciv_demo_meds
# Description: Dataset containing 5 files (application/x-parquet) with automatically inferred types and structure
# Files: 5
# Record sets: 5
```

