### PR TITLE
fix: close ParquetFile handle to prevent resource leak (#54)

### DIFF
--- a/src/croissant_maker/handlers/parquet_handler.py
+++ b/src/croissant_maker/handlers/parquet_handler.py
@@ -30,13 +30,13 @@ class ParquetHandler(FileTypeHandler):
             raise FileNotFoundError(f"Parquet file not found: {file_path}")
 
         try:
-            pq = ParquetFile(str(file_path))
-            schema = pq.schema_arrow
-            num_rows = pq.metadata.num_rows if pq.metadata is not None else 0
+            with ParquetFile(str(file_path)) as pq:
+                schema = pq.schema_arrow
+                num_rows = pq.metadata.num_rows if pq.metadata is not None else 0
 
-            # Use the shared Arrow type mapper (same as CSV handler)
-            column_types = infer_column_types_from_arrow_schema(schema)
-            columns = [field.name for field in schema]
+                # Use the shared Arrow type mapper (same as CSV handler)
+                column_types = infer_column_types_from_arrow_schema(schema)
+                columns = [field.name for field in schema]
 
             file_size = file_path.stat().st_size
             sha256_hash = compute_file_hash(file_path)

--- a/tests/test_parquet_handler.py
+++ b/tests/test_parquet_handler.py
@@ -1,0 +1,109 @@
+"""Tests for Parquet handler."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from croissant_maker.handlers.parquet_handler import ParquetHandler
+
+
+@pytest.fixture
+def handler() -> ParquetHandler:
+    return ParquetHandler()
+
+
+@pytest.fixture
+def sample_parquet(tmp_path: Path) -> Path:
+    """Create a minimal Parquet file for testing."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "name": pa.array(["Alice", "Bob", "Charlie"], type=pa.string()),
+            "score": pa.array([9.5, 8.3, 7.1], type=pa.float64()),
+        }
+    )
+    path = tmp_path / "test.parquet"
+    pq.write_table(table, str(path))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# can_handle
+# ---------------------------------------------------------------------------
+
+
+def test_can_handle_parquet(handler: ParquetHandler) -> None:
+    """Test Parquet handler file type detection."""
+    assert handler.can_handle(Path("data.parquet"))
+    assert handler.can_handle(Path("data.PARQUET"))
+    assert not handler.can_handle(Path("data.csv"))
+    assert not handler.can_handle(Path("data.txt"))
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_extract_metadata(handler: ParquetHandler, sample_parquet: Path) -> None:
+    """Test Parquet metadata extraction returns correct structure."""
+    metadata = handler.extract_metadata(sample_parquet)
+
+    assert metadata["file_name"] == "test.parquet"
+    assert metadata["encoding_format"] == "application/vnd.apache.parquet"
+    assert metadata["file_size"] > 0
+    assert len(metadata["sha256"]) == 64
+    assert metadata["num_rows"] == 3
+    assert metadata["num_columns"] == 3
+    assert metadata["columns"] == ["id", "name", "score"]
+
+    column_types = metadata["column_types"]
+    assert column_types["id"] == "cr:Int64"
+    assert column_types["name"] == "sc:Text"
+    assert column_types["score"] == "cr:Float64"
+
+
+# ---------------------------------------------------------------------------
+# Resource leak: file handle must be closed after extract_metadata (#54)
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_file_handle_closed(
+    handler: ParquetHandler, sample_parquet: Path
+) -> None:
+    """Verify the underlying file handle is closed after metadata extraction.
+
+    Regression test for GitHub issue #54: ParquetFile was opened without a
+    context manager, leaking file descriptors until garbage collection.
+    """
+    captured_handles: list[pq.ParquetFile] = []
+    _OrigParquetFile = pq.ParquetFile
+
+    def _spy(*args, **kwargs):
+        pf = _OrigParquetFile(*args, **kwargs)
+        captured_handles.append(pf)
+        return pf
+
+    with patch(
+        "croissant_maker.handlers.parquet_handler.ParquetFile", side_effect=_spy
+    ):
+        handler.extract_metadata(sample_parquet)
+
+    assert len(captured_handles) == 1, "ParquetFile should be opened exactly once"
+    assert captured_handles[0].reader.closed, (
+        "ParquetFile reader must be closed after extract_metadata returns"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_extract_metadata_not_found(handler: ParquetHandler) -> None:
+    """Test that missing file raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        handler.extract_metadata(Path("/nonexistent/data.parquet"))


### PR DESCRIPTION
## Summary

- Wrap `ParquetFile` in a context manager (`with` statement) in
  `parquet_handler.py` so the underlying file descriptor is
  deterministically closed after schema and row-count extraction,
  instead of relying on garbage collection.
- Add `tests/test_parquet_handler.py` with unit tests for the handler,
  including a regression test that verifies the file handle is closed
  after `extract_metadata` returns.

Closes #54

## Test plan

- [x] All 57 tests pass (`uv run pytest -v`)
- [x] All pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [x] Manually tested against real MEDS Parquet data
- [x] Regression test fails on old code, passes on fix