### PR TITLE
Fix JSON-LD @id collisions between Field and Source nodes

### DIFF
--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -55,7 +55,6 @@ def _build_fields(
         inner_type = arrow_type.value_type if is_array else arrow_type
 
         source = mlc.Source(
-            id=f"{field_id}/source",
             extract=mlc.Extract(column=col_path),
             **source_ref,
         )
@@ -405,7 +404,6 @@ class MetadataGenerator:
                                 description=f"Column '{col_name}' from {file_meta['file_name']}",
                                 data_types=[col_type],
                                 source=mlc.Source(
-                                    id=f"{field_id}/source",
                                     file_object=file_id,
                                     extract=mlc.Extract(column=col_name),
                                 ),
@@ -433,7 +431,6 @@ class MetadataGenerator:
                         description=f"Signal '{signal_name}' from {file_meta['record_name']}",
                         data_types=[signal_type],
                         source=mlc.Source(
-                            id=f"{file_id}_source_{safe_name}",
                             file_object=file_id,
                         ),
                     )
@@ -511,7 +508,6 @@ class MetadataGenerator:
                     description=f"Image content ({summary['num_images']} files, {formats_str})",
                     data_types=["sc:ImageObject"],
                     source=mlc.Source(
-                        id="images/image_content/source",
                         file_set=fileset_id,
                         extract=mlc.Extract(file_property="content"),
                     ),
@@ -568,7 +564,6 @@ class MetadataGenerator:
                             description=f"Column '{col_name}' from table '{table_name}'",
                             data_types=[col_type],
                             source=mlc.Source(
-                                id=f"{field_id}/source",
                                 file_set=fileset_id,
                                 extract=mlc.Extract(column=col_name),
                             ),

--- a/tests/data/output/eicu_demo_croissant.jsonld
+++ b/tests/data/output/eicu_demo_croissant.jsonld
@@ -367,7 +367,6 @@
           "description": "Column 'diagnosisid' from diagnosis.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnosis/diagnosisid/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -383,7 +382,6 @@
           "description": "Column 'patientunitstayid' from diagnosis.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnosis/patientunitstayid/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -399,7 +397,6 @@
           "description": "Column 'activeupondischarge' from diagnosis.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "diagnosis/activeupondischarge/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -415,7 +412,6 @@
           "description": "Column 'diagnosisoffset' from diagnosis.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnosis/diagnosisoffset/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -431,7 +427,6 @@
           "description": "Column 'diagnosisstring' from diagnosis.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "diagnosis/diagnosisstring/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -447,7 +442,6 @@
           "description": "Column 'icd9code' from diagnosis.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "diagnosis/icd9code/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -463,7 +457,6 @@
           "description": "Column 'diagnosispriority' from diagnosis.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "diagnosis/diagnosispriority/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -487,7 +480,6 @@
           "description": "Column 'vitalaperiodicid' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/vitalaperiodicid/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -503,7 +495,6 @@
           "description": "Column 'patientunitstayid' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/patientunitstayid/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -519,7 +510,6 @@
           "description": "Column 'observationoffset' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/observationoffset/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -535,7 +525,6 @@
           "description": "Column 'noninvasivesystolic' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/noninvasivesystolic/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -551,7 +540,6 @@
           "description": "Column 'noninvasivediastolic' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/noninvasivediastolic/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -567,7 +555,6 @@
           "description": "Column 'noninvasivemean' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/noninvasivemean/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -583,7 +570,6 @@
           "description": "Column 'paop' from vitalAperiodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalAperiodic/paop/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -599,7 +585,6 @@
           "description": "Column 'cardiacoutput' from vitalAperiodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalAperiodic/cardiacoutput/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -615,7 +600,6 @@
           "description": "Column 'cardiacinput' from vitalAperiodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalAperiodic/cardiacinput/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -631,7 +615,6 @@
           "description": "Column 'svr' from vitalAperiodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalAperiodic/svr/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -647,7 +630,6 @@
           "description": "Column 'svri' from vitalAperiodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalAperiodic/svri/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -663,7 +645,6 @@
           "description": "Column 'pvr' from vitalAperiodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalAperiodic/pvr/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -679,7 +660,6 @@
           "description": "Column 'pvri' from vitalAperiodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalAperiodic/pvri/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -703,7 +683,6 @@
           "description": "Column 'admissiondxid' from admissionDx.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissionDx/admissiondxid/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -719,7 +698,6 @@
           "description": "Column 'patientunitstayid' from admissionDx.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissionDx/patientunitstayid/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -735,7 +713,6 @@
           "description": "Column 'admitdxenteredoffset' from admissionDx.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissionDx/admitdxenteredoffset/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -751,7 +728,6 @@
           "description": "Column 'admitdxpath' from admissionDx.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissionDx/admitdxpath/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -767,7 +743,6 @@
           "description": "Column 'admitdxname' from admissionDx.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissionDx/admitdxname/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -783,7 +758,6 @@
           "description": "Column 'admitdxtext' from admissionDx.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissionDx/admitdxtext/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -807,7 +781,6 @@
           "description": "Column 'respcareid' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/respcareid/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -823,7 +796,6 @@
           "description": "Column 'patientunitstayid' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/patientunitstayid/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -839,7 +811,6 @@
           "description": "Column 'respcarestatusoffset' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/respcarestatusoffset/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -855,7 +826,6 @@
           "description": "Column 'currenthistoryseqnum' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/currenthistoryseqnum/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -871,7 +841,6 @@
           "description": "Column 'airwaytype' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/airwaytype/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -887,7 +856,6 @@
           "description": "Column 'airwaysize' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/airwaysize/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -903,7 +871,6 @@
           "description": "Column 'airwayposition' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/airwayposition/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -919,7 +886,6 @@
           "description": "Column 'cuffpressure' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/cuffpressure/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -935,7 +901,6 @@
           "description": "Column 'ventstartoffset' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/ventstartoffset/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -951,7 +916,6 @@
           "description": "Column 'ventendoffset' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/ventendoffset/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -967,7 +931,6 @@
           "description": "Column 'priorventstartoffset' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/priorventstartoffset/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -983,7 +946,6 @@
           "description": "Column 'priorventendoffset' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/priorventendoffset/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -999,7 +961,6 @@
           "description": "Column 'apneaparams' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/apneaparams/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1015,7 +976,6 @@
           "description": "Column 'lowexhmvlimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/lowexhmvlimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1031,7 +991,6 @@
           "description": "Column 'hiexhmvlimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/hiexhmvlimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1047,7 +1006,6 @@
           "description": "Column 'lowexhtvlimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/lowexhtvlimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1063,7 +1021,6 @@
           "description": "Column 'hipeakpreslimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/hipeakpreslimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1079,7 +1036,6 @@
           "description": "Column 'lowpeakpreslimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/lowpeakpreslimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1095,7 +1051,6 @@
           "description": "Column 'hirespratelimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/hirespratelimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1111,7 +1066,6 @@
           "description": "Column 'lowrespratelimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/lowrespratelimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1127,7 +1081,6 @@
           "description": "Column 'sighpreslimit' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/sighpreslimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1143,7 +1096,6 @@
           "description": "Column 'lowironoxlimit' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/lowironoxlimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1159,7 +1111,6 @@
           "description": "Column 'highironoxlimit' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/highironoxlimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1175,7 +1126,6 @@
           "description": "Column 'meanairwaypreslimit' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/meanairwaypreslimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1191,7 +1141,6 @@
           "description": "Column 'peeplimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/peeplimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1207,7 +1156,6 @@
           "description": "Column 'cpaplimit' from respiratoryCare.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "respiratoryCare/cpaplimit/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1223,7 +1171,6 @@
           "description": "Column 'setapneainterval' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapneainterval/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1239,7 +1186,6 @@
           "description": "Column 'setapneatv' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapneatv/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1255,7 +1201,6 @@
           "description": "Column 'setapneaippeephigh' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapneaippeephigh/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1271,7 +1216,6 @@
           "description": "Column 'setapnearr' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapnearr/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1287,7 +1231,6 @@
           "description": "Column 'setapneapeakflow' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapneapeakflow/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1303,7 +1246,6 @@
           "description": "Column 'setapneainsptime' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapneainsptime/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1319,7 +1261,6 @@
           "description": "Column 'setapneaie' from respiratoryCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCare/setapneaie/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1335,7 +1276,6 @@
           "description": "Column 'setapneafio2' from respiratoryCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCare/setapneafio2/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1359,7 +1299,6 @@
           "description": "Column 'nurseassessid' from nurseAssessment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseAssessment/nurseassessid/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1375,7 +1314,6 @@
           "description": "Column 'patientunitstayid' from nurseAssessment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseAssessment/patientunitstayid/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1391,7 +1329,6 @@
           "description": "Column 'nurseassessoffset' from nurseAssessment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseAssessment/nurseassessoffset/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1407,7 +1344,6 @@
           "description": "Column 'nurseassessentryoffset' from nurseAssessment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseAssessment/nurseassessentryoffset/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1423,7 +1359,6 @@
           "description": "Column 'cellattributepath' from nurseAssessment.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseAssessment/cellattributepath/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1439,7 +1374,6 @@
           "description": "Column 'celllabel' from nurseAssessment.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseAssessment/celllabel/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1455,7 +1389,6 @@
           "description": "Column 'cellattribute' from nurseAssessment.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseAssessment/cellattribute/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1471,7 +1404,6 @@
           "description": "Column 'cellattributevalue' from nurseAssessment.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseAssessment/cellattributevalue/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1495,7 +1427,6 @@
           "description": "Column 'hospitalid' from hospital.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "hospital/hospitalid/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1511,7 +1442,6 @@
           "description": "Column 'numbedscategory' from hospital.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "hospital/numbedscategory/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1527,7 +1457,6 @@
           "description": "Column 'teachingstatus' from hospital.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "hospital/teachingstatus/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1543,7 +1472,6 @@
           "description": "Column 'region' from hospital.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "hospital/region/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1567,7 +1495,6 @@
           "description": "Column 'vitalperiodicid' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/vitalperiodicid/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1583,7 +1510,6 @@
           "description": "Column 'patientunitstayid' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/patientunitstayid/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1599,7 +1525,6 @@
           "description": "Column 'observationoffset' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/observationoffset/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1615,7 +1540,6 @@
           "description": "Column 'temperature' from vitalPeriodic.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "vitalPeriodic/temperature/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1631,7 +1555,6 @@
           "description": "Column 'sao2' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/sao2/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1647,7 +1570,6 @@
           "description": "Column 'heartrate' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/heartrate/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1663,7 +1585,6 @@
           "description": "Column 'respiration' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/respiration/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1679,7 +1600,6 @@
           "description": "Column 'cvp' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/cvp/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1695,7 +1615,6 @@
           "description": "Column 'etco2' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/etco2/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1711,7 +1630,6 @@
           "description": "Column 'systemicsystolic' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/systemicsystolic/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1727,7 +1645,6 @@
           "description": "Column 'systemicdiastolic' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/systemicdiastolic/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1743,7 +1660,6 @@
           "description": "Column 'systemicmean' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/systemicmean/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1759,7 +1675,6 @@
           "description": "Column 'pasystolic' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/pasystolic/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1775,7 +1690,6 @@
           "description": "Column 'padiastolic' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/padiastolic/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1791,7 +1705,6 @@
           "description": "Column 'pamean' from vitalPeriodic.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "vitalPeriodic/pamean/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1807,7 +1720,6 @@
           "description": "Column 'st1' from vitalPeriodic.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "vitalPeriodic/st1/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1823,7 +1735,6 @@
           "description": "Column 'st2' from vitalPeriodic.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "vitalPeriodic/st2/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1839,7 +1750,6 @@
           "description": "Column 'st3' from vitalPeriodic.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "vitalPeriodic/st3/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1855,7 +1765,6 @@
           "description": "Column 'icp' from vitalPeriodic.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "vitalPeriodic/icp/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1879,7 +1788,6 @@
           "description": "Column 'cplgeneralid' from carePlanGeneral.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanGeneral/cplgeneralid/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1895,7 +1803,6 @@
           "description": "Column 'patientunitstayid' from carePlanGeneral.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanGeneral/patientunitstayid/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1911,7 +1818,6 @@
           "description": "Column 'activeupondischarge' from carePlanGeneral.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "carePlanGeneral/activeupondischarge/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1927,7 +1833,6 @@
           "description": "Column 'cplitemoffset' from carePlanGeneral.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanGeneral/cplitemoffset/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1943,7 +1848,6 @@
           "description": "Column 'cplgroup' from carePlanGeneral.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanGeneral/cplgroup/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1959,7 +1863,6 @@
           "description": "Column 'cplitemvalue' from carePlanGeneral.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanGeneral/cplitemvalue/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1983,7 +1886,6 @@
           "description": "Column 'patientunitstayid' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/patientunitstayid/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1999,7 +1901,6 @@
           "description": "Column 'patienthealthsystemstayid' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/patienthealthsystemstayid/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2015,7 +1916,6 @@
           "description": "Column 'gender' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/gender/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2031,7 +1931,6 @@
           "description": "Column 'age' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/age/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2047,7 +1946,6 @@
           "description": "Column 'ethnicity' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/ethnicity/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2063,7 +1961,6 @@
           "description": "Column 'hospitalid' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/hospitalid/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2079,7 +1976,6 @@
           "description": "Column 'wardid' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/wardid/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2095,7 +1991,6 @@
           "description": "Column 'apacheadmissiondx' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/apacheadmissiondx/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2111,7 +2006,6 @@
           "description": "Column 'admissionheight' from patient.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "patient/admissionheight/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2127,7 +2021,6 @@
           "description": "Column 'hospitaladmittime24' from patient.csv.gz",
           "dataType": "sc:Time",
           "source": {
-            "@id": "patient/hospitaladmittime24/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2143,7 +2036,6 @@
           "description": "Column 'hospitaladmitoffset' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/hospitaladmitoffset/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2159,7 +2051,6 @@
           "description": "Column 'hospitaladmitsource' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/hospitaladmitsource/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2175,7 +2066,6 @@
           "description": "Column 'hospitaldischargeyear' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/hospitaldischargeyear/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2191,7 +2081,6 @@
           "description": "Column 'hospitaldischargetime24' from patient.csv.gz",
           "dataType": "sc:Time",
           "source": {
-            "@id": "patient/hospitaldischargetime24/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2207,7 +2096,6 @@
           "description": "Column 'hospitaldischargeoffset' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/hospitaldischargeoffset/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2223,7 +2111,6 @@
           "description": "Column 'hospitaldischargelocation' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/hospitaldischargelocation/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2239,7 +2126,6 @@
           "description": "Column 'hospitaldischargestatus' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/hospitaldischargestatus/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2255,7 +2141,6 @@
           "description": "Column 'unittype' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/unittype/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2271,7 +2156,6 @@
           "description": "Column 'unitadmittime24' from patient.csv.gz",
           "dataType": "sc:Time",
           "source": {
-            "@id": "patient/unitadmittime24/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2287,7 +2171,6 @@
           "description": "Column 'unitadmitsource' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/unitadmitsource/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2303,7 +2186,6 @@
           "description": "Column 'unitvisitnumber' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/unitvisitnumber/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2319,7 +2201,6 @@
           "description": "Column 'unitstaytype' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/unitstaytype/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2335,7 +2216,6 @@
           "description": "Column 'admissionweight' from patient.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "patient/admissionweight/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2351,7 +2231,6 @@
           "description": "Column 'dischargeweight' from patient.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "patient/dischargeweight/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2367,7 +2246,6 @@
           "description": "Column 'unitdischargetime24' from patient.csv.gz",
           "dataType": "sc:Time",
           "source": {
-            "@id": "patient/unitdischargetime24/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2383,7 +2261,6 @@
           "description": "Column 'unitdischargeoffset' from patient.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patient/unitdischargeoffset/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2399,7 +2276,6 @@
           "description": "Column 'unitdischargelocation' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/unitdischargelocation/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2415,7 +2291,6 @@
           "description": "Column 'unitdischargestatus' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/unitdischargestatus/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2431,7 +2306,6 @@
           "description": "Column 'uniquepid' from patient.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patient/uniquepid/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2455,7 +2329,6 @@
           "description": "Column 'cplgoalid' from carePlanGoal.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanGoal/cplgoalid/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2471,7 +2344,6 @@
           "description": "Column 'patientunitstayid' from carePlanGoal.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanGoal/patientunitstayid/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2487,7 +2359,6 @@
           "description": "Column 'cplgoaloffset' from carePlanGoal.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanGoal/cplgoaloffset/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2503,7 +2374,6 @@
           "description": "Column 'cplgoalcategory' from carePlanGoal.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanGoal/cplgoalcategory/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2519,7 +2389,6 @@
           "description": "Column 'cplgoalvalue' from carePlanGoal.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanGoal/cplgoalvalue/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2535,7 +2404,6 @@
           "description": "Column 'cplgoalstatus' from carePlanGoal.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanGoal/cplgoalstatus/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2551,7 +2419,6 @@
           "description": "Column 'activeupondischarge' from carePlanGoal.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "carePlanGoal/activeupondischarge/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2575,7 +2442,6 @@
           "description": "Column 'treatmentid' from treatment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "treatment/treatmentid/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2591,7 +2457,6 @@
           "description": "Column 'patientunitstayid' from treatment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "treatment/patientunitstayid/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2607,7 +2472,6 @@
           "description": "Column 'treatmentoffset' from treatment.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "treatment/treatmentoffset/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2623,7 +2487,6 @@
           "description": "Column 'treatmentstring' from treatment.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "treatment/treatmentstring/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2639,7 +2502,6 @@
           "description": "Column 'activeupondischarge' from treatment.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "treatment/activeupondischarge/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2663,7 +2525,6 @@
           "description": "Column 'apacheapsvarid' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/apacheapsvarid/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2679,7 +2540,6 @@
           "description": "Column 'patientunitstayid' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/patientunitstayid/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2695,7 +2555,6 @@
           "description": "Column 'intubated' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/intubated/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2711,7 +2570,6 @@
           "description": "Column 'vent' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/vent/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2727,7 +2585,6 @@
           "description": "Column 'dialysis' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/dialysis/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2743,7 +2600,6 @@
           "description": "Column 'eyes' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/eyes/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2759,7 +2615,6 @@
           "description": "Column 'motor' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/motor/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2775,7 +2630,6 @@
           "description": "Column 'verbal' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/verbal/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2791,7 +2645,6 @@
           "description": "Column 'meds' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/meds/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2807,7 +2660,6 @@
           "description": "Column 'urine' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/urine/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2823,7 +2675,6 @@
           "description": "Column 'wbc' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/wbc/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2839,7 +2690,6 @@
           "description": "Column 'temperature' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/temperature/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2855,7 +2705,6 @@
           "description": "Column 'respiratoryrate' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/respiratoryrate/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2871,7 +2720,6 @@
           "description": "Column 'sodium' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/sodium/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2887,7 +2735,6 @@
           "description": "Column 'heartrate' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/heartrate/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2903,7 +2750,6 @@
           "description": "Column 'meanbp' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/meanbp/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2919,7 +2765,6 @@
           "description": "Column 'ph' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/ph/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2935,7 +2780,6 @@
           "description": "Column 'hematocrit' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/hematocrit/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2951,7 +2795,6 @@
           "description": "Column 'creatinine' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/creatinine/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2967,7 +2810,6 @@
           "description": "Column 'albumin' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/albumin/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2983,7 +2825,6 @@
           "description": "Column 'pao2' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/pao2/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2999,7 +2840,6 @@
           "description": "Column 'pco2' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/pco2/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -3015,7 +2855,6 @@
           "description": "Column 'bun' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/bun/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -3031,7 +2870,6 @@
           "description": "Column 'glucose' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/glucose/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -3047,7 +2885,6 @@
           "description": "Column 'bilirubin' from apacheApsVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apacheApsVar/bilirubin/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -3063,7 +2900,6 @@
           "description": "Column 'fio2' from apacheApsVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apacheApsVar/fio2/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -3087,7 +2923,6 @@
           "description": "Column 'cpleolid' from carePlanEOL.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanEOL/cpleolid/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -3103,7 +2938,6 @@
           "description": "Column 'patientunitstayid' from carePlanEOL.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanEOL/patientunitstayid/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -3119,7 +2953,6 @@
           "description": "Column 'cpleolsaveoffset' from carePlanEOL.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanEOL/cpleolsaveoffset/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -3135,7 +2968,6 @@
           "description": "Column 'cpleoldiscussionoffset' from carePlanEOL.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanEOL/cpleoldiscussionoffset/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -3151,7 +2983,6 @@
           "description": "Column 'activeupondischarge' from carePlanEOL.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "carePlanEOL/activeupondischarge/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -3175,7 +3006,6 @@
           "description": "Column 'infusiondrugid' from infusiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "infusiondrug/infusiondrugid/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3191,7 +3021,6 @@
           "description": "Column 'patientunitstayid' from infusiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "infusiondrug/patientunitstayid/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3207,7 +3036,6 @@
           "description": "Column 'infusionoffset' from infusiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "infusiondrug/infusionoffset/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3223,7 +3051,6 @@
           "description": "Column 'drugname' from infusiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "infusiondrug/drugname/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3239,7 +3066,6 @@
           "description": "Column 'drugrate' from infusiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "infusiondrug/drugrate/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3255,7 +3081,6 @@
           "description": "Column 'infusionrate' from infusiondrug.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "infusiondrug/infusionrate/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3271,7 +3096,6 @@
           "description": "Column 'drugamount' from infusiondrug.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "infusiondrug/drugamount/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3287,7 +3111,6 @@
           "description": "Column 'volumeoffluid' from infusiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "infusiondrug/volumeoffluid/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3303,7 +3126,6 @@
           "description": "Column 'patientweight' from infusiondrug.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "infusiondrug/patientweight/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -3327,7 +3149,6 @@
           "description": "Column 'cplcareprovderid' from carePlanCareProvider.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanCareProvider/cplcareprovderid/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3343,7 +3164,6 @@
           "description": "Column 'patientunitstayid' from carePlanCareProvider.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanCareProvider/patientunitstayid/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3359,7 +3179,6 @@
           "description": "Column 'careprovidersaveoffset' from carePlanCareProvider.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanCareProvider/careprovidersaveoffset/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3375,7 +3194,6 @@
           "description": "Column 'providertype' from carePlanCareProvider.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanCareProvider/providertype/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3391,7 +3209,6 @@
           "description": "Column 'specialty' from carePlanCareProvider.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanCareProvider/specialty/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3407,7 +3224,6 @@
           "description": "Column 'interventioncategory' from carePlanCareProvider.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanCareProvider/interventioncategory/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3423,7 +3239,6 @@
           "description": "Column 'managingphysician' from carePlanCareProvider.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanCareProvider/managingphysician/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3439,7 +3254,6 @@
           "description": "Column 'activeupondischarge' from carePlanCareProvider.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "carePlanCareProvider/activeupondischarge/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -3463,7 +3277,6 @@
           "description": "Column 'microlabid' from microLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microLab/microlabid/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3479,7 +3292,6 @@
           "description": "Column 'patientunitstayid' from microLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microLab/patientunitstayid/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3495,7 +3307,6 @@
           "description": "Column 'culturetakenoffset' from microLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microLab/culturetakenoffset/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3511,7 +3322,6 @@
           "description": "Column 'culturesite' from microLab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microLab/culturesite/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3527,7 +3337,6 @@
           "description": "Column 'organism' from microLab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microLab/organism/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3543,7 +3352,6 @@
           "description": "Column 'antibiotic' from microLab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microLab/antibiotic/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3559,7 +3367,6 @@
           "description": "Column 'sensitivitylevel' from microLab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microLab/sensitivitylevel/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3583,7 +3390,6 @@
           "description": "Column 'nursecareid' from nurseCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCare/nursecareid/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3599,7 +3405,6 @@
           "description": "Column 'patientunitstayid' from nurseCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCare/patientunitstayid/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3615,7 +3420,6 @@
           "description": "Column 'celllabel' from nurseCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCare/celllabel/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3631,7 +3435,6 @@
           "description": "Column 'nursecareoffset' from nurseCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCare/nursecareoffset/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3647,7 +3450,6 @@
           "description": "Column 'nursecareentryoffset' from nurseCare.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCare/nursecareentryoffset/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3663,7 +3465,6 @@
           "description": "Column 'cellattributepath' from nurseCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCare/cellattributepath/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3679,7 +3480,6 @@
           "description": "Column 'cellattribute' from nurseCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCare/cellattribute/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3695,7 +3495,6 @@
           "description": "Column 'cellattributevalue' from nurseCare.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCare/cellattributevalue/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3719,7 +3518,6 @@
           "description": "Column 'physicalexamid' from physicalExam.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "physicalExam/physicalexamid/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3735,7 +3533,6 @@
           "description": "Column 'patientunitstayid' from physicalExam.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "physicalExam/patientunitstayid/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3751,7 +3548,6 @@
           "description": "Column 'physicalexamoffset' from physicalExam.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "physicalExam/physicalexamoffset/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3767,7 +3563,6 @@
           "description": "Column 'physicalexampath' from physicalExam.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "physicalExam/physicalexampath/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3783,7 +3578,6 @@
           "description": "Column 'physicalexamvalue' from physicalExam.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "physicalExam/physicalexamvalue/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3799,7 +3593,6 @@
           "description": "Column 'physicalexamtext' from physicalExam.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "physicalExam/physicalexamtext/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3823,7 +3616,6 @@
           "description": "Column 'respchartid' from respiratoryCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCharting/respchartid/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3839,7 +3631,6 @@
           "description": "Column 'patientunitstayid' from respiratoryCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCharting/patientunitstayid/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3855,7 +3646,6 @@
           "description": "Column 'respchartoffset' from respiratoryCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCharting/respchartoffset/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3871,7 +3661,6 @@
           "description": "Column 'respchartentryoffset' from respiratoryCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "respiratoryCharting/respchartentryoffset/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3887,7 +3676,6 @@
           "description": "Column 'respcharttypecat' from respiratoryCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCharting/respcharttypecat/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3903,7 +3691,6 @@
           "description": "Column 'respchartvaluelabel' from respiratoryCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCharting/respchartvaluelabel/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3919,7 +3706,6 @@
           "description": "Column 'respchartvalue' from respiratoryCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "respiratoryCharting/respchartvalue/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3943,7 +3729,6 @@
           "description": "Column 'noteid' from note.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "note/noteid/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3959,7 +3744,6 @@
           "description": "Column 'patientunitstayid' from note.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "note/patientunitstayid/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3975,7 +3759,6 @@
           "description": "Column 'noteoffset' from note.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "note/noteoffset/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3991,7 +3774,6 @@
           "description": "Column 'noteenteredoffset' from note.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "note/noteenteredoffset/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -4007,7 +3789,6 @@
           "description": "Column 'notetype' from note.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/notetype/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -4023,7 +3804,6 @@
           "description": "Column 'notepath' from note.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/notepath/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -4039,7 +3819,6 @@
           "description": "Column 'notevalue' from note.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/notevalue/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -4055,7 +3834,6 @@
           "description": "Column 'notetext' from note.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/notetext/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -4079,7 +3857,6 @@
           "description": "Column 'admissiondrugid' from admissiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissiondrug/admissiondrugid/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4095,7 +3872,6 @@
           "description": "Column 'patientunitstayid' from admissiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissiondrug/patientunitstayid/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4111,7 +3887,6 @@
           "description": "Column 'drugoffset' from admissiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissiondrug/drugoffset/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4127,7 +3902,6 @@
           "description": "Column 'drugenteredoffset' from admissiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissiondrug/drugenteredoffset/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4143,7 +3917,6 @@
           "description": "Column 'drugnotetype' from admissiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissiondrug/drugnotetype/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4159,7 +3932,6 @@
           "description": "Column 'specialtytype' from admissiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissiondrug/specialtytype/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4175,7 +3947,6 @@
           "description": "Column 'usertype' from admissiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissiondrug/usertype/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4191,7 +3962,6 @@
           "description": "Column 'rxincluded' from admissiondrug.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "admissiondrug/rxincluded/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4207,7 +3977,6 @@
           "description": "Column 'writtenineicu' from admissiondrug.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "admissiondrug/writtenineicu/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4223,7 +3992,6 @@
           "description": "Column 'drugname' from admissiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissiondrug/drugname/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4239,7 +4007,6 @@
           "description": "Column 'drugdosage' from admissiondrug.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "admissiondrug/drugdosage/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4255,7 +4022,6 @@
           "description": "Column 'drugunit' from admissiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissiondrug/drugunit/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4271,7 +4037,6 @@
           "description": "Column 'drugadmitfrequency' from admissiondrug.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissiondrug/drugadmitfrequency/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4287,7 +4052,6 @@
           "description": "Column 'drughiclseqno' from admissiondrug.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissiondrug/drughiclseqno/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4311,7 +4075,6 @@
           "description": "Column 'labid' from lab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "lab/labid/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4327,7 +4090,6 @@
           "description": "Column 'patientunitstayid' from lab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "lab/patientunitstayid/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4343,7 +4105,6 @@
           "description": "Column 'labresultoffset' from lab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "lab/labresultoffset/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4359,7 +4120,6 @@
           "description": "Column 'labtypeid' from lab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "lab/labtypeid/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4375,7 +4135,6 @@
           "description": "Column 'labname' from lab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "lab/labname/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4391,7 +4150,6 @@
           "description": "Column 'labresult' from lab.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "lab/labresult/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4407,7 +4165,6 @@
           "description": "Column 'labresulttext' from lab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "lab/labresulttext/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4423,7 +4180,6 @@
           "description": "Column 'labmeasurenamesystem' from lab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "lab/labmeasurenamesystem/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4439,7 +4195,6 @@
           "description": "Column 'labmeasurenameinterface' from lab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "lab/labmeasurenameinterface/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4455,7 +4210,6 @@
           "description": "Column 'labresultrevisedoffset' from lab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "lab/labresultrevisedoffset/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4479,7 +4233,6 @@
           "description": "Column 'apachepredvarid' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/apachepredvarid/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4495,7 +4248,6 @@
           "description": "Column 'patientunitstayid' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/patientunitstayid/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4511,7 +4263,6 @@
           "description": "Column 'sicuday' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/sicuday/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4527,7 +4278,6 @@
           "description": "Column 'saps3day1' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/saps3day1/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4543,7 +4293,6 @@
           "description": "Column 'saps3today' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/saps3today/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4559,7 +4308,6 @@
           "description": "Column 'saps3yesterday' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/saps3yesterday/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4575,7 +4323,6 @@
           "description": "Column 'gender' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/gender/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4591,7 +4338,6 @@
           "description": "Column 'teachtype' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/teachtype/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4607,7 +4353,6 @@
           "description": "Column 'region' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/region/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4623,7 +4368,6 @@
           "description": "Column 'bedcount' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/bedcount/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4639,7 +4383,6 @@
           "description": "Column 'admitsource' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/admitsource/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4655,7 +4398,6 @@
           "description": "Column 'graftcount' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/graftcount/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4671,7 +4413,6 @@
           "description": "Column 'meds' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/meds/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4687,7 +4428,6 @@
           "description": "Column 'verbal' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/verbal/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4703,7 +4443,6 @@
           "description": "Column 'motor' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/motor/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4719,7 +4458,6 @@
           "description": "Column 'eyes' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/eyes/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4735,7 +4473,6 @@
           "description": "Column 'age' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/age/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4751,7 +4488,6 @@
           "description": "Column 'admitdiagnosis' from apachePredVar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "apachePredVar/admitdiagnosis/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4767,7 +4503,6 @@
           "description": "Column 'thrombolytics' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/thrombolytics/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4783,7 +4518,6 @@
           "description": "Column 'diedinhospital' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/diedinhospital/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4799,7 +4533,6 @@
           "description": "Column 'aids' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/aids/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4815,7 +4548,6 @@
           "description": "Column 'hepaticfailure' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/hepaticfailure/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4831,7 +4563,6 @@
           "description": "Column 'lymphoma' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/lymphoma/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4847,7 +4578,6 @@
           "description": "Column 'metastaticcancer' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/metastaticcancer/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4863,7 +4593,6 @@
           "description": "Column 'leukemia' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/leukemia/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4879,7 +4608,6 @@
           "description": "Column 'immunosuppression' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/immunosuppression/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4895,7 +4623,6 @@
           "description": "Column 'cirrhosis' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/cirrhosis/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4911,7 +4638,6 @@
           "description": "Column 'electivesurgery' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/electivesurgery/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4927,7 +4653,6 @@
           "description": "Column 'activetx' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/activetx/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4943,7 +4668,6 @@
           "description": "Column 'readmit' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/readmit/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4959,7 +4683,6 @@
           "description": "Column 'ima' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/ima/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4975,7 +4698,6 @@
           "description": "Column 'midur' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/midur/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4991,7 +4713,6 @@
           "description": "Column 'ventday1' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/ventday1/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5007,7 +4728,6 @@
           "description": "Column 'oobventday1' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/oobventday1/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5023,7 +4743,6 @@
           "description": "Column 'oobintubday1' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/oobintubday1/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5039,7 +4758,6 @@
           "description": "Column 'diabetes' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/diabetes/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5055,7 +4773,6 @@
           "description": "Column 'managementsystem' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/managementsystem/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5071,7 +4788,6 @@
           "description": "Column 'var03hspxlos' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/var03hspxlos/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5087,7 +4803,6 @@
           "description": "Column 'pao2' from apachePredVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePredVar/pao2/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5103,7 +4818,6 @@
           "description": "Column 'fio2' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/fio2/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5119,7 +4833,6 @@
           "description": "Column 'ejectfx' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/ejectfx/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5135,7 +4848,6 @@
           "description": "Column 'creatinine' from apachePredVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePredVar/creatinine/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5151,7 +4863,6 @@
           "description": "Column 'dischargelocation' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/dischargelocation/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5167,7 +4878,6 @@
           "description": "Column 'visitnumber' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/visitnumber/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5183,7 +4893,6 @@
           "description": "Column 'amilocation' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/amilocation/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5199,7 +4908,6 @@
           "description": "Column 'day1meds' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/day1meds/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5215,7 +4923,6 @@
           "description": "Column 'day1verbal' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/day1verbal/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5231,7 +4938,6 @@
           "description": "Column 'day1motor' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/day1motor/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5247,7 +4953,6 @@
           "description": "Column 'day1eyes' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/day1eyes/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5263,7 +4968,6 @@
           "description": "Column 'day1pao2' from apachePredVar.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePredVar/day1pao2/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5279,7 +4983,6 @@
           "description": "Column 'day1fio2' from apachePredVar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePredVar/day1fio2/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -5303,7 +5006,6 @@
           "description": "Column 'customlabid' from customLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "customLab/customlabid/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5319,7 +5021,6 @@
           "description": "Column 'patientunitstayid' from customLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "customLab/patientunitstayid/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5335,7 +5036,6 @@
           "description": "Column 'labotheroffset' from customLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "customLab/labotheroffset/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5351,7 +5051,6 @@
           "description": "Column 'labothertypeid' from customLab.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "customLab/labothertypeid/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5367,7 +5066,6 @@
           "description": "Column 'labothername' from customLab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "customLab/labothername/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5383,7 +5081,6 @@
           "description": "Column 'labotherresult' from customLab.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "customLab/labotherresult/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5399,7 +5096,6 @@
           "description": "Column 'labothervaluetext' from customLab.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "customLab/labothervaluetext/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -5423,7 +5119,6 @@
           "description": "Column 'apachepatientresultsid' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/apachepatientresultsid/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5439,7 +5134,6 @@
           "description": "Column 'patientunitstayid' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/patientunitstayid/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5455,7 +5149,6 @@
           "description": "Column 'physicianspeciality' from apachePatientResult.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "apachePatientResult/physicianspeciality/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5471,7 +5164,6 @@
           "description": "Column 'physicianinterventioncategory' from apachePatientResult.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "apachePatientResult/physicianinterventioncategory/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5487,7 +5179,6 @@
           "description": "Column 'acutephysiologyscore' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/acutephysiologyscore/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5503,7 +5194,6 @@
           "description": "Column 'apachescore' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/apachescore/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5519,7 +5209,6 @@
           "description": "Column 'apacheversion' from apachePatientResult.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "apachePatientResult/apacheversion/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5535,7 +5224,6 @@
           "description": "Column 'predictedicumortality' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/predictedicumortality/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5551,7 +5239,6 @@
           "description": "Column 'actualicumortality' from apachePatientResult.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "apachePatientResult/actualicumortality/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5567,7 +5254,6 @@
           "description": "Column 'predictediculos' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/predictediculos/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5583,7 +5269,6 @@
           "description": "Column 'actualiculos' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/actualiculos/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5599,7 +5284,6 @@
           "description": "Column 'predictedhospitalmortality' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/predictedhospitalmortality/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5615,7 +5299,6 @@
           "description": "Column 'actualhospitalmortality' from apachePatientResult.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "apachePatientResult/actualhospitalmortality/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5631,7 +5314,6 @@
           "description": "Column 'predictedhospitallos' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/predictedhospitallos/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5647,7 +5329,6 @@
           "description": "Column 'actualhospitallos' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/actualhospitallos/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5663,7 +5344,6 @@
           "description": "Column 'preopmi' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/preopmi/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5679,7 +5359,6 @@
           "description": "Column 'preopcardiaccath' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/preopcardiaccath/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5695,7 +5374,6 @@
           "description": "Column 'ptcawithin24h' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/ptcawithin24h/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5711,7 +5389,6 @@
           "description": "Column 'unabridgedunitlos' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/unabridgedunitlos/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5727,7 +5404,6 @@
           "description": "Column 'unabridgedhosplos' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/unabridgedhosplos/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5743,7 +5419,6 @@
           "description": "Column 'actualventdays' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/actualventdays/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5759,7 +5434,6 @@
           "description": "Column 'predventdays' from apachePatientResult.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "apachePatientResult/predventdays/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5775,7 +5449,6 @@
           "description": "Column 'unabridgedactualventdays' from apachePatientResult.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "apachePatientResult/unabridgedactualventdays/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -5799,7 +5472,6 @@
           "description": "Column 'cplinfectid' from carePlanInfectiousDisease.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanInfectiousDisease/cplinfectid/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5815,7 +5487,6 @@
           "description": "Column 'patientunitstayid' from carePlanInfectiousDisease.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanInfectiousDisease/patientunitstayid/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5831,7 +5502,6 @@
           "description": "Column 'activeupondischarge' from carePlanInfectiousDisease.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "carePlanInfectiousDisease/activeupondischarge/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5847,7 +5517,6 @@
           "description": "Column 'cplinfectdiseaseoffset' from carePlanInfectiousDisease.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "carePlanInfectiousDisease/cplinfectdiseaseoffset/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5863,7 +5532,6 @@
           "description": "Column 'infectdiseasesite' from carePlanInfectiousDisease.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanInfectiousDisease/infectdiseasesite/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5879,7 +5547,6 @@
           "description": "Column 'infectdiseaseassessment' from carePlanInfectiousDisease.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanInfectiousDisease/infectdiseaseassessment/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5895,7 +5562,6 @@
           "description": "Column 'responsetotherapy' from carePlanInfectiousDisease.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanInfectiousDisease/responsetotherapy/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5911,7 +5577,6 @@
           "description": "Column 'treatment' from carePlanInfectiousDisease.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "carePlanInfectiousDisease/treatment/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5935,7 +5600,6 @@
           "description": "Column 'allergyid' from allergy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "allergy/allergyid/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5951,7 +5615,6 @@
           "description": "Column 'patientunitstayid' from allergy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "allergy/patientunitstayid/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5967,7 +5630,6 @@
           "description": "Column 'allergyoffset' from allergy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "allergy/allergyoffset/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5983,7 +5645,6 @@
           "description": "Column 'allergyenteredoffset' from allergy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "allergy/allergyenteredoffset/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5999,7 +5660,6 @@
           "description": "Column 'allergynotetype' from allergy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "allergy/allergynotetype/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6015,7 +5675,6 @@
           "description": "Column 'specialtytype' from allergy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "allergy/specialtytype/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6031,7 +5690,6 @@
           "description": "Column 'usertype' from allergy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "allergy/usertype/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6047,7 +5705,6 @@
           "description": "Column 'rxincluded' from allergy.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "allergy/rxincluded/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6063,7 +5720,6 @@
           "description": "Column 'writtenineicu' from allergy.csv.gz",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "allergy/writtenineicu/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6079,7 +5735,6 @@
           "description": "Column 'drugname' from allergy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "allergy/drugname/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6095,7 +5750,6 @@
           "description": "Column 'allergytype' from allergy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "allergy/allergytype/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6111,7 +5765,6 @@
           "description": "Column 'allergyname' from allergy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "allergy/allergyname/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6127,7 +5780,6 @@
           "description": "Column 'drughiclseqno' from allergy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "allergy/drughiclseqno/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -6151,7 +5803,6 @@
           "description": "Column 'nursingchartid' from nurseCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCharting/nursingchartid/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6167,7 +5818,6 @@
           "description": "Column 'patientunitstayid' from nurseCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCharting/patientunitstayid/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6183,7 +5833,6 @@
           "description": "Column 'nursingchartoffset' from nurseCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCharting/nursingchartoffset/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6199,7 +5848,6 @@
           "description": "Column 'nursingchartentryoffset' from nurseCharting.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "nurseCharting/nursingchartentryoffset/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6215,7 +5863,6 @@
           "description": "Column 'nursingchartcelltypecat' from nurseCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCharting/nursingchartcelltypecat/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6231,7 +5878,6 @@
           "description": "Column 'nursingchartcelltypevallabel' from nurseCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCharting/nursingchartcelltypevallabel/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6247,7 +5893,6 @@
           "description": "Column 'nursingchartcelltypevalname' from nurseCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCharting/nursingchartcelltypevalname/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6263,7 +5908,6 @@
           "description": "Column 'nursingchartvalue' from nurseCharting.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "nurseCharting/nursingchartvalue/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -6287,7 +5931,6 @@
           "description": "Column 'pasthistoryid' from pastHistory.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pastHistory/pasthistoryid/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6303,7 +5946,6 @@
           "description": "Column 'patientunitstayid' from pastHistory.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pastHistory/patientunitstayid/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6319,7 +5961,6 @@
           "description": "Column 'pasthistoryoffset' from pastHistory.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pastHistory/pasthistoryoffset/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6335,7 +5976,6 @@
           "description": "Column 'pasthistoryenteredoffset' from pastHistory.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pastHistory/pasthistoryenteredoffset/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6351,7 +5991,6 @@
           "description": "Column 'pasthistorynotetype' from pastHistory.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pastHistory/pasthistorynotetype/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6367,7 +6006,6 @@
           "description": "Column 'pasthistorypath' from pastHistory.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pastHistory/pasthistorypath/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6383,7 +6021,6 @@
           "description": "Column 'pasthistoryvalue' from pastHistory.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pastHistory/pasthistoryvalue/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6399,7 +6036,6 @@
           "description": "Column 'pasthistoryvaluetext' from pastHistory.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pastHistory/pasthistoryvaluetext/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -6423,7 +6059,6 @@
           "description": "Column 'medicationid' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/medicationid/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6439,7 +6074,6 @@
           "description": "Column 'patientunitstayid' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/patientunitstayid/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6455,7 +6089,6 @@
           "description": "Column 'drugorderoffset' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/drugorderoffset/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6471,7 +6104,6 @@
           "description": "Column 'drugstartoffset' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/drugstartoffset/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6487,7 +6119,6 @@
           "description": "Column 'drugivadmixture' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/drugivadmixture/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6503,7 +6134,6 @@
           "description": "Column 'drugordercancelled' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/drugordercancelled/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6519,7 +6149,6 @@
           "description": "Column 'drugname' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/drugname/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6535,7 +6164,6 @@
           "description": "Column 'drughiclseqno' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/drughiclseqno/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6551,7 +6179,6 @@
           "description": "Column 'dosage' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/dosage/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6567,7 +6194,6 @@
           "description": "Column 'routeadmin' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/routeadmin/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6583,7 +6209,6 @@
           "description": "Column 'frequency' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/frequency/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6599,7 +6224,6 @@
           "description": "Column 'loadingdose' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/loadingdose/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6615,7 +6239,6 @@
           "description": "Column 'prn' from medication.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "medication/prn/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6631,7 +6254,6 @@
           "description": "Column 'drugstopoffset' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/drugstopoffset/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6647,7 +6269,6 @@
           "description": "Column 'gtc' from medication.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "medication/gtc/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6671,7 +6292,6 @@
           "description": "Column 'intakeoutputid' from intakeOutput.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "intakeOutput/intakeoutputid/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6687,7 +6307,6 @@
           "description": "Column 'patientunitstayid' from intakeOutput.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "intakeOutput/patientunitstayid/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6703,7 +6322,6 @@
           "description": "Column 'intakeoutputoffset' from intakeOutput.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "intakeOutput/intakeoutputoffset/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6719,7 +6337,6 @@
           "description": "Column 'intaketotal' from intakeOutput.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "intakeOutput/intaketotal/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6735,7 +6352,6 @@
           "description": "Column 'outputtotal' from intakeOutput.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "intakeOutput/outputtotal/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6751,7 +6367,6 @@
           "description": "Column 'dialysistotal' from intakeOutput.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "intakeOutput/dialysistotal/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6767,7 +6382,6 @@
           "description": "Column 'nettotal' from intakeOutput.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "intakeOutput/nettotal/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6783,7 +6397,6 @@
           "description": "Column 'intakeoutputentryoffset' from intakeOutput.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "intakeOutput/intakeoutputentryoffset/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6799,7 +6412,6 @@
           "description": "Column 'cellpath' from intakeOutput.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "intakeOutput/cellpath/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6815,7 +6427,6 @@
           "description": "Column 'celllabel' from intakeOutput.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "intakeOutput/celllabel/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6831,7 +6442,6 @@
           "description": "Column 'cellvaluenumeric' from intakeOutput.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "intakeOutput/cellvaluenumeric/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6847,7 +6457,6 @@
           "description": "Column 'cellvaluetext' from intakeOutput.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "intakeOutput/cellvaluetext/source",
             "fileObject": {
               "@id": "file_30"
             },

--- a/tests/data/output/glaucoma_fundus_croissant.jsonld
+++ b/tests/data/output/glaucoma_fundus_croissant.jsonld
@@ -199,7 +199,6 @@
           "description": "Column 'Image Name' from Labels.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "Labels/Image_Name/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -215,7 +214,6 @@
           "description": "Column 'Patient' from Labels.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "Labels/Patient/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -231,7 +229,6 @@
           "description": "Column 'Label' from Labels.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "Labels/Label/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -247,7 +244,6 @@
           "description": "Column 'Quality Score' from Labels.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "Labels/Quality_Score/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -271,7 +267,6 @@
           "description": "Image content (12 files, JPEG (12))",
           "dataType": "sc:ImageObject",
           "source": {
-            "@id": "images/image_content/source",
             "fileSet": {
               "@id": "image-files"
             },

--- a/tests/data/output/mimiciv_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant.jsonld
@@ -393,7 +393,6 @@
           "description": "Column 'subject_id' from demo_subject_id.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "demo_subject_id/subject_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -417,7 +416,6 @@
           "description": "Column 'poe_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/poe_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -433,7 +431,6 @@
           "description": "Column 'poe_seq' from poe.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "poe/poe_seq/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -449,7 +446,6 @@
           "description": "Column 'subject_id' from poe.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "poe/subject_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -465,7 +461,6 @@
           "description": "Column 'hadm_id' from poe.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "poe/hadm_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -481,7 +476,6 @@
           "description": "Column 'ordertime' from poe.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "poe/ordertime/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -497,7 +491,6 @@
           "description": "Column 'order_type' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/order_type/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -513,7 +506,6 @@
           "description": "Column 'order_subtype' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/order_subtype/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -529,7 +521,6 @@
           "description": "Column 'transaction_type' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/transaction_type/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -545,7 +536,6 @@
           "description": "Column 'discontinue_of_poe_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/discontinue_of_poe_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -561,7 +551,6 @@
           "description": "Column 'discontinued_by_poe_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/discontinued_by_poe_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -577,7 +566,6 @@
           "description": "Column 'order_provider_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/order_provider_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -593,7 +581,6 @@
           "description": "Column 'order_status' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe/order_status/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -617,7 +604,6 @@
           "description": "Column 'code' from d_hcpcs.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_hcpcs/code/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -633,7 +619,6 @@
           "description": "Column 'category' from d_hcpcs.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "d_hcpcs/category/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -649,7 +634,6 @@
           "description": "Column 'long_description' from d_hcpcs.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_hcpcs/long_description/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -665,7 +649,6 @@
           "description": "Column 'short_description' from d_hcpcs.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_hcpcs/short_description/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -689,7 +672,6 @@
           "description": "Column 'poe_id' from poe_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe_detail/poe_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -705,7 +687,6 @@
           "description": "Column 'poe_seq' from poe_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "poe_detail/poe_seq/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -721,7 +702,6 @@
           "description": "Column 'subject_id' from poe_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "poe_detail/subject_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -737,7 +717,6 @@
           "description": "Column 'field_name' from poe_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe_detail/field_name/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -753,7 +732,6 @@
           "description": "Column 'field_value' from poe_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "poe_detail/field_value/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -777,7 +755,6 @@
           "description": "Column 'subject_id' from patients.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patients/subject_id/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -793,7 +770,6 @@
           "description": "Column 'gender' from patients.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patients/gender/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -809,7 +785,6 @@
           "description": "Column 'anchor_age' from patients.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patients/anchor_age/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -825,7 +800,6 @@
           "description": "Column 'anchor_year' from patients.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "patients/anchor_year/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -841,7 +815,6 @@
           "description": "Column 'anchor_year_group' from patients.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "patients/anchor_year_group/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -857,7 +830,6 @@
           "description": "Column 'dod' from patients.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "patients/dod/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -881,7 +853,6 @@
           "description": "Column 'subject_id' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnoses_icd/subject_id/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -897,7 +868,6 @@
           "description": "Column 'hadm_id' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnoses_icd/hadm_id/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -913,7 +883,6 @@
           "description": "Column 'seq_num' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnoses_icd/seq_num/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -929,7 +898,6 @@
           "description": "Column 'icd_code' from diagnoses_icd.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "diagnoses_icd/icd_code/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -945,7 +913,6 @@
           "description": "Column 'icd_version' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "diagnoses_icd/icd_version/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -969,7 +936,6 @@
           "description": "Column 'subject_id' from emar_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar_detail/subject_id/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -985,7 +951,6 @@
           "description": "Column 'emar_id' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/emar_id/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1001,7 +966,6 @@
           "description": "Column 'emar_seq' from emar_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar_detail/emar_seq/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1017,7 +981,6 @@
           "description": "Column 'parent_field_ordinal' from emar_detail.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "emar_detail/parent_field_ordinal/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1033,7 +996,6 @@
           "description": "Column 'administration_type' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/administration_type/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1049,7 +1011,6 @@
           "description": "Column 'pharmacy_id' from emar_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar_detail/pharmacy_id/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1065,7 +1026,6 @@
           "description": "Column 'barcode_type' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/barcode_type/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1081,7 +1041,6 @@
           "description": "Column 'reason_for_no_barcode' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/reason_for_no_barcode/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1097,7 +1056,6 @@
           "description": "Column 'complete_dose_not_given' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/complete_dose_not_given/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1113,7 +1071,6 @@
           "description": "Column 'dose_due' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/dose_due/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1129,7 +1086,6 @@
           "description": "Column 'dose_due_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/dose_due_unit/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1145,7 +1101,6 @@
           "description": "Column 'dose_given' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/dose_given/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1161,7 +1116,6 @@
           "description": "Column 'dose_given_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/dose_given_unit/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1177,7 +1131,6 @@
           "description": "Column 'will_remainder_of_dose_be_given' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/will_remainder_of_dose_be_given/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1193,7 +1146,6 @@
           "description": "Column 'product_amount_given' from emar_detail.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "emar_detail/product_amount_given/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1209,7 +1161,6 @@
           "description": "Column 'product_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/product_unit/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1225,7 +1176,6 @@
           "description": "Column 'product_code' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/product_code/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1241,7 +1191,6 @@
           "description": "Column 'product_description' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/product_description/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1257,7 +1206,6 @@
           "description": "Column 'product_description_other' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/product_description_other/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1273,7 +1221,6 @@
           "description": "Column 'prior_infusion_rate' from emar_detail.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "emar_detail/prior_infusion_rate/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1289,7 +1236,6 @@
           "description": "Column 'infusion_rate' from emar_detail.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "emar_detail/infusion_rate/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1305,7 +1251,6 @@
           "description": "Column 'infusion_rate_adjustment' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/infusion_rate_adjustment/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1321,7 +1266,6 @@
           "description": "Column 'infusion_rate_adjustment_amount' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/infusion_rate_adjustment_amount/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1337,7 +1281,6 @@
           "description": "Column 'infusion_rate_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/infusion_rate_unit/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1353,7 +1296,6 @@
           "description": "Column 'route' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/route/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1369,7 +1311,6 @@
           "description": "Column 'infusion_complete' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/infusion_complete/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1385,7 +1326,6 @@
           "description": "Column 'completion_interval' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/completion_interval/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1401,7 +1341,6 @@
           "description": "Column 'new_iv_bag_hung' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/new_iv_bag_hung/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1417,7 +1356,6 @@
           "description": "Column 'continued_infusion_in_other_location' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/continued_infusion_in_other_location/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1433,7 +1371,6 @@
           "description": "Column 'restart_interval' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/restart_interval/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1449,7 +1386,6 @@
           "description": "Column 'side' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/side/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1465,7 +1401,6 @@
           "description": "Column 'site' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/site/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1481,7 +1416,6 @@
           "description": "Column 'non_formulary_visual_verification' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar_detail/non_formulary_visual_verification/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1505,7 +1439,6 @@
           "description": "Column 'provider_id' from provider.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/provider_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1529,7 +1462,6 @@
           "description": "Column 'subject_id' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/subject_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1545,7 +1477,6 @@
           "description": "Column 'hadm_id' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/hadm_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1561,7 +1492,6 @@
           "description": "Column 'pharmacy_id' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/pharmacy_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1577,7 +1507,6 @@
           "description": "Column 'poe_id' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/poe_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1593,7 +1522,6 @@
           "description": "Column 'poe_seq' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/poe_seq/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1609,7 +1537,6 @@
           "description": "Column 'order_provider_id' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/order_provider_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1625,7 +1552,6 @@
           "description": "Column 'starttime' from prescriptions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "prescriptions/starttime/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1641,7 +1567,6 @@
           "description": "Column 'stoptime' from prescriptions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "prescriptions/stoptime/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1657,7 +1582,6 @@
           "description": "Column 'drug_type' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/drug_type/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1673,7 +1597,6 @@
           "description": "Column 'drug' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/drug/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1689,7 +1612,6 @@
           "description": "Column 'formulary_drug_cd' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/formulary_drug_cd/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1705,7 +1627,6 @@
           "description": "Column 'gsn' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/gsn/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1721,7 +1642,6 @@
           "description": "Column 'ndc' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/ndc/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1737,7 +1657,6 @@
           "description": "Column 'prod_strength' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/prod_strength/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1753,7 +1672,6 @@
           "description": "Column 'form_rx' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/form_rx/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1769,7 +1687,6 @@
           "description": "Column 'dose_val_rx' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/dose_val_rx/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1785,7 +1702,6 @@
           "description": "Column 'dose_unit_rx' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/dose_unit_rx/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1801,7 +1717,6 @@
           "description": "Column 'form_val_disp' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/form_val_disp/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1817,7 +1732,6 @@
           "description": "Column 'form_unit_disp' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/form_unit_disp/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1833,7 +1747,6 @@
           "description": "Column 'doses_per_24_hrs' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "prescriptions/doses_per_24_hrs/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1849,7 +1762,6 @@
           "description": "Column 'route' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "prescriptions/route/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1873,7 +1785,6 @@
           "description": "Column 'subject_id' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drgcodes/subject_id/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1889,7 +1800,6 @@
           "description": "Column 'hadm_id' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drgcodes/hadm_id/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1905,7 +1815,6 @@
           "description": "Column 'drg_type' from drgcodes.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drgcodes/drg_type/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1921,7 +1830,6 @@
           "description": "Column 'drg_code' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drgcodes/drg_code/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1937,7 +1845,6 @@
           "description": "Column 'description' from drgcodes.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drgcodes/description/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1953,7 +1860,6 @@
           "description": "Column 'drg_severity' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drgcodes/drg_severity/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1969,7 +1875,6 @@
           "description": "Column 'drg_mortality' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drgcodes/drg_mortality/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -1993,7 +1898,6 @@
           "description": "Column 'icd_code' from d_icd_diagnoses.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_icd_diagnoses/icd_code/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2009,7 +1913,6 @@
           "description": "Column 'icd_version' from d_icd_diagnoses.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "d_icd_diagnoses/icd_version/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2025,7 +1928,6 @@
           "description": "Column 'long_title' from d_icd_diagnoses.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_icd_diagnoses/long_title/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2049,7 +1951,6 @@
           "description": "Column 'itemid' from d_labitems.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "d_labitems/itemid/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2065,7 +1966,6 @@
           "description": "Column 'label' from d_labitems.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_labitems/label/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2081,7 +1981,6 @@
           "description": "Column 'fluid' from d_labitems.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_labitems/fluid/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2097,7 +1996,6 @@
           "description": "Column 'category' from d_labitems.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_labitems/category/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2121,7 +2019,6 @@
           "description": "Column 'subject_id' from transfers.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "transfers/subject_id/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2137,7 +2034,6 @@
           "description": "Column 'hadm_id' from transfers.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "transfers/hadm_id/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2153,7 +2049,6 @@
           "description": "Column 'transfer_id' from transfers.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "transfers/transfer_id/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2169,7 +2064,6 @@
           "description": "Column 'eventtype' from transfers.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "transfers/eventtype/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2185,7 +2079,6 @@
           "description": "Column 'careunit' from transfers.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "transfers/careunit/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2201,7 +2094,6 @@
           "description": "Column 'intime' from transfers.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "transfers/intime/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2217,7 +2109,6 @@
           "description": "Column 'outtime' from transfers.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "transfers/outtime/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2241,7 +2132,6 @@
           "description": "Column 'subject_id' from admissions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissions/subject_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2257,7 +2147,6 @@
           "description": "Column 'hadm_id' from admissions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissions/hadm_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2273,7 +2162,6 @@
           "description": "Column 'admittime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "admissions/admittime/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2289,7 +2177,6 @@
           "description": "Column 'dischtime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "admissions/dischtime/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2305,7 +2192,6 @@
           "description": "Column 'deathtime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "admissions/deathtime/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2321,7 +2207,6 @@
           "description": "Column 'admission_type' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/admission_type/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2337,7 +2222,6 @@
           "description": "Column 'admit_provider_id' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/admit_provider_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2353,7 +2237,6 @@
           "description": "Column 'admission_location' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/admission_location/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2369,7 +2252,6 @@
           "description": "Column 'discharge_location' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/discharge_location/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2385,7 +2267,6 @@
           "description": "Column 'insurance' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/insurance/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2401,7 +2282,6 @@
           "description": "Column 'language' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/language/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2417,7 +2297,6 @@
           "description": "Column 'marital_status' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/marital_status/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2433,7 +2312,6 @@
           "description": "Column 'race' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "admissions/race/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2449,7 +2327,6 @@
           "description": "Column 'edregtime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "admissions/edregtime/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2465,7 +2342,6 @@
           "description": "Column 'edouttime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "admissions/edouttime/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2481,7 +2357,6 @@
           "description": "Column 'hospital_expire_flag' from admissions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "admissions/hospital_expire_flag/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2505,7 +2380,6 @@
           "description": "Column 'labevent_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "labevents/labevent_id/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2521,7 +2395,6 @@
           "description": "Column 'subject_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "labevents/subject_id/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2537,7 +2410,6 @@
           "description": "Column 'hadm_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "labevents/hadm_id/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2553,7 +2425,6 @@
           "description": "Column 'specimen_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "labevents/specimen_id/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2569,7 +2440,6 @@
           "description": "Column 'itemid' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "labevents/itemid/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2585,7 +2455,6 @@
           "description": "Column 'order_provider_id' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "labevents/order_provider_id/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2601,7 +2470,6 @@
           "description": "Column 'charttime' from labevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "labevents/charttime/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2617,7 +2485,6 @@
           "description": "Column 'storetime' from labevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "labevents/storetime/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2633,7 +2500,6 @@
           "description": "Column 'value' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "labevents/value/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2649,7 +2515,6 @@
           "description": "Column 'valuenum' from labevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "labevents/valuenum/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2665,7 +2530,6 @@
           "description": "Column 'valueuom' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "labevents/valueuom/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2681,7 +2545,6 @@
           "description": "Column 'ref_range_lower' from labevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "labevents/ref_range_lower/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2697,7 +2560,6 @@
           "description": "Column 'ref_range_upper' from labevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "labevents/ref_range_upper/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2713,7 +2575,6 @@
           "description": "Column 'flag' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "labevents/flag/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2729,7 +2590,6 @@
           "description": "Column 'priority' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "labevents/priority/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2745,7 +2605,6 @@
           "description": "Column 'comments' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "labevents/comments/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2769,7 +2628,6 @@
           "description": "Column 'subject_id' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/subject_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2785,7 +2643,6 @@
           "description": "Column 'hadm_id' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/hadm_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2801,7 +2658,6 @@
           "description": "Column 'pharmacy_id' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/pharmacy_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2817,7 +2673,6 @@
           "description": "Column 'poe_id' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/poe_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2833,7 +2688,6 @@
           "description": "Column 'starttime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "pharmacy/starttime/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2849,7 +2703,6 @@
           "description": "Column 'stoptime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "pharmacy/stoptime/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2865,7 +2718,6 @@
           "description": "Column 'medication' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/medication/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2881,7 +2733,6 @@
           "description": "Column 'proc_type' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/proc_type/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2897,7 +2748,6 @@
           "description": "Column 'status' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/status/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2913,7 +2763,6 @@
           "description": "Column 'entertime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "pharmacy/entertime/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2929,7 +2778,6 @@
           "description": "Column 'verifiedtime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "pharmacy/verifiedtime/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2945,7 +2793,6 @@
           "description": "Column 'route' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/route/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2961,7 +2808,6 @@
           "description": "Column 'frequency' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/frequency/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2977,7 +2823,6 @@
           "description": "Column 'disp_sched' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/disp_sched/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2993,7 +2838,6 @@
           "description": "Column 'infusion_type' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/infusion_type/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3009,7 +2853,6 @@
           "description": "Column 'sliding_scale' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/sliding_scale/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3025,7 +2868,6 @@
           "description": "Column 'lockout_interval' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/lockout_interval/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3041,7 +2883,6 @@
           "description": "Column 'basal_rate' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/basal_rate/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3057,7 +2898,6 @@
           "description": "Column 'one_hr_max' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/one_hr_max/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3073,7 +2913,6 @@
           "description": "Column 'doses_per_24_hrs' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/doses_per_24_hrs/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3089,7 +2928,6 @@
           "description": "Column 'duration' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/duration/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3105,7 +2943,6 @@
           "description": "Column 'duration_interval' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/duration_interval/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3121,7 +2958,6 @@
           "description": "Column 'expiration_value' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "pharmacy/expiration_value/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3137,7 +2973,6 @@
           "description": "Column 'expiration_unit' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/expiration_unit/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3153,7 +2988,6 @@
           "description": "Column 'expirationdate' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/expirationdate/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3169,7 +3003,6 @@
           "description": "Column 'dispensation' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/dispensation/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3185,7 +3018,6 @@
           "description": "Column 'fill_quantity' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "pharmacy/fill_quantity/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3209,7 +3041,6 @@
           "description": "Column 'subject_id' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedures_icd/subject_id/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3225,7 +3056,6 @@
           "description": "Column 'hadm_id' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedures_icd/hadm_id/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3241,7 +3071,6 @@
           "description": "Column 'seq_num' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedures_icd/seq_num/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3257,7 +3086,6 @@
           "description": "Column 'chartdate' from procedures_icd.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "procedures_icd/chartdate/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3273,7 +3101,6 @@
           "description": "Column 'icd_code' from procedures_icd.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedures_icd/icd_code/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3289,7 +3116,6 @@
           "description": "Column 'icd_version' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedures_icd/icd_version/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3313,7 +3139,6 @@
           "description": "Column 'subject_id' from hcpcsevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "hcpcsevents/subject_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3329,7 +3154,6 @@
           "description": "Column 'hadm_id' from hcpcsevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "hcpcsevents/hadm_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3345,7 +3169,6 @@
           "description": "Column 'chartdate' from hcpcsevents.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "hcpcsevents/chartdate/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3361,7 +3184,6 @@
           "description": "Column 'hcpcs_cd' from hcpcsevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "hcpcsevents/hcpcs_cd/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3377,7 +3199,6 @@
           "description": "Column 'seq_num' from hcpcsevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "hcpcsevents/seq_num/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3393,7 +3214,6 @@
           "description": "Column 'short_description' from hcpcsevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "hcpcsevents/short_description/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3417,7 +3237,6 @@
           "description": "Column 'subject_id' from services.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "services/subject_id/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3433,7 +3252,6 @@
           "description": "Column 'hadm_id' from services.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "services/hadm_id/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3449,7 +3267,6 @@
           "description": "Column 'transfertime' from services.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "services/transfertime/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3465,7 +3282,6 @@
           "description": "Column 'prev_service' from services.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "services/prev_service/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3481,7 +3297,6 @@
           "description": "Column 'curr_service' from services.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "services/curr_service/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3505,7 +3320,6 @@
           "description": "Column 'icd_code' from d_icd_procedures.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_icd_procedures/icd_code/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3521,7 +3335,6 @@
           "description": "Column 'icd_version' from d_icd_procedures.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "d_icd_procedures/icd_version/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3537,7 +3350,6 @@
           "description": "Column 'long_title' from d_icd_procedures.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_icd_procedures/long_title/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3561,7 +3373,6 @@
           "description": "Column 'subject_id' from omr.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "omr/subject_id/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3577,7 +3388,6 @@
           "description": "Column 'chartdate' from omr.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "omr/chartdate/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3593,7 +3403,6 @@
           "description": "Column 'seq_num' from omr.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "omr/seq_num/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3609,7 +3418,6 @@
           "description": "Column 'result_name' from omr.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "omr/result_name/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3625,7 +3433,6 @@
           "description": "Column 'result_value' from omr.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "omr/result_value/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3649,7 +3456,6 @@
           "description": "Column 'subject_id' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar/subject_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3665,7 +3471,6 @@
           "description": "Column 'hadm_id' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar/hadm_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3681,7 +3486,6 @@
           "description": "Column 'emar_id' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar/emar_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3697,7 +3501,6 @@
           "description": "Column 'emar_seq' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar/emar_seq/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3713,7 +3516,6 @@
           "description": "Column 'poe_id' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar/poe_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3729,7 +3531,6 @@
           "description": "Column 'pharmacy_id' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "emar/pharmacy_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3745,7 +3546,6 @@
           "description": "Column 'enter_provider_id' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar/enter_provider_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3761,7 +3561,6 @@
           "description": "Column 'charttime' from emar.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "emar/charttime/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3777,7 +3576,6 @@
           "description": "Column 'medication' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar/medication/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3793,7 +3591,6 @@
           "description": "Column 'event_txt' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "emar/event_txt/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3809,7 +3606,6 @@
           "description": "Column 'scheduletime' from emar.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "emar/scheduletime/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3825,7 +3621,6 @@
           "description": "Column 'storetime' from emar.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "emar/storetime/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -3849,7 +3644,6 @@
           "description": "Column 'microevent_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/microevent_id/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3865,7 +3659,6 @@
           "description": "Column 'subject_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/subject_id/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3881,7 +3674,6 @@
           "description": "Column 'hadm_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/hadm_id/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3897,7 +3689,6 @@
           "description": "Column 'micro_specimen_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/micro_specimen_id/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3913,7 +3704,6 @@
           "description": "Column 'order_provider_id' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/order_provider_id/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3929,7 +3719,6 @@
           "description": "Column 'chartdate' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "microbiologyevents/chartdate/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3945,7 +3734,6 @@
           "description": "Column 'charttime' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "microbiologyevents/charttime/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3961,7 +3749,6 @@
           "description": "Column 'spec_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/spec_itemid/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3977,7 +3764,6 @@
           "description": "Column 'spec_type_desc' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/spec_type_desc/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -3993,7 +3779,6 @@
           "description": "Column 'test_seq' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/test_seq/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4009,7 +3794,6 @@
           "description": "Column 'storedate' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "microbiologyevents/storedate/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4025,7 +3809,6 @@
           "description": "Column 'storetime' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "microbiologyevents/storetime/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4041,7 +3824,6 @@
           "description": "Column 'test_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/test_itemid/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4057,7 +3839,6 @@
           "description": "Column 'test_name' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/test_name/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4073,7 +3854,6 @@
           "description": "Column 'org_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/org_itemid/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4089,7 +3869,6 @@
           "description": "Column 'org_name' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/org_name/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4105,7 +3884,6 @@
           "description": "Column 'isolate_num' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/isolate_num/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4121,7 +3899,6 @@
           "description": "Column 'quantity' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/quantity/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4137,7 +3914,6 @@
           "description": "Column 'ab_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "microbiologyevents/ab_itemid/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4153,7 +3929,6 @@
           "description": "Column 'ab_name' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/ab_name/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4169,7 +3944,6 @@
           "description": "Column 'dilution_text' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/dilution_text/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4185,7 +3959,6 @@
           "description": "Column 'dilution_comparison' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/dilution_comparison/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4201,7 +3974,6 @@
           "description": "Column 'dilution_value' from microbiologyevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "microbiologyevents/dilution_value/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4217,7 +3989,6 @@
           "description": "Column 'interpretation' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/interpretation/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4233,7 +4004,6 @@
           "description": "Column 'comments' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "microbiologyevents/comments/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4257,7 +4027,6 @@
           "description": "Column 'subject_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "datetimeevents/subject_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4273,7 +4042,6 @@
           "description": "Column 'hadm_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "datetimeevents/hadm_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4289,7 +4057,6 @@
           "description": "Column 'stay_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "datetimeevents/stay_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4305,7 +4072,6 @@
           "description": "Column 'caregiver_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "datetimeevents/caregiver_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4321,7 +4087,6 @@
           "description": "Column 'charttime' from datetimeevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "datetimeevents/charttime/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4337,7 +4102,6 @@
           "description": "Column 'storetime' from datetimeevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "datetimeevents/storetime/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4353,7 +4117,6 @@
           "description": "Column 'itemid' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "datetimeevents/itemid/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4369,7 +4132,6 @@
           "description": "Column 'value' from datetimeevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "datetimeevents/value/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4385,7 +4147,6 @@
           "description": "Column 'valueuom' from datetimeevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "datetimeevents/valueuom/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4401,7 +4162,6 @@
           "description": "Column 'warning' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "datetimeevents/warning/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4425,7 +4185,6 @@
           "description": "Column 'caregiver_id' from caregiver.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "caregiver/caregiver_id/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4449,7 +4208,6 @@
           "description": "Column 'subject_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/subject_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4465,7 +4223,6 @@
           "description": "Column 'hadm_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/hadm_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4481,7 +4238,6 @@
           "description": "Column 'stay_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/stay_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4497,7 +4253,6 @@
           "description": "Column 'caregiver_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/caregiver_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4513,7 +4268,6 @@
           "description": "Column 'starttime' from ingredientevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "ingredientevents/starttime/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4529,7 +4283,6 @@
           "description": "Column 'endtime' from ingredientevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "ingredientevents/endtime/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4545,7 +4298,6 @@
           "description": "Column 'storetime' from ingredientevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "ingredientevents/storetime/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4561,7 +4313,6 @@
           "description": "Column 'itemid' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/itemid/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4577,7 +4328,6 @@
           "description": "Column 'amount' from ingredientevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "ingredientevents/amount/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4593,7 +4343,6 @@
           "description": "Column 'amountuom' from ingredientevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "ingredientevents/amountuom/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4609,7 +4358,6 @@
           "description": "Column 'rate' from ingredientevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "ingredientevents/rate/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4625,7 +4373,6 @@
           "description": "Column 'rateuom' from ingredientevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "ingredientevents/rateuom/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4641,7 +4388,6 @@
           "description": "Column 'orderid' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/orderid/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4657,7 +4403,6 @@
           "description": "Column 'linkorderid' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/linkorderid/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4673,7 +4418,6 @@
           "description": "Column 'statusdescription' from ingredientevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "ingredientevents/statusdescription/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4689,7 +4433,6 @@
           "description": "Column 'originalamount' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "ingredientevents/originalamount/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4705,7 +4448,6 @@
           "description": "Column 'originalrate' from ingredientevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "ingredientevents/originalrate/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4729,7 +4471,6 @@
           "description": "Column 'subject_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/subject_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4745,7 +4486,6 @@
           "description": "Column 'hadm_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/hadm_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4761,7 +4501,6 @@
           "description": "Column 'stay_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/stay_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4777,7 +4516,6 @@
           "description": "Column 'caregiver_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/caregiver_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4793,7 +4531,6 @@
           "description": "Column 'starttime' from inputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "inputevents/starttime/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4809,7 +4546,6 @@
           "description": "Column 'endtime' from inputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "inputevents/endtime/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4825,7 +4561,6 @@
           "description": "Column 'storetime' from inputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "inputevents/storetime/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4841,7 +4576,6 @@
           "description": "Column 'itemid' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/itemid/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4857,7 +4591,6 @@
           "description": "Column 'amount' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "inputevents/amount/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4873,7 +4606,6 @@
           "description": "Column 'amountuom' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/amountuom/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4889,7 +4621,6 @@
           "description": "Column 'rate' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "inputevents/rate/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4905,7 +4636,6 @@
           "description": "Column 'rateuom' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/rateuom/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4921,7 +4651,6 @@
           "description": "Column 'orderid' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/orderid/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4937,7 +4666,6 @@
           "description": "Column 'linkorderid' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/linkorderid/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4953,7 +4681,6 @@
           "description": "Column 'ordercategoryname' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/ordercategoryname/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4969,7 +4696,6 @@
           "description": "Column 'secondaryordercategoryname' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/secondaryordercategoryname/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -4985,7 +4711,6 @@
           "description": "Column 'ordercomponenttypedescription' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/ordercomponenttypedescription/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5001,7 +4726,6 @@
           "description": "Column 'ordercategorydescription' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/ordercategorydescription/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5017,7 +4741,6 @@
           "description": "Column 'patientweight' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "inputevents/patientweight/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5033,7 +4756,6 @@
           "description": "Column 'totalamount' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/totalamount/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5049,7 +4771,6 @@
           "description": "Column 'totalamountuom' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/totalamountuom/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5065,7 +4786,6 @@
           "description": "Column 'isopenbag' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/isopenbag/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5081,7 +4801,6 @@
           "description": "Column 'continueinnextdept' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "inputevents/continueinnextdept/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5097,7 +4816,6 @@
           "description": "Column 'statusdescription' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "inputevents/statusdescription/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5113,7 +4831,6 @@
           "description": "Column 'originalamount' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "inputevents/originalamount/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5129,7 +4846,6 @@
           "description": "Column 'originalrate' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "inputevents/originalrate/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5153,7 +4869,6 @@
           "description": "Column 'subject_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/subject_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5169,7 +4884,6 @@
           "description": "Column 'hadm_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/hadm_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5185,7 +4899,6 @@
           "description": "Column 'stay_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/stay_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5201,7 +4914,6 @@
           "description": "Column 'caregiver_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/caregiver_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5217,7 +4929,6 @@
           "description": "Column 'starttime' from procedureevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "procedureevents/starttime/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5233,7 +4944,6 @@
           "description": "Column 'endtime' from procedureevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "procedureevents/endtime/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5249,7 +4959,6 @@
           "description": "Column 'storetime' from procedureevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "procedureevents/storetime/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5265,7 +4974,6 @@
           "description": "Column 'itemid' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/itemid/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5281,7 +4989,6 @@
           "description": "Column 'value' from procedureevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "procedureevents/value/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5297,7 +5004,6 @@
           "description": "Column 'valueuom' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedureevents/valueuom/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5313,7 +5019,6 @@
           "description": "Column 'location' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedureevents/location/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5329,7 +5034,6 @@
           "description": "Column 'locationcategory' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedureevents/locationcategory/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5345,7 +5049,6 @@
           "description": "Column 'orderid' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/orderid/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5361,7 +5064,6 @@
           "description": "Column 'linkorderid' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/linkorderid/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5377,7 +5079,6 @@
           "description": "Column 'ordercategoryname' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedureevents/ordercategoryname/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5393,7 +5094,6 @@
           "description": "Column 'ordercategorydescription' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedureevents/ordercategorydescription/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5409,7 +5109,6 @@
           "description": "Column 'patientweight' from procedureevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "procedureevents/patientweight/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5425,7 +5124,6 @@
           "description": "Column 'isopenbag' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/isopenbag/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5441,7 +5139,6 @@
           "description": "Column 'continueinnextdept' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/continueinnextdept/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5457,7 +5154,6 @@
           "description": "Column 'statusdescription' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedureevents/statusdescription/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5473,7 +5169,6 @@
           "description": "Column 'ORIGINALAMOUNT' from procedureevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "procedureevents/ORIGINALAMOUNT/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5489,7 +5184,6 @@
           "description": "Column 'ORIGINALRATE' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedureevents/ORIGINALRATE/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5513,7 +5207,6 @@
           "description": "Column 'itemid' from d_items.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "d_items/itemid/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5529,7 +5222,6 @@
           "description": "Column 'label' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_items/label/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5545,7 +5237,6 @@
           "description": "Column 'abbreviation' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_items/abbreviation/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5561,7 +5252,6 @@
           "description": "Column 'linksto' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_items/linksto/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5577,7 +5267,6 @@
           "description": "Column 'category' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_items/category/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5593,7 +5282,6 @@
           "description": "Column 'unitname' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_items/unitname/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5609,7 +5297,6 @@
           "description": "Column 'param_type' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "d_items/param_type/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5625,7 +5312,6 @@
           "description": "Column 'lownormalvalue' from d_items.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "d_items/lownormalvalue/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5641,7 +5327,6 @@
           "description": "Column 'highnormalvalue' from d_items.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "d_items/highnormalvalue/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5665,7 +5350,6 @@
           "description": "Column 'subject_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "chartevents/subject_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5681,7 +5365,6 @@
           "description": "Column 'hadm_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "chartevents/hadm_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5697,7 +5380,6 @@
           "description": "Column 'stay_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "chartevents/stay_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5713,7 +5395,6 @@
           "description": "Column 'caregiver_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "chartevents/caregiver_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5729,7 +5410,6 @@
           "description": "Column 'charttime' from chartevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "chartevents/charttime/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5745,7 +5425,6 @@
           "description": "Column 'storetime' from chartevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "chartevents/storetime/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5761,7 +5440,6 @@
           "description": "Column 'itemid' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "chartevents/itemid/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5777,7 +5455,6 @@
           "description": "Column 'value' from chartevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "chartevents/value/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5793,7 +5470,6 @@
           "description": "Column 'valuenum' from chartevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "chartevents/valuenum/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5809,7 +5485,6 @@
           "description": "Column 'valueuom' from chartevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "chartevents/valueuom/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5825,7 +5500,6 @@
           "description": "Column 'warning' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "chartevents/warning/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5849,7 +5523,6 @@
           "description": "Column 'subject_id' from icustays.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "icustays/subject_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5865,7 +5538,6 @@
           "description": "Column 'hadm_id' from icustays.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "icustays/hadm_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5881,7 +5553,6 @@
           "description": "Column 'stay_id' from icustays.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "icustays/stay_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5897,7 +5568,6 @@
           "description": "Column 'first_careunit' from icustays.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "icustays/first_careunit/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5913,7 +5583,6 @@
           "description": "Column 'last_careunit' from icustays.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "icustays/last_careunit/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5929,7 +5598,6 @@
           "description": "Column 'intime' from icustays.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "icustays/intime/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5945,7 +5613,6 @@
           "description": "Column 'outtime' from icustays.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "icustays/outtime/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5961,7 +5628,6 @@
           "description": "Column 'los' from icustays.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "icustays/los/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -5985,7 +5651,6 @@
           "description": "Column 'subject_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "outputevents/subject_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6001,7 +5666,6 @@
           "description": "Column 'hadm_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "outputevents/hadm_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6017,7 +5681,6 @@
           "description": "Column 'stay_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "outputevents/stay_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6033,7 +5696,6 @@
           "description": "Column 'caregiver_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "outputevents/caregiver_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6049,7 +5711,6 @@
           "description": "Column 'charttime' from outputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "outputevents/charttime/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6065,7 +5726,6 @@
           "description": "Column 'storetime' from outputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "outputevents/storetime/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6081,7 +5741,6 @@
           "description": "Column 'itemid' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "outputevents/itemid/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6097,7 +5756,6 @@
           "description": "Column 'value' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "outputevents/value/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6113,7 +5771,6 @@
           "description": "Column 'valueuom' from outputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "outputevents/valueuom/source",
             "fileObject": {
               "@id": "file_31"
             },

--- a/tests/data/output/mimiciv_demo_meds_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_meds_croissant.jsonld
@@ -107,7 +107,6 @@
           "description": "Column 'subject_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/subject_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -123,7 +122,6 @@
           "description": "Column 'time'",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "held_out/time/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -139,7 +137,6 @@
           "description": "Column 'code'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/code/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -155,7 +152,6 @@
           "description": "Column 'numeric_value'",
           "dataType": "cr:Float32",
           "source": {
-            "@id": "held_out/numeric_value/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -171,7 +167,6 @@
           "description": "Column 'insurance'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/insurance/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -187,7 +182,6 @@
           "description": "Column 'language'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/language/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -203,7 +197,6 @@
           "description": "Column 'marital_status'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/marital_status/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -219,7 +212,6 @@
           "description": "Column 'race'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/race/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -235,7 +227,6 @@
           "description": "Column 'hadm_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/hadm_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -251,7 +242,6 @@
           "description": "Column 'drg_severity'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/drg_severity/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -267,7 +257,6 @@
           "description": "Column 'drg_mortality'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/drg_mortality/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -283,7 +272,6 @@
           "description": "Column 'emar_id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/emar_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -299,7 +287,6 @@
           "description": "Column 'emar_seq'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/emar_seq/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -315,7 +302,6 @@
           "description": "Column 'text_value'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/text_value/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -331,7 +317,6 @@
           "description": "Column 'priority'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/priority/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -347,7 +332,6 @@
           "description": "Column 'route'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/route/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -363,7 +347,6 @@
           "description": "Column 'frequency'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/frequency/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -379,7 +362,6 @@
           "description": "Column 'doses_per_24_hrs'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/doses_per_24_hrs/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -395,7 +377,6 @@
           "description": "Column 'poe_id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/poe_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -411,7 +392,6 @@
           "description": "Column 'icustay_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/icustay_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -427,7 +407,6 @@
           "description": "Column 'order_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/order_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -443,7 +422,6 @@
           "description": "Column 'link_order_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "held_out/link_order_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -459,7 +437,6 @@
           "description": "Column 'unit'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/unit/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -475,7 +452,6 @@
           "description": "Column 'ordercategorydescription'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/ordercategorydescription/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -491,7 +467,6 @@
           "description": "Column 'statusdescription'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "held_out/statusdescription/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -515,7 +490,6 @@
           "description": "Column 'subject_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/subject_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -531,7 +505,6 @@
           "description": "Column 'time'",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "train/time/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -547,7 +520,6 @@
           "description": "Column 'code'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/code/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -563,7 +535,6 @@
           "description": "Column 'numeric_value'",
           "dataType": "cr:Float32",
           "source": {
-            "@id": "train/numeric_value/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -579,7 +550,6 @@
           "description": "Column 'insurance'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/insurance/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -595,7 +565,6 @@
           "description": "Column 'language'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/language/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -611,7 +580,6 @@
           "description": "Column 'marital_status'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/marital_status/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -627,7 +595,6 @@
           "description": "Column 'race'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/race/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -643,7 +610,6 @@
           "description": "Column 'hadm_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/hadm_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -659,7 +625,6 @@
           "description": "Column 'drg_severity'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/drg_severity/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -675,7 +640,6 @@
           "description": "Column 'drg_mortality'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/drg_mortality/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -691,7 +655,6 @@
           "description": "Column 'emar_id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/emar_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -707,7 +670,6 @@
           "description": "Column 'emar_seq'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/emar_seq/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -723,7 +685,6 @@
           "description": "Column 'text_value'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/text_value/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -739,7 +700,6 @@
           "description": "Column 'priority'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/priority/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -755,7 +715,6 @@
           "description": "Column 'route'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/route/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -771,7 +730,6 @@
           "description": "Column 'frequency'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/frequency/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -787,7 +745,6 @@
           "description": "Column 'doses_per_24_hrs'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/doses_per_24_hrs/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -803,7 +760,6 @@
           "description": "Column 'poe_id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/poe_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -819,7 +775,6 @@
           "description": "Column 'icustay_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/icustay_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -835,7 +790,6 @@
           "description": "Column 'order_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/order_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -851,7 +805,6 @@
           "description": "Column 'link_order_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "train/link_order_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -867,7 +820,6 @@
           "description": "Column 'unit'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/unit/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -883,7 +835,6 @@
           "description": "Column 'ordercategorydescription'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/ordercategorydescription/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -899,7 +850,6 @@
           "description": "Column 'statusdescription'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "train/statusdescription/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -923,7 +873,6 @@
           "description": "Column 'subject_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/subject_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -939,7 +888,6 @@
           "description": "Column 'time'",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "tuning/time/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -955,7 +903,6 @@
           "description": "Column 'code'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/code/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -971,7 +918,6 @@
           "description": "Column 'numeric_value'",
           "dataType": "cr:Float32",
           "source": {
-            "@id": "tuning/numeric_value/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -987,7 +933,6 @@
           "description": "Column 'insurance'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/insurance/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1003,7 +948,6 @@
           "description": "Column 'language'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/language/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1019,7 +963,6 @@
           "description": "Column 'marital_status'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/marital_status/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1035,7 +978,6 @@
           "description": "Column 'race'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/race/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1051,7 +993,6 @@
           "description": "Column 'hadm_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/hadm_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1067,7 +1008,6 @@
           "description": "Column 'drg_severity'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/drg_severity/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1083,7 +1023,6 @@
           "description": "Column 'drg_mortality'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/drg_mortality/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1099,7 +1038,6 @@
           "description": "Column 'emar_id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/emar_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1115,7 +1053,6 @@
           "description": "Column 'emar_seq'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/emar_seq/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1131,7 +1068,6 @@
           "description": "Column 'text_value'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/text_value/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1147,7 +1083,6 @@
           "description": "Column 'priority'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/priority/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1163,7 +1098,6 @@
           "description": "Column 'route'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/route/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1179,7 +1113,6 @@
           "description": "Column 'frequency'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/frequency/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1195,7 +1128,6 @@
           "description": "Column 'doses_per_24_hrs'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/doses_per_24_hrs/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1211,7 +1143,6 @@
           "description": "Column 'poe_id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/poe_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1227,7 +1158,6 @@
           "description": "Column 'icustay_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/icustay_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1243,7 +1173,6 @@
           "description": "Column 'order_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/order_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1259,7 +1188,6 @@
           "description": "Column 'link_order_id'",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "tuning/link_order_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1275,7 +1203,6 @@
           "description": "Column 'unit'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/unit/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1291,7 +1218,6 @@
           "description": "Column 'ordercategorydescription'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/ordercategorydescription/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -1307,7 +1233,6 @@
           "description": "Column 'statusdescription'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "tuning/statusdescription/source",
             "fileObject": {
               "@id": "file_2"
             },

--- a/tests/data/output/mimiciv_demo_omop_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_omop_croissant.jsonld
@@ -372,7 +372,6 @@
           "description": "Column 'provider_id' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/provider_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -388,7 +387,6 @@
           "description": "Column 'provider_name' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/provider_name/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -404,7 +402,6 @@
           "description": "Column 'npi' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/npi/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -420,7 +417,6 @@
           "description": "Column 'dea' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/dea/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -436,7 +432,6 @@
           "description": "Column 'specialty_concept_id' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/specialty_concept_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -452,7 +447,6 @@
           "description": "Column 'care_site_id' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/care_site_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -468,7 +462,6 @@
           "description": "Column 'year_of_birth' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/year_of_birth/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -484,7 +477,6 @@
           "description": "Column 'gender_concept_id' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/gender_concept_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -500,7 +492,6 @@
           "description": "Column 'provider_source_value' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/provider_source_value/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -516,7 +507,6 @@
           "description": "Column 'specialty_source_value' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/specialty_source_value/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -532,7 +522,6 @@
           "description": "Column 'specialty_source_concept_id' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/specialty_source_concept_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -548,7 +537,6 @@
           "description": "Column 'gender_source_value' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/gender_source_value/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -564,7 +552,6 @@
           "description": "Column 'gender_source_concept_id' from provider.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "provider/gender_source_concept_id/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -588,7 +575,6 @@
           "description": "Column 'vocabulary_id' from 2b_vocabulary.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_vocabulary/vocabulary_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -604,7 +590,6 @@
           "description": "Column 'vocabulary_name' from 2b_vocabulary.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_vocabulary/vocabulary_name/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -620,7 +605,6 @@
           "description": "Column 'vocabulary_reference' from 2b_vocabulary.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_vocabulary/vocabulary_reference/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -636,7 +620,6 @@
           "description": "Column 'vocabulary_version' from 2b_vocabulary.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_vocabulary/vocabulary_version/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -652,7 +635,6 @@
           "description": "Column 'vocabulary_concept_id' from 2b_vocabulary.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "2b_vocabulary/vocabulary_concept_id/source",
             "fileObject": {
               "@id": "file_1"
             },
@@ -676,7 +658,6 @@
           "description": "Column 'observation_period_id' from observation_period.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation_period/observation_period_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -692,7 +673,6 @@
           "description": "Column 'person_id' from observation_period.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation_period/person_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -708,7 +688,6 @@
           "description": "Column 'observation_period_start_date' from observation_period.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "observation_period/observation_period_start_date/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -724,7 +703,6 @@
           "description": "Column 'observation_period_end_date' from observation_period.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "observation_period/observation_period_end_date/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -740,7 +718,6 @@
           "description": "Column 'period_type_concept_id' from observation_period.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation_period/period_type_concept_id/source",
             "fileObject": {
               "@id": "file_2"
             },
@@ -764,7 +741,6 @@
           "description": "Column 'drug_exposure_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/drug_exposure_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -780,7 +756,6 @@
           "description": "Column 'person_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/person_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -796,7 +771,6 @@
           "description": "Column 'drug_concept_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/drug_concept_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -812,7 +786,6 @@
           "description": "Column 'drug_exposure_start_date' from drug_exposure.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "drug_exposure/drug_exposure_start_date/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -828,7 +801,6 @@
           "description": "Column 'drug_exposure_start_datetime' from drug_exposure.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "drug_exposure/drug_exposure_start_datetime/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -844,7 +816,6 @@
           "description": "Column 'drug_exposure_end_date' from drug_exposure.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "drug_exposure/drug_exposure_end_date/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -860,7 +831,6 @@
           "description": "Column 'drug_exposure_end_datetime' from drug_exposure.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "drug_exposure/drug_exposure_end_datetime/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -876,7 +846,6 @@
           "description": "Column 'verbatim_end_date' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/verbatim_end_date/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -892,7 +861,6 @@
           "description": "Column 'drug_type_concept_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/drug_type_concept_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -908,7 +876,6 @@
           "description": "Column 'stop_reason' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/stop_reason/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -924,7 +891,6 @@
           "description": "Column 'refills' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/refills/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -940,7 +906,6 @@
           "description": "Column 'quantity' from drug_exposure.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "drug_exposure/quantity/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -956,7 +921,6 @@
           "description": "Column 'days_supply' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/days_supply/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -972,7 +936,6 @@
           "description": "Column 'sig' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/sig/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -988,7 +951,6 @@
           "description": "Column 'route_concept_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/route_concept_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1004,7 +966,6 @@
           "description": "Column 'lot_number' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/lot_number/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1020,7 +981,6 @@
           "description": "Column 'provider_id' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/provider_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1036,7 +996,6 @@
           "description": "Column 'visit_occurrence_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1052,7 +1011,6 @@
           "description": "Column 'visit_detail_id' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/visit_detail_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1068,7 +1026,6 @@
           "description": "Column 'drug_source_value' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/drug_source_value/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1084,7 +1041,6 @@
           "description": "Column 'drug_source_concept_id' from drug_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_exposure/drug_source_concept_id/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1100,7 +1056,6 @@
           "description": "Column 'route_source_value' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/route_source_value/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1116,7 +1071,6 @@
           "description": "Column 'dose_unit_source_value' from drug_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_exposure/dose_unit_source_value/source",
             "fileObject": {
               "@id": "file_3"
             },
@@ -1140,7 +1094,6 @@
           "description": "Column 'care_site_id' from care_site.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "care_site/care_site_id/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1156,7 +1109,6 @@
           "description": "Column 'care_site_name' from care_site.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "care_site/care_site_name/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1172,7 +1124,6 @@
           "description": "Column 'place_of_service_concept_id' from care_site.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "care_site/place_of_service_concept_id/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1188,7 +1139,6 @@
           "description": "Column 'location_id' from care_site.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "care_site/location_id/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1204,7 +1154,6 @@
           "description": "Column 'care_site_source_value' from care_site.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "care_site/care_site_source_value/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1220,7 +1169,6 @@
           "description": "Column 'place_of_service_source_value' from care_site.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "care_site/place_of_service_source_value/source",
             "fileObject": {
               "@id": "file_4"
             },
@@ -1244,7 +1192,6 @@
           "description": "Column 'concept_id' from 2b_concept.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "2b_concept/concept_id/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1260,7 +1207,6 @@
           "description": "Column 'concept_name' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/concept_name/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1276,7 +1222,6 @@
           "description": "Column 'domain_id' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/domain_id/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1292,7 +1237,6 @@
           "description": "Column 'vocabulary_id' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/vocabulary_id/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1308,7 +1252,6 @@
           "description": "Column 'concept_class_id' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/concept_class_id/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1324,7 +1267,6 @@
           "description": "Column 'standard_concept' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/standard_concept/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1340,7 +1282,6 @@
           "description": "Column 'concept_code' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/concept_code/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1356,7 +1297,6 @@
           "description": "Column 'valid_start_DATE' from 2b_concept.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "2b_concept/valid_start_DATE/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1372,7 +1312,6 @@
           "description": "Column 'valid_end_DATE' from 2b_concept.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "2b_concept/valid_end_DATE/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1388,7 +1327,6 @@
           "description": "Column 'invalid_reason' from 2b_concept.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept/invalid_reason/source",
             "fileObject": {
               "@id": "file_5"
             },
@@ -1412,7 +1350,6 @@
           "description": "Column 'cohort_definition_id' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/cohort_definition_id/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1428,7 +1365,6 @@
           "description": "Column 'cohort_definition_name' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/cohort_definition_name/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1444,7 +1380,6 @@
           "description": "Column 'cohort_definition_description' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/cohort_definition_description/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1460,7 +1395,6 @@
           "description": "Column 'definition_type_concept_id' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/definition_type_concept_id/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1476,7 +1410,6 @@
           "description": "Column 'cohort_definition_syntax' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/cohort_definition_syntax/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1492,7 +1425,6 @@
           "description": "Column 'subject_concept_id' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/subject_concept_id/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1508,7 +1440,6 @@
           "description": "Column 'cohort_initiation_date' from cohort_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_definition/cohort_initiation_date/source",
             "fileObject": {
               "@id": "file_6"
             },
@@ -1532,7 +1463,6 @@
           "description": "Column 'cost_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/cost_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1548,7 +1478,6 @@
           "description": "Column 'cost_event_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/cost_event_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1564,7 +1493,6 @@
           "description": "Column 'cost_domain_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/cost_domain_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1580,7 +1508,6 @@
           "description": "Column 'cost_type_concept_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/cost_type_concept_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1596,7 +1523,6 @@
           "description": "Column 'currency_concept_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/currency_concept_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1612,7 +1538,6 @@
           "description": "Column 'total_charge' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/total_charge/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1628,7 +1553,6 @@
           "description": "Column 'total_cost' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/total_cost/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1644,7 +1568,6 @@
           "description": "Column 'total_paid' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/total_paid/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1660,7 +1583,6 @@
           "description": "Column 'paid_by_payer' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_by_payer/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1676,7 +1598,6 @@
           "description": "Column 'paid_by_patient' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_by_patient/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1692,7 +1613,6 @@
           "description": "Column 'paid_patient_copay' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_patient_copay/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1708,7 +1628,6 @@
           "description": "Column 'paid_patient_coinsurance' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_patient_coinsurance/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1724,7 +1643,6 @@
           "description": "Column 'paid_patient_deductible' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_patient_deductible/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1740,7 +1658,6 @@
           "description": "Column 'paid_by_primary' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_by_primary/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1756,7 +1673,6 @@
           "description": "Column 'paid_ingredient_cost' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_ingredient_cost/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1772,7 +1688,6 @@
           "description": "Column 'paid_dispensing_fee' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/paid_dispensing_fee/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1788,7 +1703,6 @@
           "description": "Column 'payer_plan_period_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/payer_plan_period_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1804,7 +1718,6 @@
           "description": "Column 'amount_allowed' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/amount_allowed/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1820,7 +1733,6 @@
           "description": "Column 'revenue_code_concept_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/revenue_code_concept_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1836,7 +1748,6 @@
           "description": "Column 'revenue_code_source_value' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/revenue_code_source_value/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1852,7 +1763,6 @@
           "description": "Column 'drg_concept_id' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/drg_concept_id/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1868,7 +1778,6 @@
           "description": "Column 'drg_source_value' from cost.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cost/drg_source_value/source",
             "fileObject": {
               "@id": "file_7"
             },
@@ -1892,7 +1801,6 @@
           "description": "Column 'specimen_id' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/specimen_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1908,7 +1816,6 @@
           "description": "Column 'person_id' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/person_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1924,7 +1831,6 @@
           "description": "Column 'specimen_concept_id' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/specimen_concept_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1940,7 +1846,6 @@
           "description": "Column 'specimen_type_concept_id' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/specimen_type_concept_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1956,7 +1861,6 @@
           "description": "Column 'specimen_date' from specimen.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "specimen/specimen_date/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1972,7 +1876,6 @@
           "description": "Column 'specimen_datetime' from specimen.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "specimen/specimen_datetime/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -1988,7 +1891,6 @@
           "description": "Column 'quantity' from specimen.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "specimen/quantity/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2004,7 +1906,6 @@
           "description": "Column 'unit_concept_id' from specimen.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "specimen/unit_concept_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2020,7 +1921,6 @@
           "description": "Column 'anatomic_site_concept_id' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/anatomic_site_concept_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2036,7 +1936,6 @@
           "description": "Column 'disease_status_concept_id' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/disease_status_concept_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2052,7 +1951,6 @@
           "description": "Column 'specimen_source_id' from specimen.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "specimen/specimen_source_id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2068,7 +1966,6 @@
           "description": "Column 'specimen_source_value' from specimen.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "specimen/specimen_source_value/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2084,7 +1981,6 @@
           "description": "Column 'unit_source_value' from specimen.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "specimen/unit_source_value/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2100,7 +1996,6 @@
           "description": "Column 'anatomic_site_source_value' from specimen.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "specimen/anatomic_site_source_value/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2116,7 +2011,6 @@
           "description": "Column 'disease_status_source_value' from specimen.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "specimen/disease_status_source_value/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -2140,7 +2034,6 @@
           "description": "Column 'person_id' from death.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "death/person_id/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2156,7 +2049,6 @@
           "description": "Column 'death_date' from death.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "death/death_date/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2172,7 +2064,6 @@
           "description": "Column 'death_datetime' from death.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "death/death_datetime/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2188,7 +2079,6 @@
           "description": "Column 'death_type_concept_id' from death.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "death/death_type_concept_id/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2204,7 +2094,6 @@
           "description": "Column 'cause_concept_id' from death.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "death/cause_concept_id/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2220,7 +2109,6 @@
           "description": "Column 'cause_source_value' from death.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "death/cause_source_value/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2236,7 +2124,6 @@
           "description": "Column 'cause_source_concept_id' from death.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "death/cause_source_concept_id/source",
             "fileObject": {
               "@id": "file_9"
             },
@@ -2260,7 +2147,6 @@
           "description": "Column 'device_exposure_id' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/device_exposure_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2276,7 +2162,6 @@
           "description": "Column 'person_id' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/person_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2292,7 +2177,6 @@
           "description": "Column 'device_concept_id' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/device_concept_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2308,7 +2192,6 @@
           "description": "Column 'device_exposure_start_date' from device_exposure.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "device_exposure/device_exposure_start_date/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2324,7 +2207,6 @@
           "description": "Column 'device_exposure_start_datetime' from device_exposure.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "device_exposure/device_exposure_start_datetime/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2340,7 +2222,6 @@
           "description": "Column 'device_exposure_end_date' from device_exposure.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "device_exposure/device_exposure_end_date/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2356,7 +2237,6 @@
           "description": "Column 'device_exposure_end_datetime' from device_exposure.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "device_exposure/device_exposure_end_datetime/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2372,7 +2252,6 @@
           "description": "Column 'device_type_concept_id' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/device_type_concept_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2388,7 +2267,6 @@
           "description": "Column 'unique_device_id' from device_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "device_exposure/unique_device_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2404,7 +2282,6 @@
           "description": "Column 'quantity' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/quantity/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2420,7 +2297,6 @@
           "description": "Column 'provider_id' from device_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "device_exposure/provider_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2436,7 +2312,6 @@
           "description": "Column 'visit_occurrence_id' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2452,7 +2327,6 @@
           "description": "Column 'visit_detail_id' from device_exposure.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "device_exposure/visit_detail_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2468,7 +2342,6 @@
           "description": "Column 'device_source_value' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/device_source_value/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2484,7 +2357,6 @@
           "description": "Column 'device_source_concept_id' from device_exposure.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "device_exposure/device_source_concept_id/source",
             "fileObject": {
               "@id": "file_10"
             },
@@ -2508,7 +2380,6 @@
           "description": "Column 'attribute_definition_id' from attribute_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "attribute_definition/attribute_definition_id/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2524,7 +2395,6 @@
           "description": "Column 'attribute_name' from attribute_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "attribute_definition/attribute_name/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2540,7 +2410,6 @@
           "description": "Column 'attribute_description' from attribute_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "attribute_definition/attribute_description/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2556,7 +2425,6 @@
           "description": "Column 'attribute_type_concept_id' from attribute_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "attribute_definition/attribute_type_concept_id/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2572,7 +2440,6 @@
           "description": "Column 'attribute_syntax' from attribute_definition.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "attribute_definition/attribute_syntax/source",
             "fileObject": {
               "@id": "file_11"
             },
@@ -2596,7 +2463,6 @@
           "description": "Column 'domain_concept_id_1' from fact_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "fact_relationship/domain_concept_id_1/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2612,7 +2478,6 @@
           "description": "Column 'fact_id_1' from fact_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "fact_relationship/fact_id_1/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2628,7 +2493,6 @@
           "description": "Column 'domain_concept_id_2' from fact_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "fact_relationship/domain_concept_id_2/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2644,7 +2508,6 @@
           "description": "Column 'fact_id_2' from fact_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "fact_relationship/fact_id_2/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2660,7 +2523,6 @@
           "description": "Column 'relationship_concept_id' from fact_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "fact_relationship/relationship_concept_id/source",
             "fileObject": {
               "@id": "file_12"
             },
@@ -2684,7 +2546,6 @@
           "description": "Column 'dose_era_id' from dose_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "dose_era/dose_era_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2700,7 +2561,6 @@
           "description": "Column 'person_id' from dose_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "dose_era/person_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2716,7 +2576,6 @@
           "description": "Column 'drug_concept_id' from dose_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "dose_era/drug_concept_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2732,7 +2591,6 @@
           "description": "Column 'unit_concept_id' from dose_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "dose_era/unit_concept_id/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2748,7 +2606,6 @@
           "description": "Column 'dose_value' from dose_era.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "dose_era/dose_value/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2764,7 +2621,6 @@
           "description": "Column 'dose_era_start_date' from dose_era.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "dose_era/dose_era_start_date/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2780,7 +2636,6 @@
           "description": "Column 'dose_era_end_date' from dose_era.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "dose_era/dose_era_end_date/source",
             "fileObject": {
               "@id": "file_13"
             },
@@ -2804,7 +2659,6 @@
           "description": "Column 'location_id' from location.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "location/location_id/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2820,7 +2674,6 @@
           "description": "Column 'address_1' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/address_1/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2836,7 +2689,6 @@
           "description": "Column 'address_2' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/address_2/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2852,7 +2704,6 @@
           "description": "Column 'city' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/city/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2868,7 +2719,6 @@
           "description": "Column 'state' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/state/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2884,7 +2734,6 @@
           "description": "Column 'zip' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/zip/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2900,7 +2749,6 @@
           "description": "Column 'county' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/county/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2916,7 +2764,6 @@
           "description": "Column 'location_source_value' from location.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "location/location_source_value/source",
             "fileObject": {
               "@id": "file_14"
             },
@@ -2940,7 +2787,6 @@
           "description": "Column 'measurement_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/measurement_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2956,7 +2802,6 @@
           "description": "Column 'person_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/person_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2972,7 +2817,6 @@
           "description": "Column 'measurement_concept_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/measurement_concept_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -2988,7 +2832,6 @@
           "description": "Column 'measurement_date' from measurement.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "measurement/measurement_date/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3004,7 +2847,6 @@
           "description": "Column 'measurement_datetime' from measurement.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "measurement/measurement_datetime/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3020,7 +2862,6 @@
           "description": "Column 'measurement_time' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/measurement_time/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3036,7 +2877,6 @@
           "description": "Column 'measurement_type_concept_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/measurement_type_concept_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3052,7 +2892,6 @@
           "description": "Column 'operator_concept_id' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/operator_concept_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3068,7 +2907,6 @@
           "description": "Column 'value_as_number' from measurement.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "measurement/value_as_number/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3084,7 +2922,6 @@
           "description": "Column 'value_as_concept_id' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/value_as_concept_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3100,7 +2937,6 @@
           "description": "Column 'unit_concept_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/unit_concept_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3116,7 +2952,6 @@
           "description": "Column 'range_low' from measurement.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "measurement/range_low/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3132,7 +2967,6 @@
           "description": "Column 'range_high' from measurement.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "measurement/range_high/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3148,7 +2982,6 @@
           "description": "Column 'provider_id' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/provider_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3164,7 +2997,6 @@
           "description": "Column 'visit_occurrence_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3180,7 +3012,6 @@
           "description": "Column 'visit_detail_id' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/visit_detail_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3196,7 +3027,6 @@
           "description": "Column 'measurement_source_value' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/measurement_source_value/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3212,7 +3042,6 @@
           "description": "Column 'measurement_source_concept_id' from measurement.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "measurement/measurement_source_concept_id/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3228,7 +3057,6 @@
           "description": "Column 'unit_source_value' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/unit_source_value/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3244,7 +3072,6 @@
           "description": "Column 'value_source_value' from measurement.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "measurement/value_source_value/source",
             "fileObject": {
               "@id": "file_15"
             },
@@ -3268,7 +3095,6 @@
           "description": "Column 'cohort_definition_id' from cohort.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort/cohort_definition_id/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3284,7 +3110,6 @@
           "description": "Column 'subject_id' from cohort.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort/subject_id/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3300,7 +3125,6 @@
           "description": "Column 'cohort_start_date' from cohort.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort/cohort_start_date/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3316,7 +3140,6 @@
           "description": "Column 'cohort_end_date' from cohort.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort/cohort_end_date/source",
             "fileObject": {
               "@id": "file_16"
             },
@@ -3340,7 +3163,6 @@
           "description": "Column 'note_nlp_id' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/note_nlp_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3356,7 +3178,6 @@
           "description": "Column 'note_id' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/note_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3372,7 +3193,6 @@
           "description": "Column 'section_concept_id' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/section_concept_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3388,7 +3208,6 @@
           "description": "Column 'snippet' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/snippet/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3404,7 +3223,6 @@
           "description": "Column 'offset' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/offset/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3420,7 +3238,6 @@
           "description": "Column 'lexical_variant' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/lexical_variant/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3436,7 +3253,6 @@
           "description": "Column 'note_nlp_concept_id' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/note_nlp_concept_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3452,7 +3268,6 @@
           "description": "Column 'note_nlp_source_concept_id' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/note_nlp_source_concept_id/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3468,7 +3283,6 @@
           "description": "Column 'nlp_system' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/nlp_system/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3484,7 +3298,6 @@
           "description": "Column 'nlp_date' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/nlp_date/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3500,7 +3313,6 @@
           "description": "Column 'nlp_datetime' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/nlp_datetime/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3516,7 +3328,6 @@
           "description": "Column 'term_exists' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/term_exists/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3532,7 +3343,6 @@
           "description": "Column 'term_temporal' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/term_temporal/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3548,7 +3358,6 @@
           "description": "Column 'term_modifiers' from note_nlp.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note_nlp/term_modifiers/source",
             "fileObject": {
               "@id": "file_17"
             },
@@ -3572,7 +3381,6 @@
           "description": "Column 'cohort_definition_id' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/cohort_definition_id/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3588,7 +3396,6 @@
           "description": "Column 'subject_id' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/subject_id/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3604,7 +3411,6 @@
           "description": "Column 'cohort_start_date' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/cohort_start_date/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3620,7 +3426,6 @@
           "description": "Column 'cohort_end_date' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/cohort_end_date/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3636,7 +3441,6 @@
           "description": "Column 'attribute_definition_id' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/attribute_definition_id/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3652,7 +3456,6 @@
           "description": "Column 'value_as_number' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/value_as_number/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3668,7 +3471,6 @@
           "description": "Column 'value_as_concept_id' from cohort_attribute.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cohort_attribute/value_as_concept_id/source",
             "fileObject": {
               "@id": "file_18"
             },
@@ -3692,7 +3494,6 @@
           "description": "Column 'condition_occurrence_id' from condition_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_occurrence/condition_occurrence_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3708,7 +3509,6 @@
           "description": "Column 'person_id' from condition_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_occurrence/person_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3724,7 +3524,6 @@
           "description": "Column 'condition_concept_id' from condition_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_occurrence/condition_concept_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3740,7 +3539,6 @@
           "description": "Column 'condition_start_date' from condition_occurrence.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "condition_occurrence/condition_start_date/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3756,7 +3554,6 @@
           "description": "Column 'condition_start_datetime' from condition_occurrence.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "condition_occurrence/condition_start_datetime/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3772,7 +3569,6 @@
           "description": "Column 'condition_end_date' from condition_occurrence.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "condition_occurrence/condition_end_date/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3788,7 +3584,6 @@
           "description": "Column 'condition_end_datetime' from condition_occurrence.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "condition_occurrence/condition_end_datetime/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3804,7 +3599,6 @@
           "description": "Column 'condition_type_concept_id' from condition_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_occurrence/condition_type_concept_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3820,7 +3614,6 @@
           "description": "Column 'stop_reason' from condition_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "condition_occurrence/stop_reason/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3836,7 +3629,6 @@
           "description": "Column 'provider_id' from condition_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "condition_occurrence/provider_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3852,7 +3644,6 @@
           "description": "Column 'visit_occurrence_id' from condition_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_occurrence/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3868,7 +3659,6 @@
           "description": "Column 'visit_detail_id' from condition_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "condition_occurrence/visit_detail_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3884,7 +3674,6 @@
           "description": "Column 'condition_source_value' from condition_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "condition_occurrence/condition_source_value/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3900,7 +3689,6 @@
           "description": "Column 'condition_source_concept_id' from condition_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_occurrence/condition_source_concept_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3916,7 +3704,6 @@
           "description": "Column 'condition_status_source_value' from condition_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "condition_occurrence/condition_status_source_value/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3932,7 +3719,6 @@
           "description": "Column 'condition_status_concept_id' from condition_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "condition_occurrence/condition_status_concept_id/source",
             "fileObject": {
               "@id": "file_19"
             },
@@ -3956,7 +3742,6 @@
           "description": "Column 'concept_id_1' from 2b_concept_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "2b_concept_relationship/concept_id_1/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3972,7 +3757,6 @@
           "description": "Column 'concept_id_2' from 2b_concept_relationship.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "2b_concept_relationship/concept_id_2/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -3988,7 +3772,6 @@
           "description": "Column 'relationship_id' from 2b_concept_relationship.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept_relationship/relationship_id/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4004,7 +3787,6 @@
           "description": "Column 'valid_start_DATE' from 2b_concept_relationship.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "2b_concept_relationship/valid_start_DATE/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4020,7 +3802,6 @@
           "description": "Column 'valid_end_DATE' from 2b_concept_relationship.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "2b_concept_relationship/valid_end_DATE/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4036,7 +3817,6 @@
           "description": "Column 'invalid_reason' from 2b_concept_relationship.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "2b_concept_relationship/invalid_reason/source",
             "fileObject": {
               "@id": "file_20"
             },
@@ -4060,7 +3840,6 @@
           "description": "Column 'drug_era_id' from drug_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_era/drug_era_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4076,7 +3855,6 @@
           "description": "Column 'person_id' from drug_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_era/person_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4092,7 +3870,6 @@
           "description": "Column 'drug_concept_id' from drug_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_era/drug_concept_id/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4108,7 +3885,6 @@
           "description": "Column 'drug_era_start_date' from drug_era.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "drug_era/drug_era_start_date/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4124,7 +3900,6 @@
           "description": "Column 'drug_era_end_date' from drug_era.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "drug_era/drug_era_end_date/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4140,7 +3915,6 @@
           "description": "Column 'drug_exposure_count' from drug_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_era/drug_exposure_count/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4156,7 +3930,6 @@
           "description": "Column 'gap_days' from drug_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "drug_era/gap_days/source",
             "fileObject": {
               "@id": "file_21"
             },
@@ -4180,7 +3953,6 @@
           "description": "Column 'cdm_source_name' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/cdm_source_name/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4196,7 +3968,6 @@
           "description": "Column 'cdm_source_abbreviation' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/cdm_source_abbreviation/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4212,7 +3983,6 @@
           "description": "Column 'cdm_holder' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/cdm_holder/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4228,7 +3998,6 @@
           "description": "Column 'source_description' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/source_description/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4244,7 +4013,6 @@
           "description": "Column 'source_documentation_reference' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/source_documentation_reference/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4260,7 +4028,6 @@
           "description": "Column 'cdm_etl_reference' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/cdm_etl_reference/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4276,7 +4043,6 @@
           "description": "Column 'source_release_date' from cdm_source.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "cdm_source/source_release_date/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4292,7 +4058,6 @@
           "description": "Column 'cdm_release_date' from cdm_source.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "cdm_source/cdm_release_date/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4308,7 +4073,6 @@
           "description": "Column 'cdm_version' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/cdm_version/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4324,7 +4088,6 @@
           "description": "Column 'vocabulary_version' from cdm_source.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "cdm_source/vocabulary_version/source",
             "fileObject": {
               "@id": "file_22"
             },
@@ -4348,7 +4111,6 @@
           "description": "Column 'visit_occurrence_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4364,7 +4126,6 @@
           "description": "Column 'person_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/person_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4380,7 +4141,6 @@
           "description": "Column 'visit_concept_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/visit_concept_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4396,7 +4156,6 @@
           "description": "Column 'visit_start_date' from visit_occurrence.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "visit_occurrence/visit_start_date/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4412,7 +4171,6 @@
           "description": "Column 'visit_start_datetime' from visit_occurrence.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "visit_occurrence/visit_start_datetime/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4428,7 +4186,6 @@
           "description": "Column 'visit_end_date' from visit_occurrence.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "visit_occurrence/visit_end_date/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4444,7 +4201,6 @@
           "description": "Column 'visit_end_datetime' from visit_occurrence.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "visit_occurrence/visit_end_datetime/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4460,7 +4216,6 @@
           "description": "Column 'visit_type_concept_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/visit_type_concept_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4476,7 +4231,6 @@
           "description": "Column 'provider_id' from visit_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_occurrence/provider_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4492,7 +4246,6 @@
           "description": "Column 'care_site_id' from visit_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_occurrence/care_site_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4508,7 +4261,6 @@
           "description": "Column 'visit_source_value' from visit_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_occurrence/visit_source_value/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4524,7 +4276,6 @@
           "description": "Column 'visit_source_concept_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/visit_source_concept_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4540,7 +4291,6 @@
           "description": "Column 'admitting_source_concept_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/admitting_source_concept_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4556,7 +4306,6 @@
           "description": "Column 'admitting_source_value' from visit_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_occurrence/admitting_source_value/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4572,7 +4321,6 @@
           "description": "Column 'discharge_to_concept_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/discharge_to_concept_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4588,7 +4336,6 @@
           "description": "Column 'discharge_to_source_value' from visit_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_occurrence/discharge_to_source_value/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4604,7 +4351,6 @@
           "description": "Column 'preceding_visit_occurrence_id' from visit_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_occurrence/preceding_visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_23"
             },
@@ -4628,7 +4374,6 @@
           "description": "Column 'metadata_concept_id' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/metadata_concept_id/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4644,7 +4389,6 @@
           "description": "Column 'metadata_type_concept_id' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/metadata_type_concept_id/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4660,7 +4404,6 @@
           "description": "Column 'name' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/name/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4676,7 +4419,6 @@
           "description": "Column 'value_as_string' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/value_as_string/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4692,7 +4434,6 @@
           "description": "Column 'value_as_concept_id' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/value_as_concept_id/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4708,7 +4449,6 @@
           "description": "Column 'metadata_date' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/metadata_date/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4724,7 +4464,6 @@
           "description": "Column 'metadata_datetime' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/metadata_datetime/source",
             "fileObject": {
               "@id": "file_24"
             },
@@ -4748,7 +4487,6 @@
           "description": "Column 'person_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/person_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4764,7 +4502,6 @@
           "description": "Column 'gender_concept_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/gender_concept_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4780,7 +4517,6 @@
           "description": "Column 'year_of_birth' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/year_of_birth/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4796,7 +4532,6 @@
           "description": "Column 'month_of_birth' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/month_of_birth/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4812,7 +4547,6 @@
           "description": "Column 'day_of_birth' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/day_of_birth/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4828,7 +4562,6 @@
           "description": "Column 'birth_datetime' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/birth_datetime/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4844,7 +4577,6 @@
           "description": "Column 'race_concept_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/race_concept_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4860,7 +4592,6 @@
           "description": "Column 'ethnicity_concept_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/ethnicity_concept_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4876,7 +4607,6 @@
           "description": "Column 'location_id' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/location_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4892,7 +4622,6 @@
           "description": "Column 'provider_id' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/provider_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4908,7 +4637,6 @@
           "description": "Column 'care_site_id' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/care_site_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4924,7 +4652,6 @@
           "description": "Column 'person_source_value' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/person_source_value/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4940,7 +4667,6 @@
           "description": "Column 'gender_source_value' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/gender_source_value/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4956,7 +4682,6 @@
           "description": "Column 'gender_source_concept_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/gender_source_concept_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4972,7 +4697,6 @@
           "description": "Column 'race_source_value' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/race_source_value/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -4988,7 +4712,6 @@
           "description": "Column 'race_source_concept_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/race_source_concept_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5004,7 +4727,6 @@
           "description": "Column 'ethnicity_source_value' from person.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "person/ethnicity_source_value/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5020,7 +4742,6 @@
           "description": "Column 'ethnicity_source_concept_id' from person.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "person/ethnicity_source_concept_id/source",
             "fileObject": {
               "@id": "file_25"
             },
@@ -5044,7 +4765,6 @@
           "description": "Column 'observation_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/observation_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5060,7 +4780,6 @@
           "description": "Column 'person_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/person_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5076,7 +4795,6 @@
           "description": "Column 'observation_concept_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/observation_concept_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5092,7 +4810,6 @@
           "description": "Column 'observation_date' from observation.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "observation/observation_date/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5108,7 +4825,6 @@
           "description": "Column 'observation_datetime' from observation.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "observation/observation_datetime/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5124,7 +4840,6 @@
           "description": "Column 'observation_type_concept_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/observation_type_concept_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5140,7 +4855,6 @@
           "description": "Column 'value_as_number' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/value_as_number/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5156,7 +4870,6 @@
           "description": "Column 'value_as_string' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/value_as_string/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5172,7 +4885,6 @@
           "description": "Column 'value_as_concept_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/value_as_concept_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5188,7 +4900,6 @@
           "description": "Column 'qualifier_concept_id' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/qualifier_concept_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5204,7 +4915,6 @@
           "description": "Column 'unit_concept_id' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/unit_concept_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5220,7 +4930,6 @@
           "description": "Column 'provider_id' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/provider_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5236,7 +4945,6 @@
           "description": "Column 'visit_occurrence_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5252,7 +4960,6 @@
           "description": "Column 'visit_detail_id' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/visit_detail_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5268,7 +4975,6 @@
           "description": "Column 'observation_source_value' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/observation_source_value/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5284,7 +4990,6 @@
           "description": "Column 'observation_source_concept_id' from observation.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "observation/observation_source_concept_id/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5300,7 +5005,6 @@
           "description": "Column 'unit_source_value' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/unit_source_value/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5316,7 +5020,6 @@
           "description": "Column 'qualifier_source_value' from observation.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "observation/qualifier_source_value/source",
             "fileObject": {
               "@id": "file_26"
             },
@@ -5340,7 +5043,6 @@
           "description": "Column 'visit_detail_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/visit_detail_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5356,7 +5058,6 @@
           "description": "Column 'person_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/person_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5372,7 +5073,6 @@
           "description": "Column 'visit_detail_concept_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/visit_detail_concept_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5388,7 +5088,6 @@
           "description": "Column 'visit_detail_start_date' from visit_detail.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "visit_detail/visit_detail_start_date/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5404,7 +5103,6 @@
           "description": "Column 'visit_detail_start_datetime' from visit_detail.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "visit_detail/visit_detail_start_datetime/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5420,7 +5118,6 @@
           "description": "Column 'visit_detail_end_date' from visit_detail.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "visit_detail/visit_detail_end_date/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5436,7 +5133,6 @@
           "description": "Column 'visit_detail_end_datetime' from visit_detail.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "visit_detail/visit_detail_end_datetime/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5452,7 +5148,6 @@
           "description": "Column 'visit_detail_type_concept_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/visit_detail_type_concept_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5468,7 +5163,6 @@
           "description": "Column 'provider_id' from visit_detail.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_detail/provider_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5484,7 +5178,6 @@
           "description": "Column 'care_site_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/care_site_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5500,7 +5193,6 @@
           "description": "Column 'admitting_source_concept_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/admitting_source_concept_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5516,7 +5208,6 @@
           "description": "Column 'discharge_to_concept_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/discharge_to_concept_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5532,7 +5223,6 @@
           "description": "Column 'preceding_visit_detail_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/preceding_visit_detail_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5548,7 +5238,6 @@
           "description": "Column 'visit_detail_source_value' from visit_detail.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_detail/visit_detail_source_value/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5564,7 +5253,6 @@
           "description": "Column 'visit_detail_source_concept_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/visit_detail_source_concept_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5580,7 +5268,6 @@
           "description": "Column 'admitting_source_value' from visit_detail.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_detail/admitting_source_value/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5596,7 +5283,6 @@
           "description": "Column 'discharge_to_source_value' from visit_detail.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_detail/discharge_to_source_value/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5612,7 +5298,6 @@
           "description": "Column 'visit_detail_parent_id' from visit_detail.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "visit_detail/visit_detail_parent_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5628,7 +5313,6 @@
           "description": "Column 'visit_occurrence_id' from visit_detail.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "visit_detail/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_27"
             },
@@ -5652,7 +5336,6 @@
           "description": "Column 'payer_plan_period_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/payer_plan_period_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5668,7 +5351,6 @@
           "description": "Column 'person_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/person_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5684,7 +5366,6 @@
           "description": "Column 'payer_plan_period_start_date' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/payer_plan_period_start_date/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5700,7 +5381,6 @@
           "description": "Column 'payer_plan_period_end_date' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/payer_plan_period_end_date/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5716,7 +5396,6 @@
           "description": "Column 'payer_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/payer_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5732,7 +5411,6 @@
           "description": "Column 'payer_source_value' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/payer_source_value/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5748,7 +5426,6 @@
           "description": "Column 'payer_source_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/payer_source_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5764,7 +5441,6 @@
           "description": "Column 'plan_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/plan_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5780,7 +5456,6 @@
           "description": "Column 'plan_source_value' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/plan_source_value/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5796,7 +5471,6 @@
           "description": "Column 'plan_source_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/plan_source_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5812,7 +5486,6 @@
           "description": "Column 'sponsor_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/sponsor_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5828,7 +5501,6 @@
           "description": "Column 'sponsor_source_value' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/sponsor_source_value/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5844,7 +5516,6 @@
           "description": "Column 'sponsor_source_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/sponsor_source_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5860,7 +5531,6 @@
           "description": "Column 'family_source_value' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/family_source_value/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5876,7 +5546,6 @@
           "description": "Column 'stop_reason_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/stop_reason_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5892,7 +5561,6 @@
           "description": "Column 'stop_reason_source_value' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/stop_reason_source_value/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5908,7 +5576,6 @@
           "description": "Column 'stop_reason_source_concept_id' from payer_plan_period.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "payer_plan_period/stop_reason_source_concept_id/source",
             "fileObject": {
               "@id": "file_28"
             },
@@ -5932,7 +5599,6 @@
           "description": "Column 'procedure_occurrence_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/procedure_occurrence_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5948,7 +5614,6 @@
           "description": "Column 'person_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/person_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5964,7 +5629,6 @@
           "description": "Column 'procedure_concept_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/procedure_concept_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5980,7 +5644,6 @@
           "description": "Column 'procedure_date' from procedure_occurrence.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "procedure_occurrence/procedure_date/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -5996,7 +5659,6 @@
           "description": "Column 'procedure_datetime' from procedure_occurrence.csv",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "procedure_occurrence/procedure_datetime/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6012,7 +5674,6 @@
           "description": "Column 'procedure_type_concept_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/procedure_type_concept_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6028,7 +5689,6 @@
           "description": "Column 'modifier_concept_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/modifier_concept_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6044,7 +5704,6 @@
           "description": "Column 'quantity' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/quantity/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6060,7 +5719,6 @@
           "description": "Column 'provider_id' from procedure_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedure_occurrence/provider_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6076,7 +5734,6 @@
           "description": "Column 'visit_occurrence_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6092,7 +5749,6 @@
           "description": "Column 'visit_detail_id' from procedure_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedure_occurrence/visit_detail_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6108,7 +5764,6 @@
           "description": "Column 'procedure_source_value' from procedure_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedure_occurrence/procedure_source_value/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6124,7 +5779,6 @@
           "description": "Column 'procedure_source_concept_id' from procedure_occurrence.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "procedure_occurrence/procedure_source_concept_id/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6140,7 +5794,6 @@
           "description": "Column 'modifier_source_value' from procedure_occurrence.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "procedure_occurrence/modifier_source_value/source",
             "fileObject": {
               "@id": "file_29"
             },
@@ -6164,7 +5817,6 @@
           "description": "Column 'note_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6180,7 +5832,6 @@
           "description": "Column 'person_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/person_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6196,7 +5847,6 @@
           "description": "Column 'note_date' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_date/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6212,7 +5862,6 @@
           "description": "Column 'note_datetime' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_datetime/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6228,7 +5877,6 @@
           "description": "Column 'note_type_concept_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_type_concept_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6244,7 +5892,6 @@
           "description": "Column 'note_class_concept_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_class_concept_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6260,7 +5907,6 @@
           "description": "Column 'note_title' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_title/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6276,7 +5922,6 @@
           "description": "Column 'note_text' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_text/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6292,7 +5937,6 @@
           "description": "Column 'encoding_concept_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/encoding_concept_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6308,7 +5952,6 @@
           "description": "Column 'language_concept_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/language_concept_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6324,7 +5967,6 @@
           "description": "Column 'provider_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/provider_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6340,7 +5982,6 @@
           "description": "Column 'visit_occurrence_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/visit_occurrence_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6356,7 +5997,6 @@
           "description": "Column 'visit_detail_id' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/visit_detail_id/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6372,7 +6012,6 @@
           "description": "Column 'note_source_value' from note.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "note/note_source_value/source",
             "fileObject": {
               "@id": "file_30"
             },
@@ -6396,7 +6035,6 @@
           "description": "Column 'condition_era_id' from condition_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_era/condition_era_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6412,7 +6050,6 @@
           "description": "Column 'person_id' from condition_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_era/person_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6428,7 +6065,6 @@
           "description": "Column 'condition_concept_id' from condition_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_era/condition_concept_id/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6444,7 +6080,6 @@
           "description": "Column 'condition_era_start_date' from condition_era.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "condition_era/condition_era_start_date/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6460,7 +6095,6 @@
           "description": "Column 'condition_era_end_date' from condition_era.csv",
           "dataType": "sc:Date",
           "source": {
-            "@id": "condition_era/condition_era_end_date/source",
             "fileObject": {
               "@id": "file_31"
             },
@@ -6476,7 +6110,6 @@
           "description": "Column 'condition_occurrence_count' from condition_era.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "condition_era/condition_occurrence_count/source",
             "fileObject": {
               "@id": "file_31"
             },

--- a/tests/data/output/mimiciv_full_croissant.jsonld
+++ b/tests/data/output/mimiciv_full_croissant.jsonld
@@ -54,7 +54,7 @@
     "@type": "sc:Person",
     "name": "MIT Lab for Computational Physiology"
   },
-  "datePublished": "2026-02-15T21:01:41.710165",
+  "datePublished": "2026-02-15T00:00:00",
   "license": "https://physionet.org/content/mimiciv/view-license/",
   "url": "https://physionet.org/content/mimiciv/",
   "version": "1.0.0",
@@ -66,7 +66,7 @@
       "contentSize": "666594177",
       "contentUrl": "hosp/poe.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "914eebd5e44bd634eb528ec36f23398ce364b8b0db5f1b83f23b0fae444c0dca"
+      "sha256": "14694845fbba96688b635f57be3e99c6d20297d5cd97f57c383e43faf73d14e4"
     },
     {
       "@type": "cr:FileObject",
@@ -75,7 +75,7 @@
       "contentSize": "427554",
       "contentUrl": "hosp/d_hcpcs.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "fb09c682021ffcfc186f175ef6798b2b096974083c4ff67dd44b26c7cce32d77"
+      "sha256": "b42943c33eb24aab94dcbc6769e09830aa4085f1293894dfcd7aa307ef0537c1"
     },
     {
       "@type": "cr:FileObject",
@@ -84,7 +84,7 @@
       "contentSize": "55267894",
       "contentUrl": "hosp/poe_detail.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "548fc355e28d9349315ac13dd0e1660a09f18cd2daf1c04833947a9d0510173d"
+      "sha256": "ff52c07911c7e030d68e62ea13f710ee1e5e8b257ea014362e55f1d7fcffbb7d"
     },
     {
       "@type": "cr:FileObject",
@@ -93,7 +93,7 @@
       "contentSize": "2835586",
       "contentUrl": "hosp/patients.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "11df8b065f89410e894ab72857c1ce5c431f6f5d675e1541f132d49122f7d756"
+      "sha256": "4c7507de7ecad8c5ba7647ea4d26018e88ff6672c5fc22ab59c2a5697d687cdd"
     },
     {
       "@type": "cr:FileObject",
@@ -102,258 +102,275 @@
       "contentSize": "33564802",
       "contentUrl": "hosp/diagnoses_icd.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "0fb9d03a4466bdb19ddc5f60360251ce22e30413af809bb4a635b929733af575"
+      "sha256": "47665a41b2a3ad990d6f314062d5bd6d29d467b0fd402dd94662044ec8b073d2"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_5",
-      "name": "emar_detail.csv.gz",
-      "contentSize": "748158322",
-      "contentUrl": "hosp/emar_detail.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "b1df4fe253b6b99e9dad45c770e4d86596713a3029dfad313335855ecd73511d"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_6",
-      "name": "provider.csv.gz",
-      "contentSize": "127330",
-      "contentUrl": "hosp/provider.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "aa022feb9cd4ba80389dc69d884d54453913e4c6dbbc8afbae045a6a78eeb20e"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_7",
-      "name": "prescriptions.csv.gz",
-      "contentSize": "606298611",
-      "contentUrl": "hosp/prescriptions.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "f7967bbf1a4aff8e37f466f675cb36b6bff0cea44faec139f572f5353e9738c0"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_8",
-      "name": "drgcodes.csv.gz",
-      "contentSize": "9743908",
-      "contentUrl": "hosp/drgcodes.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "75f1d69a87256991cdc65551b9de9dc688e4dfbc13b967a8965003382b86219d"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_9",
-      "name": "d_icd_diagnoses.csv.gz",
-      "contentSize": "876360",
-      "contentUrl": "hosp/d_icd_diagnoses.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "1ab72c732bdde3a34831740da55b9ab35bc3dc4cabb05d453d4d4174c19cd971"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_10",
-      "name": "d_labitems.csv.gz",
-      "contentSize": "13169",
-      "contentUrl": "hosp/d_labitems.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "f3182dbace857d8cd3439ebbd2095d3128c1751cb42b12e3e4208bdc4b363567"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_11",
-      "name": "transfers.csv.gz",
-      "contentSize": "46185771",
-      "contentUrl": "hosp/transfers.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "99a5d03793a18c7497203ab79a94f6afa90b2faccc1b58cd86d88945ca6be6e8"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_12",
-      "name": "admissions.csv.gz",
-      "contentSize": "19928140",
-      "contentUrl": "hosp/admissions.csv.gz",
-      "encodingFormat": "application/gzip",
-      "sha256": "9592fb5d355321801f3cb5789a20921d7394fde2ade5325832ea527318056d63"
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "file_13",
-      "name": "labevents.csv.gz",
-      "contentSize": "2592909134",
-      "contentUrl": "hosp/labevents.csv.gz",
-      "encodingFormat": "application/gzip",
+      "name": "labevents.csv",
+      "contentSize": "18402851720",
+      "contentUrl": "hosp/labevents.csv",
+      "encodingFormat": "text/csv",
       "sha256": "dc4deb75491acb09b0c589b88d36e72f6e6db7676152510d83221aa8133dff54"
     },
     {
       "@type": "cr:FileObject",
-      "@id": "file_14",
-      "name": "pharmacy.csv.gz",
-      "contentSize": "525708076",
-      "contentUrl": "hosp/pharmacy.csv.gz",
+      "@id": "file_6",
+      "name": "d_labitems.csv",
+      "contentSize": "64663",
+      "contentUrl": "hosp/d_labitems.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "f3182dbace857d8cd3439ebbd2095d3128c1751cb42b12e3e4208bdc4b363567"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_7",
+      "name": "emar_detail.csv.gz",
+      "contentSize": "748158322",
+      "contentUrl": "hosp/emar_detail.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "13550119eedf974ec635c32880bcc3d349d1f243b2f6cb1aaf7811430e0dbebc"
+      "sha256": "5af03b493ce08705b4f203c7fc44cc97fe5ca32ff607dd719368a116c82c17b4"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_8",
+      "name": "provider.csv.gz",
+      "contentSize": "127330",
+      "contentUrl": "hosp/provider.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "3320781d9e7062b80e1f411719db29b970cc7db0dfe4499dfe51d9a2f6d93477"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_9",
+      "name": "prescriptions.csv.gz",
+      "contentSize": "606298611",
+      "contentUrl": "hosp/prescriptions.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "0d8481c7d5d7c9ec2fea3fc543ddaaadb5a933cd22c7b9dda4289361e4d77199"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_10",
+      "name": "drgcodes.csv.gz",
+      "contentSize": "9743908",
+      "contentUrl": "hosp/drgcodes.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "60aceace5f1291a81441ca1004891334b89526f1a8ac7cc8bc12da632e7e6087"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_11",
+      "name": "d_icd_diagnoses.csv.gz",
+      "contentSize": "876360",
+      "contentUrl": "hosp/d_icd_diagnoses.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "a81065bf45ccf74f589bec855bbb0a07b5c014907b34ff76fe20583a2c87cc79"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_12",
+      "name": "d_labitems.csv.gz",
+      "contentSize": "13169",
+      "contentUrl": "hosp/d_labitems.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "b7afdda77b637a7afe4f2ddfcce19e6c6becad41da397e95631cc1d416de548f"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_13",
+      "name": "transfers.csv.gz",
+      "contentSize": "46185771",
+      "contentUrl": "hosp/transfers.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "4ea296ddafb4fa51d31319c1eaa330dac975e4d50ddb2ba98783c05476488db2"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_14",
+      "name": "admissions.csv.gz",
+      "contentSize": "19928140",
+      "contentUrl": "hosp/admissions.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "a9584ed88e9ed664a2f66f86a5cf9fd175c8bb0af50e3b6115598b19e978384e"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_15",
-      "name": "procedures_icd.csv.gz",
-      "contentSize": "7777324",
-      "contentUrl": "hosp/procedures_icd.csv.gz",
+      "name": "labevents.csv.gz",
+      "contentSize": "2592909134",
+      "contentUrl": "hosp/labevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "b6553bc6b15581af519dbb6228fa73905c15c2024b41b4263133c75bd6ee4f71"
+      "sha256": "2cd5e09b7e48c0189828854221f97e2e8568268eda82157c6933bf8e674d08d5"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_16",
-      "name": "hcpcsevents.csv.gz",
-      "contentSize": "2162335",
-      "contentUrl": "hosp/hcpcsevents.csv.gz",
+      "name": "pharmacy.csv.gz",
+      "contentSize": "525708076",
+      "contentUrl": "hosp/pharmacy.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "755340f1356a082b6e976ad5a76d70dc15af84240407c2951a3996a869c14443"
+      "sha256": "c9885721e4c968f0773145d7f6ba4d3cc3755d5600ee400ff95b1d3238053811"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_17",
-      "name": "services.csv.gz",
-      "contentSize": "8569241",
-      "contentUrl": "hosp/services.csv.gz",
+      "name": "procedures_icd.csv.gz",
+      "contentSize": "7777324",
+      "contentUrl": "hosp/procedures_icd.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "7daf5e7bb880812bd6d3a474c09074ffd115b2acac5011228e2fb8cb31e79b0c"
+      "sha256": "3271397d0517131f84399b698cbb0c2f435aaab0f873a3806e13b097661596f7"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_18",
-      "name": "d_icd_procedures.csv.gz",
-      "contentSize": "589186",
-      "contentUrl": "hosp/d_icd_procedures.csv.gz",
+      "name": "hcpcsevents.csv.gz",
+      "contentSize": "2162335",
+      "contentUrl": "hosp/hcpcsevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "ccf952c8cafba1b2b20e4e781dda09ef5f68bc3c9c4b7e751824d4ed306e69aa"
+      "sha256": "89524fecb52041d688d8c201fd060acb10a146fa4a904de410e8d6a0d6fe2a72"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_19",
-      "name": "omr.csv.gz",
-      "contentSize": "44069351",
-      "contentUrl": "hosp/omr.csv.gz",
+      "name": "services.csv.gz",
+      "contentSize": "8569241",
+      "contentUrl": "hosp/services.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "844e89678b7a0949fbd50c54671a0d04618267e805d32dfbcb13c1f4f1693c7a"
+      "sha256": "31c82ebee94e0c04d6966fbfec30579ec00f9c7816b80852f9580656e6183888"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_20",
-      "name": "emar.csv.gz",
-      "contentSize": "811305629",
-      "contentUrl": "hosp/emar.csv.gz",
+      "name": "d_icd_procedures.csv.gz",
+      "contentSize": "589186",
+      "contentUrl": "hosp/d_icd_procedures.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "74a76ac03349d82e02908f3a7ade76e3c31121e6ac68b241fd349f1bbc453617"
+      "sha256": "a2ac8afcb99fd16bce2e6c7ad445e3bd1dfd658e521823130ab08b66fdd3d6d4"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_21",
-      "name": "microbiologyevents.csv.gz",
-      "contentSize": "117644075",
-      "contentUrl": "hosp/microbiologyevents.csv.gz",
+      "name": "omr.csv.gz",
+      "contentSize": "44069351",
+      "contentUrl": "hosp/omr.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "2ae3f75d0399476902c9a17f41aeb5a3de663c4012c18a4f4a5a017d6b24d4bd"
+      "sha256": "8280a8023203bddc6cc4419bd8cd253a015b8bc0bc53852ec92f98c7353f31e2"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_22",
-      "name": "datetimeevents.csv.gz",
-      "contentSize": "63481196",
-      "contentUrl": "icu/datetimeevents.csv.gz",
+      "name": "emar.csv.gz",
+      "contentSize": "811305629",
+      "contentUrl": "hosp/emar.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "8a06804955091244d53a9f21648b73b0ae00650a4132f4b0a4a8f0169c4efd43"
+      "sha256": "1c147c152c8cc12dfb22bd2b26328ec7817100bbcc4e84dd8fcb92960a01fdec"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_23",
-      "name": "caregiver.csv.gz",
-      "contentSize": "41566",
-      "contentUrl": "icu/caregiver.csv.gz",
+      "name": "microbiologyevents.csv.gz",
+      "contentSize": "117644075",
+      "contentUrl": "hosp/microbiologyevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "4e0f21c383f4bf1d6715fd451a6fb21ba14f9167d57eb724b0a6d89c7b243086"
+      "sha256": "bfb17d9c67a5f7d7036e7acb0b8e35969fa491aceb1a710adac9645fcfc34a16"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_24",
-      "name": "ingredientevents.csv.gz",
-      "contentSize": "311642048",
-      "contentUrl": "icu/ingredientevents.csv.gz",
+      "name": "datetimeevents.csv.gz",
+      "contentSize": "63481196",
+      "contentUrl": "icu/datetimeevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "5c27c31c81d4b59e2fe5dca4fc468fa04835f0ad9c8a78885c89ecccd63e19f4"
+      "sha256": "21c65276b413039ef1c855822aed2c2eb47f2134381ec022237a18e51548c11d"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_25",
-      "name": "inputevents.csv.gz",
-      "contentSize": "401088206",
-      "contentUrl": "icu/inputevents.csv.gz",
+      "name": "caregiver.csv.gz",
+      "contentSize": "41566",
+      "contentUrl": "icu/caregiver.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "d0440445f74b2edeeef17106c941d08d29a3fed1f6f0625f3c956bed6237c9c2"
+      "sha256": "70561bed99ec495e38ace94db0300ec9a644c5a43da3d480523045de9e92e4b1"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_26",
-      "name": "procedureevents.csv.gz",
-      "contentSize": "24096834",
-      "contentUrl": "icu/procedureevents.csv.gz",
+      "name": "ingredientevents.csv.gz",
+      "contentSize": "311642048",
+      "contentUrl": "icu/ingredientevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "4858144bf33be198a002658556fd0352143653802a93d965de4f891b0beb1450"
+      "sha256": "d2a5b1177f8aed1f9b8e31f5ee1937cade69bd1e42c14afafb8d548e088b4ec6"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_27",
-      "name": "d_items.csv.gz",
-      "contentSize": "58741",
-      "contentUrl": "icu/d_items.csv.gz",
+      "name": "inputevents.csv.gz",
+      "contentSize": "401088206",
+      "contentUrl": "icu/inputevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "2e8987d8ac98e48358e582708f953710f50bdea7fb4a8bb427acb364a7212894"
+      "sha256": "09ffc40fade12d017debcb939225ab3924ac807625fdae27f09a260a8ee0ce48"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_28",
-      "name": "chartevents.csv.gz",
-      "contentSize": "3502392765",
-      "contentUrl": "icu/chartevents.csv.gz",
+      "name": "procedureevents.csv.gz",
+      "contentSize": "24096834",
+      "contentUrl": "icu/procedureevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "0d1932df345c2d135ce715df1f6afa603f7124894a5aa8c6ba56aa6ee02160d4"
+      "sha256": "5ec6c252aae1f035de05c2053ad1279a138ee00d22d1569a712a1df7e31371c2"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_29",
-      "name": "icustays.csv.gz",
-      "contentSize": "3342355",
-      "contentUrl": "icu/icustays.csv.gz",
+      "name": "d_items.csv.gz",
+      "contentSize": "58741",
+      "contentUrl": "icu/d_items.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "3b16bc6cc9b93c7f20a040ba5ec38d00951f42475bf5157aea7ffde052676ef0"
+      "sha256": "7f223a9570da9c02bd12f281b398cb4951d5a560a51836540f357bc247366b7f"
     },
     {
       "@type": "cr:FileObject",
       "@id": "file_30",
+      "name": "chartevents.csv.gz",
+      "contentSize": "3502392765",
+      "contentUrl": "icu/chartevents.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "fd0387653084e5b142756b98b74fdddc2e5e7eb0f496aa8bf5af3d4176e71098"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_31",
+      "name": "icustays.csv.gz",
+      "contentSize": "3342355",
+      "contentUrl": "icu/icustays.csv.gz",
+      "encodingFormat": "application/gzip",
+      "sha256": "3c590ed37f1fb7a77a128f2f6961f836001512ba81adcd0dfeced2702f96bc5f"
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_32",
       "name": "outputevents.csv.gz",
       "contentSize": "49307639",
       "contentUrl": "icu/outputevents.csv.gz",
       "encodingFormat": "application/gzip",
-      "sha256": "7eff7fa0bbbb4e0c6514e0235ed489e9f4bd541c8888b404525ace25f38b4755"
+      "sha256": "67734d621addb1a3abf959e96a6e047bfa073a14a512b942a9434c9dfa018df6"
     }
   ],
   "recordSet": [
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_0",
+      "@id": "poe",
       "name": "poe",
-      "description": "Records from poe.csv.gz (52212109 rows)",
+      "description": "Records from poe.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_0_poe_id",
+          "@id": "poe/poe_id",
           "name": "poe_id",
           "description": "Column 'poe_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_poe_id",
             "fileObject": {
               "@id": "file_0"
             },
@@ -364,12 +381,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_poe_seq",
+          "@id": "poe/poe_seq",
           "name": "poe_seq",
           "description": "Column 'poe_seq' from poe.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_0_source_poe_seq",
             "fileObject": {
               "@id": "file_0"
             },
@@ -380,12 +396,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_subject_id",
+          "@id": "poe/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from poe.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_0_source_subject_id",
             "fileObject": {
               "@id": "file_0"
             },
@@ -396,12 +411,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_hadm_id",
+          "@id": "poe/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from poe.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_0_source_hadm_id",
             "fileObject": {
               "@id": "file_0"
             },
@@ -412,12 +426,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_ordertime",
+          "@id": "poe/ordertime",
           "name": "ordertime",
           "description": "Column 'ordertime' from poe.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_0_source_ordertime",
             "fileObject": {
               "@id": "file_0"
             },
@@ -428,12 +441,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_order_type",
+          "@id": "poe/order_type",
           "name": "order_type",
           "description": "Column 'order_type' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_order_type",
             "fileObject": {
               "@id": "file_0"
             },
@@ -444,12 +456,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_order_subtype",
+          "@id": "poe/order_subtype",
           "name": "order_subtype",
           "description": "Column 'order_subtype' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_order_subtype",
             "fileObject": {
               "@id": "file_0"
             },
@@ -460,12 +471,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_transaction_type",
+          "@id": "poe/transaction_type",
           "name": "transaction_type",
           "description": "Column 'transaction_type' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_transaction_type",
             "fileObject": {
               "@id": "file_0"
             },
@@ -476,12 +486,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_discontinue_of_poe_id",
+          "@id": "poe/discontinue_of_poe_id",
           "name": "discontinue_of_poe_id",
           "description": "Column 'discontinue_of_poe_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_discontinue_of_poe_id",
             "fileObject": {
               "@id": "file_0"
             },
@@ -492,12 +501,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_discontinued_by_poe_id",
+          "@id": "poe/discontinued_by_poe_id",
           "name": "discontinued_by_poe_id",
           "description": "Column 'discontinued_by_poe_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_discontinued_by_poe_id",
             "fileObject": {
               "@id": "file_0"
             },
@@ -508,12 +516,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_order_provider_id",
+          "@id": "poe/order_provider_id",
           "name": "order_provider_id",
           "description": "Column 'order_provider_id' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_order_provider_id",
             "fileObject": {
               "@id": "file_0"
             },
@@ -524,12 +531,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_order_status",
+          "@id": "poe/order_status",
           "name": "order_status",
           "description": "Column 'order_status' from poe.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_0_source_order_status",
             "fileObject": {
               "@id": "file_0"
             },
@@ -542,18 +548,17 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_1",
+      "@id": "d_hcpcs",
       "name": "d_hcpcs",
-      "description": "Records from d_hcpcs.csv.gz (89208 rows)",
+      "description": "Records from d_hcpcs.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_1_code",
+          "@id": "d_hcpcs/code",
           "name": "code",
           "description": "Column 'code' from d_hcpcs.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_1_source_code",
             "fileObject": {
               "@id": "file_1"
             },
@@ -564,12 +569,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_1_category",
+          "@id": "d_hcpcs/category",
           "name": "category",
           "description": "Column 'category' from d_hcpcs.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_1_source_category",
             "fileObject": {
               "@id": "file_1"
             },
@@ -580,12 +584,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_1_long_description",
+          "@id": "d_hcpcs/long_description",
           "name": "long_description",
           "description": "Column 'long_description' from d_hcpcs.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_1_source_long_description",
             "fileObject": {
               "@id": "file_1"
             },
@@ -596,12 +599,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_1_short_description",
+          "@id": "d_hcpcs/short_description",
           "name": "short_description",
           "description": "Column 'short_description' from d_hcpcs.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_1_source_short_description",
             "fileObject": {
               "@id": "file_1"
             },
@@ -614,18 +616,17 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_2",
+      "@id": "poe_detail",
       "name": "poe_detail",
-      "description": "Records from poe_detail.csv.gz (8504982 rows)",
+      "description": "Records from poe_detail.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_2_poe_id",
+          "@id": "poe_detail/poe_id",
           "name": "poe_id",
           "description": "Column 'poe_id' from poe_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_2_source_poe_id",
             "fileObject": {
               "@id": "file_2"
             },
@@ -636,12 +637,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_2_poe_seq",
+          "@id": "poe_detail/poe_seq",
           "name": "poe_seq",
           "description": "Column 'poe_seq' from poe_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_2_source_poe_seq",
             "fileObject": {
               "@id": "file_2"
             },
@@ -652,12 +652,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_2_subject_id",
+          "@id": "poe_detail/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from poe_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_2_source_subject_id",
             "fileObject": {
               "@id": "file_2"
             },
@@ -668,12 +667,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_2_field_name",
+          "@id": "poe_detail/field_name",
           "name": "field_name",
           "description": "Column 'field_name' from poe_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_2_source_field_name",
             "fileObject": {
               "@id": "file_2"
             },
@@ -684,12 +682,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_2_field_value",
+          "@id": "poe_detail/field_value",
           "name": "field_value",
           "description": "Column 'field_value' from poe_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_2_source_field_value",
             "fileObject": {
               "@id": "file_2"
             },
@@ -702,18 +699,17 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_3",
+      "@id": "patients",
       "name": "patients",
-      "description": "Records from patients.csv.gz (364627 rows)",
+      "description": "Records from patients.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_3_subject_id",
+          "@id": "patients/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from patients.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_3_source_subject_id",
             "fileObject": {
               "@id": "file_3"
             },
@@ -724,12 +720,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_3_gender",
+          "@id": "patients/gender",
           "name": "gender",
           "description": "Column 'gender' from patients.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_3_source_gender",
             "fileObject": {
               "@id": "file_3"
             },
@@ -740,12 +735,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_3_anchor_age",
+          "@id": "patients/anchor_age",
           "name": "anchor_age",
           "description": "Column 'anchor_age' from patients.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_3_source_anchor_age",
             "fileObject": {
               "@id": "file_3"
             },
@@ -756,12 +750,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_3_anchor_year",
+          "@id": "patients/anchor_year",
           "name": "anchor_year",
           "description": "Column 'anchor_year' from patients.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_3_source_anchor_year",
             "fileObject": {
               "@id": "file_3"
             },
@@ -772,12 +765,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_3_anchor_year_group",
+          "@id": "patients/anchor_year_group",
           "name": "anchor_year_group",
           "description": "Column 'anchor_year_group' from patients.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_3_source_anchor_year_group",
             "fileObject": {
               "@id": "file_3"
             },
@@ -788,12 +780,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_3_dod",
+          "@id": "patients/dod",
           "name": "dod",
           "description": "Column 'dod' from patients.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "file_3_source_dod",
             "fileObject": {
               "@id": "file_3"
             },
@@ -806,18 +797,17 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_4",
+      "@id": "diagnoses_icd",
       "name": "diagnoses_icd",
-      "description": "Records from diagnoses_icd.csv.gz (6364488 rows)",
+      "description": "Records from diagnoses_icd.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_4_subject_id",
+          "@id": "diagnoses_icd/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_4_source_subject_id",
             "fileObject": {
               "@id": "file_4"
             },
@@ -828,12 +818,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_4_hadm_id",
+          "@id": "diagnoses_icd/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_4_source_hadm_id",
             "fileObject": {
               "@id": "file_4"
             },
@@ -844,12 +833,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_4_seq_num",
+          "@id": "diagnoses_icd/seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_4_source_seq_num",
             "fileObject": {
               "@id": "file_4"
             },
@@ -860,12 +848,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_4_icd_code",
+          "@id": "diagnoses_icd/icd_code",
           "name": "icd_code",
           "description": "Column 'icd_code' from diagnoses_icd.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_4_source_icd_code",
             "fileObject": {
               "@id": "file_4"
             },
@@ -876,12 +863,11 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_4_icd_version",
+          "@id": "diagnoses_icd/icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from diagnoses_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_4_source_icd_version",
             "fileObject": {
               "@id": "file_4"
             },
@@ -894,18 +880,32 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_5",
-      "name": "emar_detail",
-      "description": "Records from emar_detail.csv.gz (87371064 rows)",
+      "@id": "labevents",
+      "name": "labevents",
+      "description": "Records from labevents.csv",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_5_subject_id",
-          "name": "subject_id",
-          "description": "Column 'subject_id' from emar_detail.csv.gz",
+          "@id": "labevents/labevent_id",
+          "name": "labevent_id",
+          "description": "Column 'labevent_id' from labevents.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_5_source_subject_id",
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "labevent_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from labevents.csv",
+          "dataType": "cr:Int64",
+          "source": {
             "fileObject": {
               "@id": "file_5"
             },
@@ -916,14 +916,314 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_emar_id",
+          "@id": "labevents/hadm_id",
+          "name": "hadm_id",
+          "description": "Column 'hadm_id' from labevents.csv",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "hadm_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/specimen_id",
+          "name": "specimen_id",
+          "description": "Column 'specimen_id' from labevents.csv",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "specimen_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from labevents.csv",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/order_provider_id",
+          "name": "order_provider_id",
+          "description": "Column 'order_provider_id' from labevents.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "order_provider_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/charttime",
+          "name": "charttime",
+          "description": "Column 'charttime' from labevents.csv",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "charttime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/storetime",
+          "name": "storetime",
+          "description": "Column 'storetime' from labevents.csv",
+          "dataType": "sc:DateTime",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "storetime"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/value",
+          "name": "value",
+          "description": "Column 'value' from labevents.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "value"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/valuenum",
+          "name": "valuenum",
+          "description": "Column 'valuenum' from labevents.csv",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "valuenum"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/valueuom",
+          "name": "valueuom",
+          "description": "Column 'valueuom' from labevents.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "valueuom"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/ref_range_lower",
+          "name": "ref_range_lower",
+          "description": "Column 'ref_range_lower' from labevents.csv",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "ref_range_lower"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/ref_range_upper",
+          "name": "ref_range_upper",
+          "description": "Column 'ref_range_upper' from labevents.csv",
+          "dataType": "cr:Float64",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "ref_range_upper"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/flag",
+          "name": "flag",
+          "description": "Column 'flag' from labevents.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "flag"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/priority",
+          "name": "priority",
+          "description": "Column 'priority' from labevents.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "priority"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "labevents/comments",
+          "name": "comments",
+          "description": "Column 'comments' from labevents.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_5"
+            },
+            "extract": {
+              "column": "comments"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "d_labitems",
+      "name": "d_labitems",
+      "description": "Records from d_labitems.csv",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/itemid",
+          "name": "itemid",
+          "description": "Column 'itemid' from d_labitems.csv",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "itemid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/label",
+          "name": "label",
+          "description": "Column 'label' from d_labitems.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "label"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/fluid",
+          "name": "fluid",
+          "description": "Column 'fluid' from d_labitems.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "fluid"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "d_labitems/category",
+          "name": "category",
+          "description": "Column 'category' from d_labitems.csv",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_6"
+            },
+            "extract": {
+              "column": "category"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "emar_detail",
+      "name": "emar_detail",
+      "description": "Records from emar_detail.csv.gz",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/subject_id",
+          "name": "subject_id",
+          "description": "Column 'subject_id' from emar_detail.csv.gz",
+          "dataType": "cr:Int64",
+          "source": {
+            "fileObject": {
+              "@id": "file_7"
+            },
+            "extract": {
+              "column": "subject_id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "emar_detail/emar_id",
           "name": "emar_id",
           "description": "Column 'emar_id' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_emar_id",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "emar_id"
@@ -932,14 +1232,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_emar_seq",
+          "@id": "emar_detail/emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from emar_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_5_source_emar_seq",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "emar_seq"
@@ -948,14 +1247,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_parent_field_ordinal",
+          "@id": "emar_detail/parent_field_ordinal",
           "name": "parent_field_ordinal",
           "description": "Column 'parent_field_ordinal' from emar_detail.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_5_source_parent_field_ordinal",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "parent_field_ordinal"
@@ -964,14 +1262,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_administration_type",
+          "@id": "emar_detail/administration_type",
           "name": "administration_type",
           "description": "Column 'administration_type' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_administration_type",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "administration_type"
@@ -980,14 +1277,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_pharmacy_id",
+          "@id": "emar_detail/pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from emar_detail.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_5_source_pharmacy_id",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "pharmacy_id"
@@ -996,14 +1292,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_barcode_type",
+          "@id": "emar_detail/barcode_type",
           "name": "barcode_type",
           "description": "Column 'barcode_type' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_barcode_type",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "barcode_type"
@@ -1012,14 +1307,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_reason_for_no_barcode",
+          "@id": "emar_detail/reason_for_no_barcode",
           "name": "reason_for_no_barcode",
           "description": "Column 'reason_for_no_barcode' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_reason_for_no_barcode",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "reason_for_no_barcode"
@@ -1028,14 +1322,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_complete_dose_not_given",
+          "@id": "emar_detail/complete_dose_not_given",
           "name": "complete_dose_not_given",
           "description": "Column 'complete_dose_not_given' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_complete_dose_not_given",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "complete_dose_not_given"
@@ -1044,14 +1337,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_dose_due",
+          "@id": "emar_detail/dose_due",
           "name": "dose_due",
           "description": "Column 'dose_due' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_dose_due",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "dose_due"
@@ -1060,14 +1352,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_dose_due_unit",
+          "@id": "emar_detail/dose_due_unit",
           "name": "dose_due_unit",
           "description": "Column 'dose_due_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_dose_due_unit",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "dose_due_unit"
@@ -1076,14 +1367,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_dose_given",
+          "@id": "emar_detail/dose_given",
           "name": "dose_given",
           "description": "Column 'dose_given' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_dose_given",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "dose_given"
@@ -1092,14 +1382,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_dose_given_unit",
+          "@id": "emar_detail/dose_given_unit",
           "name": "dose_given_unit",
           "description": "Column 'dose_given_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_dose_given_unit",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "dose_given_unit"
@@ -1108,14 +1397,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_will_remainder_of_dose_be_given",
+          "@id": "emar_detail/will_remainder_of_dose_be_given",
           "name": "will_remainder_of_dose_be_given",
           "description": "Column 'will_remainder_of_dose_be_given' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_will_remainder_of_dose_be_given",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "will_remainder_of_dose_be_given"
@@ -1124,14 +1412,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_product_amount_given",
+          "@id": "emar_detail/product_amount_given",
           "name": "product_amount_given",
           "description": "Column 'product_amount_given' from emar_detail.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
-            "@id": "file_5_source_product_amount_given",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "product_amount_given"
@@ -1140,14 +1427,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_product_unit",
+          "@id": "emar_detail/product_unit",
           "name": "product_unit",
           "description": "Column 'product_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_product_unit",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "product_unit"
@@ -1156,14 +1442,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_product_code",
+          "@id": "emar_detail/product_code",
           "name": "product_code",
           "description": "Column 'product_code' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_product_code",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "product_code"
@@ -1172,14 +1457,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_product_description",
+          "@id": "emar_detail/product_description",
           "name": "product_description",
           "description": "Column 'product_description' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_product_description",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "product_description"
@@ -1188,14 +1472,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_product_description_other",
+          "@id": "emar_detail/product_description_other",
           "name": "product_description_other",
           "description": "Column 'product_description_other' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_product_description_other",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "product_description_other"
@@ -1204,14 +1487,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_prior_infusion_rate",
+          "@id": "emar_detail/prior_infusion_rate",
           "name": "prior_infusion_rate",
           "description": "Column 'prior_infusion_rate' from emar_detail.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
-            "@id": "file_5_source_prior_infusion_rate",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "prior_infusion_rate"
@@ -1220,14 +1502,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_infusion_rate",
+          "@id": "emar_detail/infusion_rate",
           "name": "infusion_rate",
           "description": "Column 'infusion_rate' from emar_detail.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
-            "@id": "file_5_source_infusion_rate",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "infusion_rate"
@@ -1236,14 +1517,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_infusion_rate_adjustment",
+          "@id": "emar_detail/infusion_rate_adjustment",
           "name": "infusion_rate_adjustment",
           "description": "Column 'infusion_rate_adjustment' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_infusion_rate_adjustment",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "infusion_rate_adjustment"
@@ -1252,14 +1532,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_infusion_rate_adjustment_amount",
+          "@id": "emar_detail/infusion_rate_adjustment_amount",
           "name": "infusion_rate_adjustment_amount",
           "description": "Column 'infusion_rate_adjustment_amount' from emar_detail.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_5_source_infusion_rate_adjustment_amount",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "infusion_rate_adjustment_amount"
@@ -1268,14 +1547,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_infusion_rate_unit",
+          "@id": "emar_detail/infusion_rate_unit",
           "name": "infusion_rate_unit",
           "description": "Column 'infusion_rate_unit' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_infusion_rate_unit",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "infusion_rate_unit"
@@ -1284,14 +1562,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_route",
+          "@id": "emar_detail/route",
           "name": "route",
           "description": "Column 'route' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_route",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "route"
@@ -1300,14 +1577,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_infusion_complete",
+          "@id": "emar_detail/infusion_complete",
           "name": "infusion_complete",
           "description": "Column 'infusion_complete' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_infusion_complete",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "infusion_complete"
@@ -1316,14 +1592,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_completion_interval",
+          "@id": "emar_detail/completion_interval",
           "name": "completion_interval",
           "description": "Column 'completion_interval' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_completion_interval",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "completion_interval"
@@ -1332,14 +1607,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_new_iv_bag_hung",
+          "@id": "emar_detail/new_iv_bag_hung",
           "name": "new_iv_bag_hung",
           "description": "Column 'new_iv_bag_hung' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_new_iv_bag_hung",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "new_iv_bag_hung"
@@ -1348,14 +1622,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_continued_infusion_in_other_location",
+          "@id": "emar_detail/continued_infusion_in_other_location",
           "name": "continued_infusion_in_other_location",
           "description": "Column 'continued_infusion_in_other_location' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_continued_infusion_in_other_location",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "continued_infusion_in_other_location"
@@ -1364,14 +1637,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_restart_interval",
+          "@id": "emar_detail/restart_interval",
           "name": "restart_interval",
           "description": "Column 'restart_interval' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_restart_interval",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "restart_interval"
@@ -1380,14 +1652,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_side",
+          "@id": "emar_detail/side",
           "name": "side",
           "description": "Column 'side' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_side",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "side"
@@ -1396,14 +1667,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_site",
+          "@id": "emar_detail/site",
           "name": "site",
           "description": "Column 'site' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_site",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "site"
@@ -1412,14 +1682,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_5_non_formulary_visual_verification",
+          "@id": "emar_detail/non_formulary_visual_verification",
           "name": "non_formulary_visual_verification",
           "description": "Column 'non_formulary_visual_verification' from emar_detail.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_5_source_non_formulary_visual_verification",
             "fileObject": {
-              "@id": "file_5"
+              "@id": "file_7"
             },
             "extract": {
               "column": "non_formulary_visual_verification"
@@ -1430,20 +1699,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_6",
+      "@id": "provider",
       "name": "provider",
-      "description": "Records from provider.csv.gz (42244 rows)",
+      "description": "Records from provider.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_6_provider_id",
+          "@id": "provider/provider_id",
           "name": "provider_id",
           "description": "Column 'provider_id' from provider.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_6_source_provider_id",
             "fileObject": {
-              "@id": "file_6"
+              "@id": "file_8"
             },
             "extract": {
               "column": "provider_id"
@@ -1454,20 +1722,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_7",
+      "@id": "prescriptions",
       "name": "prescriptions",
-      "description": "Records from prescriptions.csv.gz (20292611 rows)",
+      "description": "Records from prescriptions.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_7_subject_id",
+          "@id": "prescriptions/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_subject_id",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "subject_id"
@@ -1476,14 +1743,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_hadm_id",
+          "@id": "prescriptions/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_hadm_id",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "hadm_id"
@@ -1492,14 +1758,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_pharmacy_id",
+          "@id": "prescriptions/pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_pharmacy_id",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "pharmacy_id"
@@ -1508,14 +1773,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_poe_id",
+          "@id": "prescriptions/poe_id",
           "name": "poe_id",
           "description": "Column 'poe_id' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_poe_id",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "poe_id"
@@ -1524,14 +1788,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_poe_seq",
+          "@id": "prescriptions/poe_seq",
           "name": "poe_seq",
           "description": "Column 'poe_seq' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_poe_seq",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "poe_seq"
@@ -1540,14 +1803,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_order_provider_id",
+          "@id": "prescriptions/order_provider_id",
           "name": "order_provider_id",
           "description": "Column 'order_provider_id' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_order_provider_id",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "order_provider_id"
@@ -1556,14 +1818,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_starttime",
+          "@id": "prescriptions/starttime",
           "name": "starttime",
           "description": "Column 'starttime' from prescriptions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_7_source_starttime",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "starttime"
@@ -1572,14 +1833,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_stoptime",
+          "@id": "prescriptions/stoptime",
           "name": "stoptime",
           "description": "Column 'stoptime' from prescriptions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_7_source_stoptime",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "stoptime"
@@ -1588,14 +1848,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_drug_type",
+          "@id": "prescriptions/drug_type",
           "name": "drug_type",
           "description": "Column 'drug_type' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_drug_type",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "drug_type"
@@ -1604,14 +1863,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_drug",
+          "@id": "prescriptions/drug",
           "name": "drug",
           "description": "Column 'drug' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_drug",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "drug"
@@ -1620,14 +1878,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_formulary_drug_cd",
+          "@id": "prescriptions/formulary_drug_cd",
           "name": "formulary_drug_cd",
           "description": "Column 'formulary_drug_cd' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_formulary_drug_cd",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "formulary_drug_cd"
@@ -1636,14 +1893,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_gsn",
+          "@id": "prescriptions/gsn",
           "name": "gsn",
           "description": "Column 'gsn' from prescriptions.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_gsn",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "gsn"
@@ -1652,14 +1908,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_ndc",
+          "@id": "prescriptions/ndc",
           "name": "ndc",
           "description": "Column 'ndc' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_ndc",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "ndc"
@@ -1668,14 +1923,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_prod_strength",
+          "@id": "prescriptions/prod_strength",
           "name": "prod_strength",
           "description": "Column 'prod_strength' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_prod_strength",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "prod_strength"
@@ -1684,14 +1938,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_form_rx",
+          "@id": "prescriptions/form_rx",
           "name": "form_rx",
           "description": "Column 'form_rx' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_form_rx",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "form_rx"
@@ -1700,14 +1953,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_dose_val_rx",
+          "@id": "prescriptions/dose_val_rx",
           "name": "dose_val_rx",
           "description": "Column 'dose_val_rx' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_dose_val_rx",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "dose_val_rx"
@@ -1716,14 +1968,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_dose_unit_rx",
+          "@id": "prescriptions/dose_unit_rx",
           "name": "dose_unit_rx",
           "description": "Column 'dose_unit_rx' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_dose_unit_rx",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "dose_unit_rx"
@@ -1732,14 +1983,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_form_val_disp",
+          "@id": "prescriptions/form_val_disp",
           "name": "form_val_disp",
           "description": "Column 'form_val_disp' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_form_val_disp",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "form_val_disp"
@@ -1748,14 +1998,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_form_unit_disp",
+          "@id": "prescriptions/form_unit_disp",
           "name": "form_unit_disp",
           "description": "Column 'form_unit_disp' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_form_unit_disp",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "form_unit_disp"
@@ -1764,14 +2013,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_doses_per_24_hrs",
+          "@id": "prescriptions/doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from prescriptions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_7_source_doses_per_24_hrs",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "doses_per_24_hrs"
@@ -1780,14 +2028,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_7_route",
+          "@id": "prescriptions/route",
           "name": "route",
           "description": "Column 'route' from prescriptions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_7_source_route",
             "fileObject": {
-              "@id": "file_7"
+              "@id": "file_9"
             },
             "extract": {
               "column": "route"
@@ -1798,20 +2045,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_8",
+      "@id": "drgcodes",
       "name": "drgcodes",
-      "description": "Records from drgcodes.csv.gz (761856 rows)",
+      "description": "Records from drgcodes.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_8_subject_id",
+          "@id": "drgcodes/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_8_source_subject_id",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "subject_id"
@@ -1820,14 +2066,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_8_hadm_id",
+          "@id": "drgcodes/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_8_source_hadm_id",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "hadm_id"
@@ -1836,14 +2081,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_8_drg_type",
+          "@id": "drgcodes/drg_type",
           "name": "drg_type",
           "description": "Column 'drg_type' from drgcodes.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_8_source_drg_type",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "drg_type"
@@ -1852,14 +2096,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_8_drg_code",
+          "@id": "drgcodes/drg_code",
           "name": "drg_code",
           "description": "Column 'drg_code' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_8_source_drg_code",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "drg_code"
@@ -1868,14 +2111,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_8_description",
+          "@id": "drgcodes/description",
           "name": "description",
           "description": "Column 'description' from drgcodes.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_8_source_description",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "description"
@@ -1884,14 +2126,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_8_drg_severity",
+          "@id": "drgcodes/drg_severity",
           "name": "drg_severity",
           "description": "Column 'drg_severity' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_8_source_drg_severity",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "drg_severity"
@@ -1900,14 +2141,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_8_drg_mortality",
+          "@id": "drgcodes/drg_mortality",
           "name": "drg_mortality",
           "description": "Column 'drg_mortality' from drgcodes.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_8_source_drg_mortality",
             "fileObject": {
-              "@id": "file_8"
+              "@id": "file_10"
             },
             "extract": {
               "column": "drg_mortality"
@@ -1918,20 +2158,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_9",
+      "@id": "d_icd_diagnoses",
       "name": "d_icd_diagnoses",
-      "description": "Records from d_icd_diagnoses.csv.gz (112107 rows)",
+      "description": "Records from d_icd_diagnoses.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_9_icd_code",
+          "@id": "d_icd_diagnoses/icd_code",
           "name": "icd_code",
           "description": "Column 'icd_code' from d_icd_diagnoses.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_9_source_icd_code",
             "fileObject": {
-              "@id": "file_9"
+              "@id": "file_11"
             },
             "extract": {
               "column": "icd_code"
@@ -1940,14 +2179,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_9_icd_version",
+          "@id": "d_icd_diagnoses/icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from d_icd_diagnoses.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_9_source_icd_version",
             "fileObject": {
-              "@id": "file_9"
+              "@id": "file_11"
             },
             "extract": {
               "column": "icd_version"
@@ -1956,14 +2194,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_9_long_title",
+          "@id": "d_icd_diagnoses/long_title",
           "name": "long_title",
           "description": "Column 'long_title' from d_icd_diagnoses.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_9_source_long_title",
             "fileObject": {
-              "@id": "file_9"
+              "@id": "file_11"
             },
             "extract": {
               "column": "long_title"
@@ -1974,20 +2211,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_10",
+      "@id": "d_labitems",
       "name": "d_labitems",
-      "description": "Records from d_labitems.csv.gz (1650 rows)",
+      "description": "Records from d_labitems.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_10_itemid",
+          "@id": "d_labitems/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from d_labitems.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_10_source_itemid",
             "fileObject": {
-              "@id": "file_10"
+              "@id": "file_12"
             },
             "extract": {
               "column": "itemid"
@@ -1996,14 +2232,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_10_label",
+          "@id": "d_labitems/label",
           "name": "label",
           "description": "Column 'label' from d_labitems.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_10_source_label",
             "fileObject": {
-              "@id": "file_10"
+              "@id": "file_12"
             },
             "extract": {
               "column": "label"
@@ -2012,14 +2247,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_10_fluid",
+          "@id": "d_labitems/fluid",
           "name": "fluid",
           "description": "Column 'fluid' from d_labitems.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_10_source_fluid",
             "fileObject": {
-              "@id": "file_10"
+              "@id": "file_12"
             },
             "extract": {
               "column": "fluid"
@@ -2028,14 +2262,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_10_category",
+          "@id": "d_labitems/category",
           "name": "category",
           "description": "Column 'category' from d_labitems.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_10_source_category",
             "fileObject": {
-              "@id": "file_10"
+              "@id": "file_12"
             },
             "extract": {
               "column": "category"
@@ -2046,20 +2279,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_11",
+      "@id": "transfers",
       "name": "transfers",
-      "description": "Records from transfers.csv.gz (2413581 rows)",
+      "description": "Records from transfers.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_11_subject_id",
+          "@id": "transfers/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from transfers.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_11_source_subject_id",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "subject_id"
@@ -2068,14 +2300,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_11_hadm_id",
+          "@id": "transfers/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from transfers.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_11_source_hadm_id",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "hadm_id"
@@ -2084,14 +2315,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_11_transfer_id",
+          "@id": "transfers/transfer_id",
           "name": "transfer_id",
           "description": "Column 'transfer_id' from transfers.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_11_source_transfer_id",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "transfer_id"
@@ -2100,14 +2330,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_11_eventtype",
+          "@id": "transfers/eventtype",
           "name": "eventtype",
           "description": "Column 'eventtype' from transfers.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_11_source_eventtype",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "eventtype"
@@ -2116,14 +2345,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_11_careunit",
+          "@id": "transfers/careunit",
           "name": "careunit",
           "description": "Column 'careunit' from transfers.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_11_source_careunit",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "careunit"
@@ -2132,14 +2360,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_11_intime",
+          "@id": "transfers/intime",
           "name": "intime",
           "description": "Column 'intime' from transfers.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_11_source_intime",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "intime"
@@ -2148,14 +2375,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_11_outtime",
+          "@id": "transfers/outtime",
           "name": "outtime",
           "description": "Column 'outtime' from transfers.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_11_source_outtime",
             "fileObject": {
-              "@id": "file_11"
+              "@id": "file_13"
             },
             "extract": {
               "column": "outtime"
@@ -2166,20 +2392,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_12",
+      "@id": "admissions",
       "name": "admissions",
-      "description": "Records from admissions.csv.gz (546028 rows)",
+      "description": "Records from admissions.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_12_subject_id",
+          "@id": "admissions/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from admissions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_12_source_subject_id",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "subject_id"
@@ -2188,14 +2413,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_hadm_id",
+          "@id": "admissions/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from admissions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_12_source_hadm_id",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "hadm_id"
@@ -2204,14 +2428,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_admittime",
+          "@id": "admissions/admittime",
           "name": "admittime",
           "description": "Column 'admittime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_12_source_admittime",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "admittime"
@@ -2220,14 +2443,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_dischtime",
+          "@id": "admissions/dischtime",
           "name": "dischtime",
           "description": "Column 'dischtime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_12_source_dischtime",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "dischtime"
@@ -2236,14 +2458,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_deathtime",
+          "@id": "admissions/deathtime",
           "name": "deathtime",
           "description": "Column 'deathtime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_12_source_deathtime",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "deathtime"
@@ -2252,14 +2473,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_admission_type",
+          "@id": "admissions/admission_type",
           "name": "admission_type",
           "description": "Column 'admission_type' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_admission_type",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "admission_type"
@@ -2268,14 +2488,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_admit_provider_id",
+          "@id": "admissions/admit_provider_id",
           "name": "admit_provider_id",
           "description": "Column 'admit_provider_id' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_admit_provider_id",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "admit_provider_id"
@@ -2284,14 +2503,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_admission_location",
+          "@id": "admissions/admission_location",
           "name": "admission_location",
           "description": "Column 'admission_location' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_admission_location",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "admission_location"
@@ -2300,14 +2518,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_discharge_location",
+          "@id": "admissions/discharge_location",
           "name": "discharge_location",
           "description": "Column 'discharge_location' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_discharge_location",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "discharge_location"
@@ -2316,14 +2533,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_insurance",
+          "@id": "admissions/insurance",
           "name": "insurance",
           "description": "Column 'insurance' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_insurance",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "insurance"
@@ -2332,14 +2548,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_language",
+          "@id": "admissions/language",
           "name": "language",
           "description": "Column 'language' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_language",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "language"
@@ -2348,14 +2563,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_marital_status",
+          "@id": "admissions/marital_status",
           "name": "marital_status",
           "description": "Column 'marital_status' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_marital_status",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "marital_status"
@@ -2364,14 +2578,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_race",
+          "@id": "admissions/race",
           "name": "race",
           "description": "Column 'race' from admissions.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_12_source_race",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "race"
@@ -2380,14 +2593,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_edregtime",
+          "@id": "admissions/edregtime",
           "name": "edregtime",
           "description": "Column 'edregtime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_12_source_edregtime",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "edregtime"
@@ -2396,14 +2608,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_edouttime",
+          "@id": "admissions/edouttime",
           "name": "edouttime",
           "description": "Column 'edouttime' from admissions.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_12_source_edouttime",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "edouttime"
@@ -2412,14 +2623,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_hospital_expire_flag",
+          "@id": "admissions/hospital_expire_flag",
           "name": "hospital_expire_flag",
           "description": "Column 'hospital_expire_flag' from admissions.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_12_source_hospital_expire_flag",
             "fileObject": {
-              "@id": "file_12"
+              "@id": "file_14"
             },
             "extract": {
               "column": "hospital_expire_flag"
@@ -2430,20 +2640,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_13",
+      "@id": "labevents",
       "name": "labevents",
-      "description": "Records from labevents.csv.gz (158374764 rows)",
+      "description": "Records from labevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_13_labevent_id",
+          "@id": "labevents/labevent_id",
           "name": "labevent_id",
           "description": "Column 'labevent_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_13_source_labevent_id",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "labevent_id"
@@ -2452,14 +2661,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_subject_id",
+          "@id": "labevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_13_source_subject_id",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "subject_id"
@@ -2468,14 +2676,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_hadm_id",
+          "@id": "labevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_13_source_hadm_id",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "hadm_id"
@@ -2484,14 +2691,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_specimen_id",
+          "@id": "labevents/specimen_id",
           "name": "specimen_id",
           "description": "Column 'specimen_id' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_13_source_specimen_id",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "specimen_id"
@@ -2500,14 +2706,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_itemid",
+          "@id": "labevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from labevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_13_source_itemid",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "itemid"
@@ -2516,14 +2721,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_order_provider_id",
+          "@id": "labevents/order_provider_id",
           "name": "order_provider_id",
           "description": "Column 'order_provider_id' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_13_source_order_provider_id",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "order_provider_id"
@@ -2532,14 +2736,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_charttime",
+          "@id": "labevents/charttime",
           "name": "charttime",
           "description": "Column 'charttime' from labevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_13_source_charttime",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "charttime"
@@ -2548,14 +2751,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_storetime",
+          "@id": "labevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from labevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_13_source_storetime",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "storetime"
@@ -2564,14 +2766,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_value",
+          "@id": "labevents/value",
           "name": "value",
           "description": "Column 'value' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_13_source_value",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "value"
@@ -2580,14 +2781,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_valuenum",
+          "@id": "labevents/valuenum",
           "name": "valuenum",
           "description": "Column 'valuenum' from labevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_13_source_valuenum",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "valuenum"
@@ -2596,14 +2796,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_valueuom",
+          "@id": "labevents/valueuom",
           "name": "valueuom",
           "description": "Column 'valueuom' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_13_source_valueuom",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "valueuom"
@@ -2612,14 +2811,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_ref_range_lower",
+          "@id": "labevents/ref_range_lower",
           "name": "ref_range_lower",
           "description": "Column 'ref_range_lower' from labevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_13_source_ref_range_lower",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "ref_range_lower"
@@ -2628,14 +2826,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_ref_range_upper",
+          "@id": "labevents/ref_range_upper",
           "name": "ref_range_upper",
           "description": "Column 'ref_range_upper' from labevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_13_source_ref_range_upper",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "ref_range_upper"
@@ -2644,14 +2841,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_flag",
+          "@id": "labevents/flag",
           "name": "flag",
           "description": "Column 'flag' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_13_source_flag",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "flag"
@@ -2660,14 +2856,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_priority",
+          "@id": "labevents/priority",
           "name": "priority",
           "description": "Column 'priority' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_13_source_priority",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "priority"
@@ -2676,14 +2871,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_13_comments",
+          "@id": "labevents/comments",
           "name": "comments",
           "description": "Column 'comments' from labevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_13_source_comments",
             "fileObject": {
-              "@id": "file_13"
+              "@id": "file_15"
             },
             "extract": {
               "column": "comments"
@@ -2694,20 +2888,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_14",
+      "@id": "pharmacy",
       "name": "pharmacy",
-      "description": "Records from pharmacy.csv.gz (17847567 rows)",
+      "description": "Records from pharmacy.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_14_subject_id",
+          "@id": "pharmacy/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_subject_id",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "subject_id"
@@ -2716,14 +2909,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_hadm_id",
+          "@id": "pharmacy/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_hadm_id",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "hadm_id"
@@ -2732,14 +2924,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_pharmacy_id",
+          "@id": "pharmacy/pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_pharmacy_id",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "pharmacy_id"
@@ -2748,14 +2939,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_poe_id",
+          "@id": "pharmacy/poe_id",
           "name": "poe_id",
           "description": "Column 'poe_id' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_poe_id",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "poe_id"
@@ -2764,14 +2954,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_starttime",
+          "@id": "pharmacy/starttime",
           "name": "starttime",
           "description": "Column 'starttime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_14_source_starttime",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "starttime"
@@ -2780,14 +2969,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_stoptime",
+          "@id": "pharmacy/stoptime",
           "name": "stoptime",
           "description": "Column 'stoptime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_14_source_stoptime",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "stoptime"
@@ -2796,14 +2984,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_medication",
+          "@id": "pharmacy/medication",
           "name": "medication",
           "description": "Column 'medication' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_medication",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "medication"
@@ -2812,14 +2999,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_proc_type",
+          "@id": "pharmacy/proc_type",
           "name": "proc_type",
           "description": "Column 'proc_type' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_proc_type",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "proc_type"
@@ -2828,14 +3014,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_status",
+          "@id": "pharmacy/status",
           "name": "status",
           "description": "Column 'status' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_status",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "status"
@@ -2844,14 +3029,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_entertime",
+          "@id": "pharmacy/entertime",
           "name": "entertime",
           "description": "Column 'entertime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_14_source_entertime",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "entertime"
@@ -2860,14 +3044,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_verifiedtime",
+          "@id": "pharmacy/verifiedtime",
           "name": "verifiedtime",
           "description": "Column 'verifiedtime' from pharmacy.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_14_source_verifiedtime",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "verifiedtime"
@@ -2876,14 +3059,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_route",
+          "@id": "pharmacy/route",
           "name": "route",
           "description": "Column 'route' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_route",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "route"
@@ -2892,14 +3074,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_frequency",
+          "@id": "pharmacy/frequency",
           "name": "frequency",
           "description": "Column 'frequency' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_frequency",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "frequency"
@@ -2908,14 +3089,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_disp_sched",
+          "@id": "pharmacy/disp_sched",
           "name": "disp_sched",
           "description": "Column 'disp_sched' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_disp_sched",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "disp_sched"
@@ -2924,14 +3104,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_infusion_type",
+          "@id": "pharmacy/infusion_type",
           "name": "infusion_type",
           "description": "Column 'infusion_type' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_infusion_type",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "infusion_type"
@@ -2940,14 +3119,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_sliding_scale",
+          "@id": "pharmacy/sliding_scale",
           "name": "sliding_scale",
           "description": "Column 'sliding_scale' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_sliding_scale",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "sliding_scale"
@@ -2956,14 +3134,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_lockout_interval",
+          "@id": "pharmacy/lockout_interval",
           "name": "lockout_interval",
           "description": "Column 'lockout_interval' from pharmacy.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_lockout_interval",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "lockout_interval"
@@ -2972,14 +3149,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_basal_rate",
+          "@id": "pharmacy/basal_rate",
           "name": "basal_rate",
           "description": "Column 'basal_rate' from pharmacy.csv.gz",
-          "dataType": "cr:Float64",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_basal_rate",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "basal_rate"
@@ -2988,14 +3164,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_one_hr_max",
+          "@id": "pharmacy/one_hr_max",
           "name": "one_hr_max",
           "description": "Column 'one_hr_max' from pharmacy.csv.gz",
-          "dataType": "sc:Text",
+          "dataType": "cr:Float64",
           "source": {
-            "@id": "file_14_source_one_hr_max",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "one_hr_max"
@@ -3004,14 +3179,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_doses_per_24_hrs",
+          "@id": "pharmacy/doses_per_24_hrs",
           "name": "doses_per_24_hrs",
           "description": "Column 'doses_per_24_hrs' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_doses_per_24_hrs",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "doses_per_24_hrs"
@@ -3020,14 +3194,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_duration",
+          "@id": "pharmacy/duration",
           "name": "duration",
           "description": "Column 'duration' from pharmacy.csv.gz",
-          "dataType": "cr:Float64",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_duration",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "duration"
@@ -3036,14 +3209,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_duration_interval",
+          "@id": "pharmacy/duration_interval",
           "name": "duration_interval",
           "description": "Column 'duration_interval' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_duration_interval",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "duration_interval"
@@ -3052,14 +3224,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_expiration_value",
+          "@id": "pharmacy/expiration_value",
           "name": "expiration_value",
           "description": "Column 'expiration_value' from pharmacy.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_14_source_expiration_value",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "expiration_value"
@@ -3068,14 +3239,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_expiration_unit",
+          "@id": "pharmacy/expiration_unit",
           "name": "expiration_unit",
           "description": "Column 'expiration_unit' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_expiration_unit",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "expiration_unit"
@@ -3084,14 +3254,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_expirationdate",
+          "@id": "pharmacy/expirationdate",
           "name": "expirationdate",
           "description": "Column 'expirationdate' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_expirationdate",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "expirationdate"
@@ -3100,14 +3269,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_dispensation",
+          "@id": "pharmacy/dispensation",
           "name": "dispensation",
           "description": "Column 'dispensation' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_dispensation",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "dispensation"
@@ -3116,14 +3284,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_14_fill_quantity",
+          "@id": "pharmacy/fill_quantity",
           "name": "fill_quantity",
           "description": "Column 'fill_quantity' from pharmacy.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_14_source_fill_quantity",
             "fileObject": {
-              "@id": "file_14"
+              "@id": "file_16"
             },
             "extract": {
               "column": "fill_quantity"
@@ -3134,20 +3301,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_15",
+      "@id": "procedures_icd",
       "name": "procedures_icd",
-      "description": "Records from procedures_icd.csv.gz (859655 rows)",
+      "description": "Records from procedures_icd.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_15_subject_id",
+          "@id": "procedures_icd/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_15_source_subject_id",
             "fileObject": {
-              "@id": "file_15"
+              "@id": "file_17"
             },
             "extract": {
               "column": "subject_id"
@@ -3156,14 +3322,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_15_hadm_id",
+          "@id": "procedures_icd/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_15_source_hadm_id",
             "fileObject": {
-              "@id": "file_15"
+              "@id": "file_17"
             },
             "extract": {
               "column": "hadm_id"
@@ -3172,14 +3337,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_15_seq_num",
+          "@id": "procedures_icd/seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_15_source_seq_num",
             "fileObject": {
-              "@id": "file_15"
+              "@id": "file_17"
             },
             "extract": {
               "column": "seq_num"
@@ -3188,14 +3352,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_15_chartdate",
+          "@id": "procedures_icd/chartdate",
           "name": "chartdate",
           "description": "Column 'chartdate' from procedures_icd.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "file_15_source_chartdate",
             "fileObject": {
-              "@id": "file_15"
+              "@id": "file_17"
             },
             "extract": {
               "column": "chartdate"
@@ -3204,14 +3367,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_15_icd_code",
+          "@id": "procedures_icd/icd_code",
           "name": "icd_code",
           "description": "Column 'icd_code' from procedures_icd.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_15_source_icd_code",
             "fileObject": {
-              "@id": "file_15"
+              "@id": "file_17"
             },
             "extract": {
               "column": "icd_code"
@@ -3220,14 +3382,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_15_icd_version",
+          "@id": "procedures_icd/icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from procedures_icd.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_15_source_icd_version",
             "fileObject": {
-              "@id": "file_15"
+              "@id": "file_17"
             },
             "extract": {
               "column": "icd_version"
@@ -3238,20 +3399,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_16",
+      "@id": "hcpcsevents",
       "name": "hcpcsevents",
-      "description": "Records from hcpcsevents.csv.gz (186074 rows)",
+      "description": "Records from hcpcsevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_16_subject_id",
+          "@id": "hcpcsevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from hcpcsevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_16_source_subject_id",
             "fileObject": {
-              "@id": "file_16"
+              "@id": "file_18"
             },
             "extract": {
               "column": "subject_id"
@@ -3260,14 +3420,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_16_hadm_id",
+          "@id": "hcpcsevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from hcpcsevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_16_source_hadm_id",
             "fileObject": {
-              "@id": "file_16"
+              "@id": "file_18"
             },
             "extract": {
               "column": "hadm_id"
@@ -3276,14 +3435,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_16_chartdate",
+          "@id": "hcpcsevents/chartdate",
           "name": "chartdate",
           "description": "Column 'chartdate' from hcpcsevents.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "file_16_source_chartdate",
             "fileObject": {
-              "@id": "file_16"
+              "@id": "file_18"
             },
             "extract": {
               "column": "chartdate"
@@ -3292,14 +3450,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_16_hcpcs_cd",
+          "@id": "hcpcsevents/hcpcs_cd",
           "name": "hcpcs_cd",
           "description": "Column 'hcpcs_cd' from hcpcsevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_16_source_hcpcs_cd",
             "fileObject": {
-              "@id": "file_16"
+              "@id": "file_18"
             },
             "extract": {
               "column": "hcpcs_cd"
@@ -3308,14 +3465,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_16_seq_num",
+          "@id": "hcpcsevents/seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from hcpcsevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_16_source_seq_num",
             "fileObject": {
-              "@id": "file_16"
+              "@id": "file_18"
             },
             "extract": {
               "column": "seq_num"
@@ -3324,14 +3480,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_16_short_description",
+          "@id": "hcpcsevents/short_description",
           "name": "short_description",
           "description": "Column 'short_description' from hcpcsevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_16_source_short_description",
             "fileObject": {
-              "@id": "file_16"
+              "@id": "file_18"
             },
             "extract": {
               "column": "short_description"
@@ -3342,20 +3497,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_17",
+      "@id": "services",
       "name": "services",
-      "description": "Records from services.csv.gz (593071 rows)",
+      "description": "Records from services.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_17_subject_id",
+          "@id": "services/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from services.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_17_source_subject_id",
             "fileObject": {
-              "@id": "file_17"
+              "@id": "file_19"
             },
             "extract": {
               "column": "subject_id"
@@ -3364,14 +3518,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_17_hadm_id",
+          "@id": "services/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from services.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_17_source_hadm_id",
             "fileObject": {
-              "@id": "file_17"
+              "@id": "file_19"
             },
             "extract": {
               "column": "hadm_id"
@@ -3380,14 +3533,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_17_transfertime",
+          "@id": "services/transfertime",
           "name": "transfertime",
           "description": "Column 'transfertime' from services.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_17_source_transfertime",
             "fileObject": {
-              "@id": "file_17"
+              "@id": "file_19"
             },
             "extract": {
               "column": "transfertime"
@@ -3396,14 +3548,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_17_prev_service",
+          "@id": "services/prev_service",
           "name": "prev_service",
           "description": "Column 'prev_service' from services.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_17_source_prev_service",
             "fileObject": {
-              "@id": "file_17"
+              "@id": "file_19"
             },
             "extract": {
               "column": "prev_service"
@@ -3412,14 +3563,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_17_curr_service",
+          "@id": "services/curr_service",
           "name": "curr_service",
           "description": "Column 'curr_service' from services.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_17_source_curr_service",
             "fileObject": {
-              "@id": "file_17"
+              "@id": "file_19"
             },
             "extract": {
               "column": "curr_service"
@@ -3430,20 +3580,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_18",
+      "@id": "d_icd_procedures",
       "name": "d_icd_procedures",
-      "description": "Records from d_icd_procedures.csv.gz (86423 rows)",
+      "description": "Records from d_icd_procedures.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_18_icd_code",
+          "@id": "d_icd_procedures/icd_code",
           "name": "icd_code",
           "description": "Column 'icd_code' from d_icd_procedures.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_18_source_icd_code",
             "fileObject": {
-              "@id": "file_18"
+              "@id": "file_20"
             },
             "extract": {
               "column": "icd_code"
@@ -3452,14 +3601,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_18_icd_version",
+          "@id": "d_icd_procedures/icd_version",
           "name": "icd_version",
           "description": "Column 'icd_version' from d_icd_procedures.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_18_source_icd_version",
             "fileObject": {
-              "@id": "file_18"
+              "@id": "file_20"
             },
             "extract": {
               "column": "icd_version"
@@ -3468,14 +3616,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_18_long_title",
+          "@id": "d_icd_procedures/long_title",
           "name": "long_title",
           "description": "Column 'long_title' from d_icd_procedures.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_18_source_long_title",
             "fileObject": {
-              "@id": "file_18"
+              "@id": "file_20"
             },
             "extract": {
               "column": "long_title"
@@ -3486,20 +3633,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_19",
+      "@id": "omr",
       "name": "omr",
-      "description": "Records from omr.csv.gz (7753027 rows)",
+      "description": "Records from omr.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_19_subject_id",
+          "@id": "omr/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from omr.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_19_source_subject_id",
             "fileObject": {
-              "@id": "file_19"
+              "@id": "file_21"
             },
             "extract": {
               "column": "subject_id"
@@ -3508,14 +3654,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_19_chartdate",
+          "@id": "omr/chartdate",
           "name": "chartdate",
           "description": "Column 'chartdate' from omr.csv.gz",
           "dataType": "sc:Date",
           "source": {
-            "@id": "file_19_source_chartdate",
             "fileObject": {
-              "@id": "file_19"
+              "@id": "file_21"
             },
             "extract": {
               "column": "chartdate"
@@ -3524,14 +3669,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_19_seq_num",
+          "@id": "omr/seq_num",
           "name": "seq_num",
           "description": "Column 'seq_num' from omr.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_19_source_seq_num",
             "fileObject": {
-              "@id": "file_19"
+              "@id": "file_21"
             },
             "extract": {
               "column": "seq_num"
@@ -3540,14 +3684,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_19_result_name",
+          "@id": "omr/result_name",
           "name": "result_name",
           "description": "Column 'result_name' from omr.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_19_source_result_name",
             "fileObject": {
-              "@id": "file_19"
+              "@id": "file_21"
             },
             "extract": {
               "column": "result_name"
@@ -3556,14 +3699,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_19_result_value",
+          "@id": "omr/result_value",
           "name": "result_value",
           "description": "Column 'result_value' from omr.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_19_source_result_value",
             "fileObject": {
-              "@id": "file_19"
+              "@id": "file_21"
             },
             "extract": {
               "column": "result_value"
@@ -3574,20 +3716,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_20",
+      "@id": "emar",
       "name": "emar",
-      "description": "Records from emar.csv.gz (42808593 rows)",
+      "description": "Records from emar.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_20_subject_id",
+          "@id": "emar/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_20_source_subject_id",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "subject_id"
@@ -3596,14 +3737,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_hadm_id",
+          "@id": "emar/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_20_source_hadm_id",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "hadm_id"
@@ -3612,14 +3752,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_emar_id",
+          "@id": "emar/emar_id",
           "name": "emar_id",
           "description": "Column 'emar_id' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_20_source_emar_id",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "emar_id"
@@ -3628,14 +3767,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_emar_seq",
+          "@id": "emar/emar_seq",
           "name": "emar_seq",
           "description": "Column 'emar_seq' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_20_source_emar_seq",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "emar_seq"
@@ -3644,14 +3782,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_poe_id",
+          "@id": "emar/poe_id",
           "name": "poe_id",
           "description": "Column 'poe_id' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_20_source_poe_id",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "poe_id"
@@ -3660,14 +3797,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_pharmacy_id",
+          "@id": "emar/pharmacy_id",
           "name": "pharmacy_id",
           "description": "Column 'pharmacy_id' from emar.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_20_source_pharmacy_id",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "pharmacy_id"
@@ -3676,14 +3812,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_enter_provider_id",
+          "@id": "emar/enter_provider_id",
           "name": "enter_provider_id",
           "description": "Column 'enter_provider_id' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_20_source_enter_provider_id",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "enter_provider_id"
@@ -3692,14 +3827,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_charttime",
+          "@id": "emar/charttime",
           "name": "charttime",
           "description": "Column 'charttime' from emar.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_20_source_charttime",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "charttime"
@@ -3708,14 +3842,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_medication",
+          "@id": "emar/medication",
           "name": "medication",
           "description": "Column 'medication' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_20_source_medication",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "medication"
@@ -3724,14 +3857,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_event_txt",
+          "@id": "emar/event_txt",
           "name": "event_txt",
           "description": "Column 'event_txt' from emar.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_20_source_event_txt",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "event_txt"
@@ -3740,14 +3872,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_scheduletime",
+          "@id": "emar/scheduletime",
           "name": "scheduletime",
           "description": "Column 'scheduletime' from emar.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_20_source_scheduletime",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "scheduletime"
@@ -3756,14 +3887,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_20_storetime",
+          "@id": "emar/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from emar.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_20_source_storetime",
             "fileObject": {
-              "@id": "file_20"
+              "@id": "file_22"
             },
             "extract": {
               "column": "storetime"
@@ -3774,20 +3904,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_21",
+      "@id": "microbiologyevents",
       "name": "microbiologyevents",
-      "description": "Records from microbiologyevents.csv.gz (3988224 rows)",
+      "description": "Records from microbiologyevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_21_microevent_id",
+          "@id": "microbiologyevents/microevent_id",
           "name": "microevent_id",
           "description": "Column 'microevent_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_microevent_id",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "microevent_id"
@@ -3796,14 +3925,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_subject_id",
+          "@id": "microbiologyevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_subject_id",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "subject_id"
@@ -3812,14 +3940,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_hadm_id",
+          "@id": "microbiologyevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_hadm_id",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "hadm_id"
@@ -3828,14 +3955,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_micro_specimen_id",
+          "@id": "microbiologyevents/micro_specimen_id",
           "name": "micro_specimen_id",
           "description": "Column 'micro_specimen_id' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_micro_specimen_id",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "micro_specimen_id"
@@ -3844,14 +3970,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_order_provider_id",
+          "@id": "microbiologyevents/order_provider_id",
           "name": "order_provider_id",
           "description": "Column 'order_provider_id' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_order_provider_id",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "order_provider_id"
@@ -3860,14 +3985,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_chartdate",
+          "@id": "microbiologyevents/chartdate",
           "name": "chartdate",
           "description": "Column 'chartdate' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_21_source_chartdate",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "chartdate"
@@ -3876,14 +4000,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_charttime",
+          "@id": "microbiologyevents/charttime",
           "name": "charttime",
           "description": "Column 'charttime' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_21_source_charttime",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "charttime"
@@ -3892,14 +4015,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_spec_itemid",
+          "@id": "microbiologyevents/spec_itemid",
           "name": "spec_itemid",
           "description": "Column 'spec_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_spec_itemid",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "spec_itemid"
@@ -3908,14 +4030,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_spec_type_desc",
+          "@id": "microbiologyevents/spec_type_desc",
           "name": "spec_type_desc",
           "description": "Column 'spec_type_desc' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_spec_type_desc",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "spec_type_desc"
@@ -3924,14 +4045,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_test_seq",
+          "@id": "microbiologyevents/test_seq",
           "name": "test_seq",
           "description": "Column 'test_seq' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_test_seq",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "test_seq"
@@ -3940,14 +4060,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_storedate",
+          "@id": "microbiologyevents/storedate",
           "name": "storedate",
           "description": "Column 'storedate' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_21_source_storedate",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "storedate"
@@ -3956,14 +4075,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_storetime",
+          "@id": "microbiologyevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from microbiologyevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_21_source_storetime",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "storetime"
@@ -3972,14 +4090,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_test_itemid",
+          "@id": "microbiologyevents/test_itemid",
           "name": "test_itemid",
           "description": "Column 'test_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_test_itemid",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "test_itemid"
@@ -3988,14 +4105,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_test_name",
+          "@id": "microbiologyevents/test_name",
           "name": "test_name",
           "description": "Column 'test_name' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_test_name",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "test_name"
@@ -4004,14 +4120,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_org_itemid",
+          "@id": "microbiologyevents/org_itemid",
           "name": "org_itemid",
           "description": "Column 'org_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_org_itemid",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "org_itemid"
@@ -4020,14 +4135,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_org_name",
+          "@id": "microbiologyevents/org_name",
           "name": "org_name",
           "description": "Column 'org_name' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_org_name",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "org_name"
@@ -4036,14 +4150,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_isolate_num",
+          "@id": "microbiologyevents/isolate_num",
           "name": "isolate_num",
           "description": "Column 'isolate_num' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_isolate_num",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "isolate_num"
@@ -4052,14 +4165,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_quantity",
+          "@id": "microbiologyevents/quantity",
           "name": "quantity",
           "description": "Column 'quantity' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_quantity",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "quantity"
@@ -4068,14 +4180,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_ab_itemid",
+          "@id": "microbiologyevents/ab_itemid",
           "name": "ab_itemid",
           "description": "Column 'ab_itemid' from microbiologyevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_21_source_ab_itemid",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "ab_itemid"
@@ -4084,14 +4195,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_ab_name",
+          "@id": "microbiologyevents/ab_name",
           "name": "ab_name",
           "description": "Column 'ab_name' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_ab_name",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "ab_name"
@@ -4100,14 +4210,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_dilution_text",
+          "@id": "microbiologyevents/dilution_text",
           "name": "dilution_text",
           "description": "Column 'dilution_text' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_dilution_text",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "dilution_text"
@@ -4116,14 +4225,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_dilution_comparison",
+          "@id": "microbiologyevents/dilution_comparison",
           "name": "dilution_comparison",
           "description": "Column 'dilution_comparison' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_dilution_comparison",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "dilution_comparison"
@@ -4132,14 +4240,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_dilution_value",
+          "@id": "microbiologyevents/dilution_value",
           "name": "dilution_value",
           "description": "Column 'dilution_value' from microbiologyevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_21_source_dilution_value",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "dilution_value"
@@ -4148,14 +4255,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_interpretation",
+          "@id": "microbiologyevents/interpretation",
           "name": "interpretation",
           "description": "Column 'interpretation' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_interpretation",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "interpretation"
@@ -4164,14 +4270,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_comments",
+          "@id": "microbiologyevents/comments",
           "name": "comments",
           "description": "Column 'comments' from microbiologyevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_21_source_comments",
             "fileObject": {
-              "@id": "file_21"
+              "@id": "file_23"
             },
             "extract": {
               "column": "comments"
@@ -4182,20 +4287,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_22",
+      "@id": "datetimeevents",
       "name": "datetimeevents",
-      "description": "Records from datetimeevents.csv.gz (9979761 rows)",
+      "description": "Records from datetimeevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_22_subject_id",
+          "@id": "datetimeevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_22_source_subject_id",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "subject_id"
@@ -4204,14 +4308,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_hadm_id",
+          "@id": "datetimeevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_22_source_hadm_id",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "hadm_id"
@@ -4220,14 +4323,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_stay_id",
+          "@id": "datetimeevents/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_22_source_stay_id",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "stay_id"
@@ -4236,14 +4338,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_caregiver_id",
+          "@id": "datetimeevents/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_22_source_caregiver_id",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "caregiver_id"
@@ -4252,14 +4353,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_charttime",
+          "@id": "datetimeevents/charttime",
           "name": "charttime",
           "description": "Column 'charttime' from datetimeevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_22_source_charttime",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "charttime"
@@ -4268,14 +4368,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_storetime",
+          "@id": "datetimeevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from datetimeevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_22_source_storetime",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "storetime"
@@ -4284,14 +4383,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_itemid",
+          "@id": "datetimeevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_22_source_itemid",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "itemid"
@@ -4300,14 +4398,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_value",
+          "@id": "datetimeevents/value",
           "name": "value",
           "description": "Column 'value' from datetimeevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_22_source_value",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "value"
@@ -4316,14 +4413,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_valueuom",
+          "@id": "datetimeevents/valueuom",
           "name": "valueuom",
           "description": "Column 'valueuom' from datetimeevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_22_source_valueuom",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "valueuom"
@@ -4332,14 +4428,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_22_warning",
+          "@id": "datetimeevents/warning",
           "name": "warning",
           "description": "Column 'warning' from datetimeevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_22_source_warning",
             "fileObject": {
-              "@id": "file_22"
+              "@id": "file_24"
             },
             "extract": {
               "column": "warning"
@@ -4350,20 +4445,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_23",
+      "@id": "caregiver",
       "name": "caregiver",
-      "description": "Records from caregiver.csv.gz (17984 rows)",
+      "description": "Records from caregiver.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_23_caregiver_id",
+          "@id": "caregiver/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from caregiver.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_23_source_caregiver_id",
             "fileObject": {
-              "@id": "file_23"
+              "@id": "file_25"
             },
             "extract": {
               "column": "caregiver_id"
@@ -4374,20 +4468,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_24",
+      "@id": "ingredientevents",
       "name": "ingredientevents",
-      "description": "Records from ingredientevents.csv.gz (14253480 rows)",
+      "description": "Records from ingredientevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_24_subject_id",
+          "@id": "ingredientevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_subject_id",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "subject_id"
@@ -4396,14 +4489,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_hadm_id",
+          "@id": "ingredientevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_hadm_id",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "hadm_id"
@@ -4412,14 +4504,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_stay_id",
+          "@id": "ingredientevents/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_stay_id",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "stay_id"
@@ -4428,14 +4519,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_caregiver_id",
+          "@id": "ingredientevents/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_caregiver_id",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "caregiver_id"
@@ -4444,14 +4534,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_starttime",
+          "@id": "ingredientevents/starttime",
           "name": "starttime",
           "description": "Column 'starttime' from ingredientevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_24_source_starttime",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "starttime"
@@ -4460,14 +4549,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_endtime",
+          "@id": "ingredientevents/endtime",
           "name": "endtime",
           "description": "Column 'endtime' from ingredientevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_24_source_endtime",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "endtime"
@@ -4476,14 +4564,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_storetime",
+          "@id": "ingredientevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from ingredientevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_24_source_storetime",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "storetime"
@@ -4492,14 +4579,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_itemid",
+          "@id": "ingredientevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_itemid",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "itemid"
@@ -4508,14 +4594,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_amount",
+          "@id": "ingredientevents/amount",
           "name": "amount",
           "description": "Column 'amount' from ingredientevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_24_source_amount",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "amount"
@@ -4524,14 +4609,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_amountuom",
+          "@id": "ingredientevents/amountuom",
           "name": "amountuom",
           "description": "Column 'amountuom' from ingredientevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_24_source_amountuom",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "amountuom"
@@ -4540,14 +4624,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_rate",
+          "@id": "ingredientevents/rate",
           "name": "rate",
           "description": "Column 'rate' from ingredientevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_24_source_rate",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "rate"
@@ -4556,14 +4639,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_rateuom",
+          "@id": "ingredientevents/rateuom",
           "name": "rateuom",
           "description": "Column 'rateuom' from ingredientevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_24_source_rateuom",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "rateuom"
@@ -4572,14 +4654,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_orderid",
+          "@id": "ingredientevents/orderid",
           "name": "orderid",
           "description": "Column 'orderid' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_orderid",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "orderid"
@@ -4588,14 +4669,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_linkorderid",
+          "@id": "ingredientevents/linkorderid",
           "name": "linkorderid",
           "description": "Column 'linkorderid' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_linkorderid",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "linkorderid"
@@ -4604,14 +4684,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_statusdescription",
+          "@id": "ingredientevents/statusdescription",
           "name": "statusdescription",
           "description": "Column 'statusdescription' from ingredientevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_24_source_statusdescription",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "statusdescription"
@@ -4620,14 +4699,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_originalamount",
+          "@id": "ingredientevents/originalamount",
           "name": "originalamount",
           "description": "Column 'originalamount' from ingredientevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_24_source_originalamount",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "originalamount"
@@ -4636,14 +4714,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_originalrate",
+          "@id": "ingredientevents/originalrate",
           "name": "originalrate",
           "description": "Column 'originalrate' from ingredientevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_24_source_originalrate",
             "fileObject": {
-              "@id": "file_24"
+              "@id": "file_26"
             },
             "extract": {
               "column": "originalrate"
@@ -4654,20 +4731,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_25",
+      "@id": "inputevents",
       "name": "inputevents",
-      "description": "Records from inputevents.csv.gz (10953713 rows)",
+      "description": "Records from inputevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_25_subject_id",
+          "@id": "inputevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_subject_id",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "subject_id"
@@ -4676,14 +4752,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_hadm_id",
+          "@id": "inputevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_hadm_id",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "hadm_id"
@@ -4692,14 +4767,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_stay_id",
+          "@id": "inputevents/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_stay_id",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "stay_id"
@@ -4708,14 +4782,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_caregiver_id",
+          "@id": "inputevents/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_caregiver_id",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "caregiver_id"
@@ -4724,14 +4797,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_starttime",
+          "@id": "inputevents/starttime",
           "name": "starttime",
           "description": "Column 'starttime' from inputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_25_source_starttime",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "starttime"
@@ -4740,14 +4812,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_endtime",
+          "@id": "inputevents/endtime",
           "name": "endtime",
           "description": "Column 'endtime' from inputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_25_source_endtime",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "endtime"
@@ -4756,14 +4827,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_storetime",
+          "@id": "inputevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from inputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_25_source_storetime",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "storetime"
@@ -4772,14 +4842,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_itemid",
+          "@id": "inputevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_itemid",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "itemid"
@@ -4788,14 +4857,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_amount",
+          "@id": "inputevents/amount",
           "name": "amount",
           "description": "Column 'amount' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_25_source_amount",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "amount"
@@ -4804,14 +4872,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_amountuom",
+          "@id": "inputevents/amountuom",
           "name": "amountuom",
           "description": "Column 'amountuom' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_amountuom",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "amountuom"
@@ -4820,14 +4887,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_rate",
+          "@id": "inputevents/rate",
           "name": "rate",
           "description": "Column 'rate' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_25_source_rate",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "rate"
@@ -4836,14 +4902,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_rateuom",
+          "@id": "inputevents/rateuom",
           "name": "rateuom",
           "description": "Column 'rateuom' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_rateuom",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "rateuom"
@@ -4852,14 +4917,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_orderid",
+          "@id": "inputevents/orderid",
           "name": "orderid",
           "description": "Column 'orderid' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_orderid",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "orderid"
@@ -4868,14 +4932,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_linkorderid",
+          "@id": "inputevents/linkorderid",
           "name": "linkorderid",
           "description": "Column 'linkorderid' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_linkorderid",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "linkorderid"
@@ -4884,14 +4947,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_ordercategoryname",
+          "@id": "inputevents/ordercategoryname",
           "name": "ordercategoryname",
           "description": "Column 'ordercategoryname' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_ordercategoryname",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "ordercategoryname"
@@ -4900,14 +4962,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_secondaryordercategoryname",
+          "@id": "inputevents/secondaryordercategoryname",
           "name": "secondaryordercategoryname",
           "description": "Column 'secondaryordercategoryname' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_secondaryordercategoryname",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "secondaryordercategoryname"
@@ -4916,14 +4977,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_ordercomponenttypedescription",
+          "@id": "inputevents/ordercomponenttypedescription",
           "name": "ordercomponenttypedescription",
           "description": "Column 'ordercomponenttypedescription' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_ordercomponenttypedescription",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "ordercomponenttypedescription"
@@ -4932,14 +4992,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_ordercategorydescription",
+          "@id": "inputevents/ordercategorydescription",
           "name": "ordercategorydescription",
           "description": "Column 'ordercategorydescription' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_ordercategorydescription",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "ordercategorydescription"
@@ -4948,14 +5007,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_patientweight",
+          "@id": "inputevents/patientweight",
           "name": "patientweight",
           "description": "Column 'patientweight' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_25_source_patientweight",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "patientweight"
@@ -4964,14 +5022,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_totalamount",
+          "@id": "inputevents/totalamount",
           "name": "totalamount",
           "description": "Column 'totalamount' from inputevents.csv.gz",
-          "dataType": "cr:Float64",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_totalamount",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "totalamount"
@@ -4980,14 +5037,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_totalamountuom",
+          "@id": "inputevents/totalamountuom",
           "name": "totalamountuom",
           "description": "Column 'totalamountuom' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_totalamountuom",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "totalamountuom"
@@ -4996,14 +5052,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_isopenbag",
+          "@id": "inputevents/isopenbag",
           "name": "isopenbag",
           "description": "Column 'isopenbag' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_isopenbag",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "isopenbag"
@@ -5012,14 +5067,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_continueinnextdept",
+          "@id": "inputevents/continueinnextdept",
           "name": "continueinnextdept",
           "description": "Column 'continueinnextdept' from inputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_25_source_continueinnextdept",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "continueinnextdept"
@@ -5028,14 +5082,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_statusdescription",
+          "@id": "inputevents/statusdescription",
           "name": "statusdescription",
           "description": "Column 'statusdescription' from inputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_25_source_statusdescription",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "statusdescription"
@@ -5044,14 +5097,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_originalamount",
+          "@id": "inputevents/originalamount",
           "name": "originalamount",
           "description": "Column 'originalamount' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_25_source_originalamount",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "originalamount"
@@ -5060,14 +5112,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_25_originalrate",
+          "@id": "inputevents/originalrate",
           "name": "originalrate",
           "description": "Column 'originalrate' from inputevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_25_source_originalrate",
             "fileObject": {
-              "@id": "file_25"
+              "@id": "file_27"
             },
             "extract": {
               "column": "originalrate"
@@ -5078,20 +5129,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_26",
+      "@id": "procedureevents",
       "name": "procedureevents",
-      "description": "Records from procedureevents.csv.gz (808706 rows)",
+      "description": "Records from procedureevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_26_subject_id",
+          "@id": "procedureevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_subject_id",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "subject_id"
@@ -5100,14 +5150,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_hadm_id",
+          "@id": "procedureevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_hadm_id",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "hadm_id"
@@ -5116,14 +5165,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_stay_id",
+          "@id": "procedureevents/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_stay_id",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "stay_id"
@@ -5132,14 +5180,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_caregiver_id",
+          "@id": "procedureevents/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_caregiver_id",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "caregiver_id"
@@ -5148,14 +5195,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_starttime",
+          "@id": "procedureevents/starttime",
           "name": "starttime",
           "description": "Column 'starttime' from procedureevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_26_source_starttime",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "starttime"
@@ -5164,14 +5210,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_endtime",
+          "@id": "procedureevents/endtime",
           "name": "endtime",
           "description": "Column 'endtime' from procedureevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_26_source_endtime",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "endtime"
@@ -5180,14 +5225,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_storetime",
+          "@id": "procedureevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from procedureevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_26_source_storetime",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "storetime"
@@ -5196,14 +5240,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_itemid",
+          "@id": "procedureevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_itemid",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "itemid"
@@ -5212,14 +5255,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_value",
+          "@id": "procedureevents/value",
           "name": "value",
           "description": "Column 'value' from procedureevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_26_source_value",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "value"
@@ -5228,14 +5270,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_valueuom",
+          "@id": "procedureevents/valueuom",
           "name": "valueuom",
           "description": "Column 'valueuom' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_26_source_valueuom",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "valueuom"
@@ -5244,14 +5285,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_location",
+          "@id": "procedureevents/location",
           "name": "location",
           "description": "Column 'location' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_26_source_location",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "location"
@@ -5260,14 +5300,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_locationcategory",
+          "@id": "procedureevents/locationcategory",
           "name": "locationcategory",
           "description": "Column 'locationcategory' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_26_source_locationcategory",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "locationcategory"
@@ -5276,14 +5315,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_orderid",
+          "@id": "procedureevents/orderid",
           "name": "orderid",
           "description": "Column 'orderid' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_orderid",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "orderid"
@@ -5292,14 +5330,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_linkorderid",
+          "@id": "procedureevents/linkorderid",
           "name": "linkorderid",
           "description": "Column 'linkorderid' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_linkorderid",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "linkorderid"
@@ -5308,14 +5345,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_ordercategoryname",
+          "@id": "procedureevents/ordercategoryname",
           "name": "ordercategoryname",
           "description": "Column 'ordercategoryname' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_26_source_ordercategoryname",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "ordercategoryname"
@@ -5324,14 +5360,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_ordercategorydescription",
+          "@id": "procedureevents/ordercategorydescription",
           "name": "ordercategorydescription",
           "description": "Column 'ordercategorydescription' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_26_source_ordercategorydescription",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "ordercategorydescription"
@@ -5340,14 +5375,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_patientweight",
+          "@id": "procedureevents/patientweight",
           "name": "patientweight",
           "description": "Column 'patientweight' from procedureevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_26_source_patientweight",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "patientweight"
@@ -5356,14 +5390,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_isopenbag",
+          "@id": "procedureevents/isopenbag",
           "name": "isopenbag",
           "description": "Column 'isopenbag' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_isopenbag",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "isopenbag"
@@ -5372,14 +5405,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_continueinnextdept",
+          "@id": "procedureevents/continueinnextdept",
           "name": "continueinnextdept",
           "description": "Column 'continueinnextdept' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_continueinnextdept",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "continueinnextdept"
@@ -5388,14 +5420,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_statusdescription",
+          "@id": "procedureevents/statusdescription",
           "name": "statusdescription",
           "description": "Column 'statusdescription' from procedureevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_26_source_statusdescription",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "statusdescription"
@@ -5404,14 +5435,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_originalamount",
+          "@id": "procedureevents/originalamount",
           "name": "originalamount",
           "description": "Column 'originalamount' from procedureevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_26_source_originalamount",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "originalamount"
@@ -5420,14 +5450,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_26_originalrate",
+          "@id": "procedureevents/originalrate",
           "name": "originalrate",
           "description": "Column 'originalrate' from procedureevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_26_source_originalrate",
             "fileObject": {
-              "@id": "file_26"
+              "@id": "file_28"
             },
             "extract": {
               "column": "originalrate"
@@ -5438,20 +5467,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_27",
+      "@id": "d_items",
       "name": "d_items",
-      "description": "Records from d_items.csv.gz (4095 rows)",
+      "description": "Records from d_items.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_27_itemid",
+          "@id": "d_items/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from d_items.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_27_source_itemid",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "itemid"
@@ -5460,14 +5488,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_label",
+          "@id": "d_items/label",
           "name": "label",
           "description": "Column 'label' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_27_source_label",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "label"
@@ -5476,14 +5503,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_abbreviation",
+          "@id": "d_items/abbreviation",
           "name": "abbreviation",
           "description": "Column 'abbreviation' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_27_source_abbreviation",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "abbreviation"
@@ -5492,14 +5518,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_linksto",
+          "@id": "d_items/linksto",
           "name": "linksto",
           "description": "Column 'linksto' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_27_source_linksto",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "linksto"
@@ -5508,14 +5533,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_category",
+          "@id": "d_items/category",
           "name": "category",
           "description": "Column 'category' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_27_source_category",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "category"
@@ -5524,14 +5548,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_unitname",
+          "@id": "d_items/unitname",
           "name": "unitname",
           "description": "Column 'unitname' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_27_source_unitname",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "unitname"
@@ -5540,14 +5563,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_param_type",
+          "@id": "d_items/param_type",
           "name": "param_type",
           "description": "Column 'param_type' from d_items.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_27_source_param_type",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "param_type"
@@ -5556,14 +5578,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_lownormalvalue",
+          "@id": "d_items/lownormalvalue",
           "name": "lownormalvalue",
           "description": "Column 'lownormalvalue' from d_items.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_27_source_lownormalvalue",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "lownormalvalue"
@@ -5572,14 +5593,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_highnormalvalue",
+          "@id": "d_items/highnormalvalue",
           "name": "highnormalvalue",
           "description": "Column 'highnormalvalue' from d_items.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_27_source_highnormalvalue",
             "fileObject": {
-              "@id": "file_27"
+              "@id": "file_29"
             },
             "extract": {
               "column": "highnormalvalue"
@@ -5590,20 +5610,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_28",
+      "@id": "chartevents",
       "name": "chartevents",
-      "description": "Records from chartevents.csv.gz (432997491 rows)",
+      "description": "Records from chartevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_28_subject_id",
+          "@id": "chartevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_28_source_subject_id",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "subject_id"
@@ -5612,14 +5631,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_hadm_id",
+          "@id": "chartevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_28_source_hadm_id",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "hadm_id"
@@ -5628,14 +5646,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_stay_id",
+          "@id": "chartevents/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_28_source_stay_id",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "stay_id"
@@ -5644,14 +5661,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_caregiver_id",
+          "@id": "chartevents/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_28_source_caregiver_id",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "caregiver_id"
@@ -5660,14 +5676,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_charttime",
+          "@id": "chartevents/charttime",
           "name": "charttime",
           "description": "Column 'charttime' from chartevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_28_source_charttime",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "charttime"
@@ -5676,14 +5691,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_storetime",
+          "@id": "chartevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from chartevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_28_source_storetime",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "storetime"
@@ -5692,14 +5706,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_itemid",
+          "@id": "chartevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_28_source_itemid",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "itemid"
@@ -5708,14 +5721,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_value",
+          "@id": "chartevents/value",
           "name": "value",
           "description": "Column 'value' from chartevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_28_source_value",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "value"
@@ -5724,14 +5736,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_valuenum",
+          "@id": "chartevents/valuenum",
           "name": "valuenum",
           "description": "Column 'valuenum' from chartevents.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_28_source_valuenum",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "valuenum"
@@ -5740,14 +5751,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_valueuom",
+          "@id": "chartevents/valueuom",
           "name": "valueuom",
           "description": "Column 'valueuom' from chartevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_28_source_valueuom",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "valueuom"
@@ -5756,14 +5766,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_28_warning",
+          "@id": "chartevents/warning",
           "name": "warning",
           "description": "Column 'warning' from chartevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_28_source_warning",
             "fileObject": {
-              "@id": "file_28"
+              "@id": "file_30"
             },
             "extract": {
               "column": "warning"
@@ -5774,20 +5783,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_29",
+      "@id": "icustays",
       "name": "icustays",
-      "description": "Records from icustays.csv.gz (94458 rows)",
+      "description": "Records from icustays.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_29_subject_id",
+          "@id": "icustays/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from icustays.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_29_source_subject_id",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "subject_id"
@@ -5796,14 +5804,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_hadm_id",
+          "@id": "icustays/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from icustays.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_29_source_hadm_id",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "hadm_id"
@@ -5812,14 +5819,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_stay_id",
+          "@id": "icustays/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from icustays.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_29_source_stay_id",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "stay_id"
@@ -5828,14 +5834,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_first_careunit",
+          "@id": "icustays/first_careunit",
           "name": "first_careunit",
           "description": "Column 'first_careunit' from icustays.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_29_source_first_careunit",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "first_careunit"
@@ -5844,14 +5849,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_last_careunit",
+          "@id": "icustays/last_careunit",
           "name": "last_careunit",
           "description": "Column 'last_careunit' from icustays.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_29_source_last_careunit",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "last_careunit"
@@ -5860,14 +5864,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_intime",
+          "@id": "icustays/intime",
           "name": "intime",
           "description": "Column 'intime' from icustays.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_29_source_intime",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "intime"
@@ -5876,14 +5879,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_outtime",
+          "@id": "icustays/outtime",
           "name": "outtime",
           "description": "Column 'outtime' from icustays.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_29_source_outtime",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "outtime"
@@ -5892,14 +5894,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_29_los",
+          "@id": "icustays/los",
           "name": "los",
           "description": "Column 'los' from icustays.csv.gz",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "file_29_source_los",
             "fileObject": {
-              "@id": "file_29"
+              "@id": "file_31"
             },
             "extract": {
               "column": "los"
@@ -5910,20 +5911,19 @@
     },
     {
       "@type": "cr:RecordSet",
-      "@id": "recordset_30",
+      "@id": "outputevents",
       "name": "outputevents",
-      "description": "Records from outputevents.csv.gz (5359395 rows)",
+      "description": "Records from outputevents.csv.gz",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_30_subject_id",
+          "@id": "outputevents/subject_id",
           "name": "subject_id",
           "description": "Column 'subject_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_30_source_subject_id",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "subject_id"
@@ -5932,14 +5932,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_hadm_id",
+          "@id": "outputevents/hadm_id",
           "name": "hadm_id",
           "description": "Column 'hadm_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_30_source_hadm_id",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "hadm_id"
@@ -5948,14 +5947,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_stay_id",
+          "@id": "outputevents/stay_id",
           "name": "stay_id",
           "description": "Column 'stay_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_30_source_stay_id",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "stay_id"
@@ -5964,14 +5962,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_caregiver_id",
+          "@id": "outputevents/caregiver_id",
           "name": "caregiver_id",
           "description": "Column 'caregiver_id' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_30_source_caregiver_id",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "caregiver_id"
@@ -5980,14 +5977,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_charttime",
+          "@id": "outputevents/charttime",
           "name": "charttime",
           "description": "Column 'charttime' from outputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_30_source_charttime",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "charttime"
@@ -5996,14 +5992,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_storetime",
+          "@id": "outputevents/storetime",
           "name": "storetime",
           "description": "Column 'storetime' from outputevents.csv.gz",
           "dataType": "sc:DateTime",
           "source": {
-            "@id": "file_30_source_storetime",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "storetime"
@@ -6012,14 +6007,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_itemid",
+          "@id": "outputevents/itemid",
           "name": "itemid",
           "description": "Column 'itemid' from outputevents.csv.gz",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "file_30_source_itemid",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "itemid"
@@ -6028,14 +6022,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_value",
+          "@id": "outputevents/value",
           "name": "value",
           "description": "Column 'value' from outputevents.csv.gz",
-          "dataType": "cr:Float64",
+          "dataType": "cr:Int64",
           "source": {
-            "@id": "file_30_source_value",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "value"
@@ -6044,14 +6037,13 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_valueuom",
+          "@id": "outputevents/valueuom",
           "name": "valueuom",
           "description": "Column 'valueuom' from outputevents.csv.gz",
           "dataType": "sc:Text",
           "source": {
-            "@id": "file_30_source_valueuom",
             "fileObject": {
-              "@id": "file_30"
+              "@id": "file_32"
             },
             "extract": {
               "column": "valueuom"

--- a/tests/data/output/mitdb_wfdb_croissant.jsonld
+++ b/tests/data/output/mitdb_wfdb_croissant.jsonld
@@ -1991,7 +1991,6 @@
           "description": "Signal 'MLII' from 209",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_0_source_MLII",
             "fileObject": {
               "@id": "file_0"
             }
@@ -2004,7 +2003,6 @@
           "description": "Signal 'V1' from 209",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_0_source_V1",
             "fileObject": {
               "@id": "file_0"
             }
@@ -2025,7 +2023,6 @@
           "description": "Signal 'MLII' from 221",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_3_source_MLII",
             "fileObject": {
               "@id": "file_3"
             }
@@ -2038,7 +2035,6 @@
           "description": "Signal 'V1' from 221",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_3_source_V1",
             "fileObject": {
               "@id": "file_3"
             }
@@ -2059,7 +2055,6 @@
           "description": "Signal 'MLII' from 220",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_6_source_MLII",
             "fileObject": {
               "@id": "file_6"
             }
@@ -2072,7 +2067,6 @@
           "description": "Signal 'V1' from 220",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_6_source_V1",
             "fileObject": {
               "@id": "file_6"
             }
@@ -2093,7 +2087,6 @@
           "description": "Signal 'MLII' from 234",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_9_source_MLII",
             "fileObject": {
               "@id": "file_9"
             }
@@ -2106,7 +2099,6 @@
           "description": "Signal 'V1' from 234",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_9_source_V1",
             "fileObject": {
               "@id": "file_9"
             }
@@ -2127,7 +2119,6 @@
           "description": "Signal 'MLII' from 208",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_12_source_MLII",
             "fileObject": {
               "@id": "file_12"
             }
@@ -2140,7 +2131,6 @@
           "description": "Signal 'V1' from 208",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_12_source_V1",
             "fileObject": {
               "@id": "file_12"
             }
@@ -2161,7 +2151,6 @@
           "description": "Signal 'MLII' from 222",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_15_source_MLII",
             "fileObject": {
               "@id": "file_15"
             }
@@ -2174,7 +2163,6 @@
           "description": "Signal 'V1' from 222",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_15_source_V1",
             "fileObject": {
               "@id": "file_15"
             }
@@ -2195,7 +2183,6 @@
           "description": "Signal 'MLII' from 223",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_18_source_MLII",
             "fileObject": {
               "@id": "file_18"
             }
@@ -2208,7 +2195,6 @@
           "description": "Signal 'V1' from 223",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_18_source_V1",
             "fileObject": {
               "@id": "file_18"
             }
@@ -2229,7 +2215,6 @@
           "description": "Signal 'MLII' from 233",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_21_source_MLII",
             "fileObject": {
               "@id": "file_21"
             }
@@ -2242,7 +2227,6 @@
           "description": "Signal 'V1' from 233",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_21_source_V1",
             "fileObject": {
               "@id": "file_21"
             }
@@ -2263,7 +2247,6 @@
           "description": "Signal 'MLII' from 232",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_24_source_MLII",
             "fileObject": {
               "@id": "file_24"
             }
@@ -2276,7 +2259,6 @@
           "description": "Signal 'V1' from 232",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_24_source_V1",
             "fileObject": {
               "@id": "file_24"
             }
@@ -2297,7 +2279,6 @@
           "description": "Signal 'MLII' from 230",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_27_source_MLII",
             "fileObject": {
               "@id": "file_27"
             }
@@ -2310,7 +2291,6 @@
           "description": "Signal 'V1' from 230",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_27_source_V1",
             "fileObject": {
               "@id": "file_27"
             }
@@ -2331,7 +2311,6 @@
           "description": "Signal 'MLII' from 219",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_30_source_MLII",
             "fileObject": {
               "@id": "file_30"
             }
@@ -2344,7 +2323,6 @@
           "description": "Signal 'V1' from 219",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_30_source_V1",
             "fileObject": {
               "@id": "file_30"
             }
@@ -2365,7 +2343,6 @@
           "description": "Signal 'MLII' from 231",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_33_source_MLII",
             "fileObject": {
               "@id": "file_33"
             }
@@ -2378,7 +2355,6 @@
           "description": "Signal 'V1' from 231",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_33_source_V1",
             "fileObject": {
               "@id": "file_33"
             }
@@ -2399,7 +2375,6 @@
           "description": "Signal 'MLII' from 108",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_36_source_MLII",
             "fileObject": {
               "@id": "file_36"
             }
@@ -2412,7 +2387,6 @@
           "description": "Signal 'V1' from 108",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_36_source_V1",
             "fileObject": {
               "@id": "file_36"
             }
@@ -2433,7 +2407,6 @@
           "description": "Signal 'MLII' from 121",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_39_source_MLII",
             "fileObject": {
               "@id": "file_39"
             }
@@ -2446,7 +2419,6 @@
           "description": "Signal 'V1' from 121",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_39_source_V1",
             "fileObject": {
               "@id": "file_39"
             }
@@ -2467,7 +2439,6 @@
           "description": "Signal 'MLII' from 109",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_42_source_MLII",
             "fileObject": {
               "@id": "file_42"
             }
@@ -2480,7 +2451,6 @@
           "description": "Signal 'V1' from 109",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_42_source_V1",
             "fileObject": {
               "@id": "file_42"
             }
@@ -2501,7 +2471,6 @@
           "description": "Signal 'MLII' from 123",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_45_source_MLII",
             "fileObject": {
               "@id": "file_45"
             }
@@ -2514,7 +2483,6 @@
           "description": "Signal 'V5' from 123",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_45_source_V5",
             "fileObject": {
               "@id": "file_45"
             }
@@ -2535,7 +2503,6 @@
           "description": "Signal 'MLII' from 122",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_48_source_MLII",
             "fileObject": {
               "@id": "file_48"
             }
@@ -2548,7 +2515,6 @@
           "description": "Signal 'V1' from 122",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_48_source_V1",
             "fileObject": {
               "@id": "file_48"
             }
@@ -2569,7 +2535,6 @@
           "description": "Signal 'MLII' from 119",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_51_source_MLII",
             "fileObject": {
               "@id": "file_51"
             }
@@ -2582,7 +2547,6 @@
           "description": "Signal 'V1' from 119",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_51_source_V1",
             "fileObject": {
               "@id": "file_51"
             }
@@ -2603,7 +2567,6 @@
           "description": "Signal 'MLII' from 118",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_54_source_MLII",
             "fileObject": {
               "@id": "file_54"
             }
@@ -2616,7 +2579,6 @@
           "description": "Signal 'V1' from 118",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_54_source_V1",
             "fileObject": {
               "@id": "file_54"
             }
@@ -2637,7 +2599,6 @@
           "description": "Signal 'MLII' from 124",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_57_source_MLII",
             "fileObject": {
               "@id": "file_57"
             }
@@ -2650,7 +2611,6 @@
           "description": "Signal 'V4' from 124",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_57_source_V4",
             "fileObject": {
               "@id": "file_57"
             }
@@ -2671,7 +2631,6 @@
           "description": "Signal 'MLII' from 101",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_60_source_MLII",
             "fileObject": {
               "@id": "file_60"
             }
@@ -2684,7 +2643,6 @@
           "description": "Signal 'V1' from 101",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_60_source_V1",
             "fileObject": {
               "@id": "file_60"
             }
@@ -2705,7 +2663,6 @@
           "description": "Signal 'MLII' from 115",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_63_source_MLII",
             "fileObject": {
               "@id": "file_63"
             }
@@ -2718,7 +2675,6 @@
           "description": "Signal 'V1' from 115",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_63_source_V1",
             "fileObject": {
               "@id": "file_63"
             }
@@ -2739,7 +2695,6 @@
           "description": "Signal 'V5' from 114",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_66_source_V5",
             "fileObject": {
               "@id": "file_66"
             }
@@ -2752,7 +2707,6 @@
           "description": "Signal 'MLII' from 114",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_66_source_MLII",
             "fileObject": {
               "@id": "file_66"
             }
@@ -2773,7 +2727,6 @@
           "description": "Signal 'MLII' from 100",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_69_source_MLII",
             "fileObject": {
               "@id": "file_69"
             }
@@ -2786,7 +2739,6 @@
           "description": "Signal 'V5' from 100",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_69_source_V5",
             "fileObject": {
               "@id": "file_69"
             }
@@ -2807,7 +2759,6 @@
           "description": "Signal 'MLII' from 116",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_72_source_MLII",
             "fileObject": {
               "@id": "file_72"
             }
@@ -2820,7 +2771,6 @@
           "description": "Signal 'V1' from 116",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_72_source_V1",
             "fileObject": {
               "@id": "file_72"
             }
@@ -2841,7 +2791,6 @@
           "description": "Signal 'V5' from 102",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_75_source_V5",
             "fileObject": {
               "@id": "file_75"
             }
@@ -2854,7 +2803,6 @@
           "description": "Signal 'V2' from 102",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_75_source_V2",
             "fileObject": {
               "@id": "file_75"
             }
@@ -2875,7 +2823,6 @@
           "description": "Signal 'MLII' from 103",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_78_source_MLII",
             "fileObject": {
               "@id": "file_78"
             }
@@ -2888,7 +2835,6 @@
           "description": "Signal 'V2' from 103",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_78_source_V2",
             "fileObject": {
               "@id": "file_78"
             }
@@ -2909,7 +2855,6 @@
           "description": "Signal 'MLII' from 117",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_81_source_MLII",
             "fileObject": {
               "@id": "file_81"
             }
@@ -2922,7 +2867,6 @@
           "description": "Signal 'V2' from 117",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_81_source_V2",
             "fileObject": {
               "@id": "file_81"
             }
@@ -2943,7 +2887,6 @@
           "description": "Signal 'MLII' from 113",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_84_source_MLII",
             "fileObject": {
               "@id": "file_84"
             }
@@ -2956,7 +2899,6 @@
           "description": "Signal 'V1' from 113",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_84_source_V1",
             "fileObject": {
               "@id": "file_84"
             }
@@ -2977,7 +2919,6 @@
           "description": "Signal 'MLII' from 107",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_87_source_MLII",
             "fileObject": {
               "@id": "file_87"
             }
@@ -2990,7 +2931,6 @@
           "description": "Signal 'V1' from 107",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_87_source_V1",
             "fileObject": {
               "@id": "file_87"
             }
@@ -3011,7 +2951,6 @@
           "description": "Signal 'MLII' from 106",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_90_source_MLII",
             "fileObject": {
               "@id": "file_90"
             }
@@ -3024,7 +2963,6 @@
           "description": "Signal 'V1' from 106",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_90_source_V1",
             "fileObject": {
               "@id": "file_90"
             }
@@ -3045,7 +2983,6 @@
           "description": "Signal 'MLII' from 112",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_93_source_MLII",
             "fileObject": {
               "@id": "file_93"
             }
@@ -3058,7 +2995,6 @@
           "description": "Signal 'V1' from 112",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_93_source_V1",
             "fileObject": {
               "@id": "file_93"
             }
@@ -3079,7 +3015,6 @@
           "description": "Signal 'V5' from 104",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_96_source_V5",
             "fileObject": {
               "@id": "file_96"
             }
@@ -3092,7 +3027,6 @@
           "description": "Signal 'V2' from 104",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_96_source_V2",
             "fileObject": {
               "@id": "file_96"
             }
@@ -3113,7 +3047,6 @@
           "description": "Signal 'MLII' from 111",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_99_source_MLII",
             "fileObject": {
               "@id": "file_99"
             }
@@ -3126,7 +3059,6 @@
           "description": "Signal 'V1' from 111",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_99_source_V1",
             "fileObject": {
               "@id": "file_99"
             }
@@ -3147,7 +3079,6 @@
           "description": "Signal 'MLII' from 105",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_102_source_MLII",
             "fileObject": {
               "@id": "file_102"
             }
@@ -3160,7 +3091,6 @@
           "description": "Signal 'V1' from 105",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_102_source_V1",
             "fileObject": {
               "@id": "file_102"
             }
@@ -3181,7 +3111,6 @@
           "description": "Signal 'MLII' from 228",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_105_source_MLII",
             "fileObject": {
               "@id": "file_105"
             }
@@ -3194,7 +3123,6 @@
           "description": "Signal 'V1' from 228",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_105_source_V1",
             "fileObject": {
               "@id": "file_105"
             }
@@ -3215,7 +3143,6 @@
           "description": "Signal 'MLII' from 214",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_108_source_MLII",
             "fileObject": {
               "@id": "file_108"
             }
@@ -3228,7 +3155,6 @@
           "description": "Signal 'V1' from 214",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_108_source_V1",
             "fileObject": {
               "@id": "file_108"
             }
@@ -3249,7 +3175,6 @@
           "description": "Signal 'MLII' from 200",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_111_source_MLII",
             "fileObject": {
               "@id": "file_111"
             }
@@ -3262,7 +3187,6 @@
           "description": "Signal 'V1' from 200",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_111_source_V1",
             "fileObject": {
               "@id": "file_111"
             }
@@ -3283,7 +3207,6 @@
           "description": "Signal 'MLII' from 201",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_114_source_MLII",
             "fileObject": {
               "@id": "file_114"
             }
@@ -3296,7 +3219,6 @@
           "description": "Signal 'V1' from 201",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_114_source_V1",
             "fileObject": {
               "@id": "file_114"
             }
@@ -3317,7 +3239,6 @@
           "description": "Signal 'MLII' from 215",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_117_source_MLII",
             "fileObject": {
               "@id": "file_117"
             }
@@ -3330,7 +3251,6 @@
           "description": "Signal 'V1' from 215",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_117_source_V1",
             "fileObject": {
               "@id": "file_117"
             }
@@ -3351,7 +3271,6 @@
           "description": "Signal 'MLII' from 203",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_120_source_MLII",
             "fileObject": {
               "@id": "file_120"
             }
@@ -3364,7 +3283,6 @@
           "description": "Signal 'V1' from 203",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_120_source_V1",
             "fileObject": {
               "@id": "file_120"
             }
@@ -3385,7 +3303,6 @@
           "description": "Signal 'MLII' from 217",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_123_source_MLII",
             "fileObject": {
               "@id": "file_123"
             }
@@ -3398,7 +3315,6 @@
           "description": "Signal 'V1' from 217",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_123_source_V1",
             "fileObject": {
               "@id": "file_123"
             }
@@ -3419,7 +3335,6 @@
           "description": "Signal 'MLII' from 202",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_126_source_MLII",
             "fileObject": {
               "@id": "file_126"
             }
@@ -3432,7 +3347,6 @@
           "description": "Signal 'V1' from 202",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_126_source_V1",
             "fileObject": {
               "@id": "file_126"
             }
@@ -3453,7 +3367,6 @@
           "description": "Signal 'MLII' from 212",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_129_source_MLII",
             "fileObject": {
               "@id": "file_129"
             }
@@ -3466,7 +3379,6 @@
           "description": "Signal 'V1' from 212",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_129_source_V1",
             "fileObject": {
               "@id": "file_129"
             }
@@ -3487,7 +3399,6 @@
           "description": "Signal 'MLII' from 213",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_132_source_MLII",
             "fileObject": {
               "@id": "file_132"
             }
@@ -3500,7 +3411,6 @@
           "description": "Signal 'V1' from 213",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_132_source_V1",
             "fileObject": {
               "@id": "file_132"
             }
@@ -3521,7 +3431,6 @@
           "description": "Signal 'MLII' from 207",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_135_source_MLII",
             "fileObject": {
               "@id": "file_135"
             }
@@ -3534,7 +3443,6 @@
           "description": "Signal 'V1' from 207",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_135_source_V1",
             "fileObject": {
               "@id": "file_135"
             }
@@ -3555,7 +3463,6 @@
           "description": "Signal 'MLII' from 205",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_138_source_MLII",
             "fileObject": {
               "@id": "file_138"
             }
@@ -3568,7 +3475,6 @@
           "description": "Signal 'V1' from 205",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_138_source_V1",
             "fileObject": {
               "@id": "file_138"
             }
@@ -3589,7 +3495,6 @@
           "description": "Signal 'MLII' from 210",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_141_source_MLII",
             "fileObject": {
               "@id": "file_141"
             }
@@ -3602,7 +3507,6 @@
           "description": "Signal 'V1' from 210",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_141_source_V1",
             "fileObject": {
               "@id": "file_141"
             }
@@ -3623,7 +3527,6 @@
           "description": "Signal 'MLII' from x_228",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_144_source_MLII",
             "fileObject": {
               "@id": "file_144"
             }
@@ -3636,7 +3539,6 @@
           "description": "Signal 'V1' from x_228",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_144_source_V1",
             "fileObject": {
               "@id": "file_144"
             }
@@ -3657,7 +3559,6 @@
           "description": "Signal 'MLII' from x_112",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_147_source_MLII",
             "fileObject": {
               "@id": "file_147"
             }
@@ -3670,7 +3571,6 @@
           "description": "Signal 'V1' from x_112",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_147_source_V1",
             "fileObject": {
               "@id": "file_147"
             }
@@ -3691,7 +3591,6 @@
           "description": "Signal 'MLII' from x_113",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_150_source_MLII",
             "fileObject": {
               "@id": "file_150"
             }
@@ -3704,7 +3603,6 @@
           "description": "Signal 'V1' from x_113",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_150_source_V1",
             "fileObject": {
               "@id": "file_150"
             }
@@ -3725,7 +3623,6 @@
           "description": "Signal 'MLII' from x_111",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_153_source_MLII",
             "fileObject": {
               "@id": "file_153"
             }
@@ -3738,7 +3635,6 @@
           "description": "Signal 'V1' from x_111",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_153_source_V1",
             "fileObject": {
               "@id": "file_153"
             }
@@ -3759,7 +3655,6 @@
           "description": "Signal 'V5' from x_114",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_156_source_V5",
             "fileObject": {
               "@id": "file_156"
             }
@@ -3772,7 +3667,6 @@
           "description": "Signal 'MLII' from x_114",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_156_source_MLII",
             "fileObject": {
               "@id": "file_156"
             }
@@ -3793,7 +3687,6 @@
           "description": "Signal 'MLII' from x_115",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_159_source_MLII",
             "fileObject": {
               "@id": "file_159"
             }
@@ -3806,7 +3699,6 @@
           "description": "Signal 'V1' from x_115",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_159_source_V1",
             "fileObject": {
               "@id": "file_159"
             }
@@ -3827,7 +3719,6 @@
           "description": "Signal 'MLII' from x_117",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_162_source_MLII",
             "fileObject": {
               "@id": "file_162"
             }
@@ -3840,7 +3731,6 @@
           "description": "Signal 'V2' from x_117",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_162_source_V2",
             "fileObject": {
               "@id": "file_162"
             }
@@ -3861,7 +3751,6 @@
           "description": "Signal 'MLII' from x_116",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_165_source_MLII",
             "fileObject": {
               "@id": "file_165"
             }
@@ -3874,7 +3763,6 @@
           "description": "Signal 'V1' from x_116",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_165_source_V1",
             "fileObject": {
               "@id": "file_165"
             }
@@ -3895,7 +3783,6 @@
           "description": "Signal 'MLII' from x_124",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_168_source_MLII",
             "fileObject": {
               "@id": "file_168"
             }
@@ -3908,7 +3795,6 @@
           "description": "Signal 'V4' from x_124",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_168_source_V4",
             "fileObject": {
               "@id": "file_168"
             }
@@ -3929,7 +3815,6 @@
           "description": "Signal 'MLII' from x_109",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_171_source_MLII",
             "fileObject": {
               "@id": "file_171"
             }
@@ -3942,7 +3827,6 @@
           "description": "Signal 'V1' from x_109",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_171_source_V1",
             "fileObject": {
               "@id": "file_171"
             }
@@ -3963,7 +3847,6 @@
           "description": "Signal 'MLII' from x_121",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_174_source_MLII",
             "fileObject": {
               "@id": "file_174"
             }
@@ -3976,7 +3859,6 @@
           "description": "Signal 'V1' from x_121",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_174_source_V1",
             "fileObject": {
               "@id": "file_174"
             }
@@ -3997,7 +3879,6 @@
           "description": "Signal 'MLII' from x_108",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_177_source_MLII",
             "fileObject": {
               "@id": "file_177"
             }
@@ -4010,7 +3891,6 @@
           "description": "Signal 'V1' from x_108",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_177_source_V1",
             "fileObject": {
               "@id": "file_177"
             }
@@ -4031,7 +3911,6 @@
           "description": "Signal 'MLII' from x_122",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_180_source_MLII",
             "fileObject": {
               "@id": "file_180"
             }
@@ -4044,7 +3923,6 @@
           "description": "Signal 'V1' from x_122",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_180_source_V1",
             "fileObject": {
               "@id": "file_180"
             }
@@ -4065,7 +3943,6 @@
           "description": "Signal 'MLII' from x_123",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_183_source_MLII",
             "fileObject": {
               "@id": "file_183"
             }
@@ -4078,7 +3955,6 @@
           "description": "Signal 'V5' from x_123",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_183_source_V5",
             "fileObject": {
               "@id": "file_183"
             }
@@ -4099,7 +3975,6 @@
           "description": "Signal 'MLII' from x_232",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_186_source_MLII",
             "fileObject": {
               "@id": "file_186"
             }
@@ -4112,7 +3987,6 @@
           "description": "Signal 'V1' from x_232",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_186_source_V1",
             "fileObject": {
               "@id": "file_186"
             }
@@ -4133,7 +4007,6 @@
           "description": "Signal 'MLII' from x_233",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_189_source_MLII",
             "fileObject": {
               "@id": "file_189"
             }
@@ -4146,7 +4019,6 @@
           "description": "Signal 'V1' from x_233",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_189_source_V1",
             "fileObject": {
               "@id": "file_189"
             }
@@ -4167,7 +4039,6 @@
           "description": "Signal 'MLII' from x_231",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_192_source_MLII",
             "fileObject": {
               "@id": "file_192"
             }
@@ -4180,7 +4051,6 @@
           "description": "Signal 'V1' from x_231",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_192_source_V1",
             "fileObject": {
               "@id": "file_192"
             }
@@ -4201,7 +4071,6 @@
           "description": "Signal 'MLII' from x_230",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_195_source_MLII",
             "fileObject": {
               "@id": "file_195"
             }
@@ -4214,7 +4083,6 @@
           "description": "Signal 'V1' from x_230",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_195_source_V1",
             "fileObject": {
               "@id": "file_195"
             }
@@ -4235,7 +4103,6 @@
           "description": "Signal 'MLII' from x_234",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_198_source_MLII",
             "fileObject": {
               "@id": "file_198"
             }
@@ -4248,7 +4115,6 @@
           "description": "Signal 'V1' from x_234",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_198_source_V1",
             "fileObject": {
               "@id": "file_198"
             }
@@ -4269,7 +4135,6 @@
           "description": "Signal 'MLII' from x_220",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_201_source_MLII",
             "fileObject": {
               "@id": "file_201"
             }
@@ -4282,7 +4147,6 @@
           "description": "Signal 'V1' from x_220",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_201_source_V1",
             "fileObject": {
               "@id": "file_201"
             }
@@ -4303,7 +4167,6 @@
           "description": "Signal 'MLII' from x_221",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_204_source_MLII",
             "fileObject": {
               "@id": "file_204"
             }
@@ -4316,7 +4179,6 @@
           "description": "Signal 'V1' from x_221",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_204_source_V1",
             "fileObject": {
               "@id": "file_204"
             }
@@ -4337,7 +4199,6 @@
           "description": "Signal 'MLII' from x_223",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_207_source_MLII",
             "fileObject": {
               "@id": "file_207"
             }
@@ -4350,7 +4211,6 @@
           "description": "Signal 'V1' from x_223",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_207_source_V1",
             "fileObject": {
               "@id": "file_207"
             }
@@ -4371,7 +4231,6 @@
           "description": "Signal 'MLII' from x_222",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_210_source_MLII",
             "fileObject": {
               "@id": "file_210"
             }
@@ -4384,7 +4243,6 @@
           "description": "Signal 'V1' from x_222",
           "dataType": "sc:Float",
           "source": {
-            "@id": "file_210_source_V1",
             "fileObject": {
               "@id": "file_210"
             }

--- a/tests/data/output/open_targets_like_croissant.jsonld
+++ b/tests/data/output/open_targets_like_croissant.jsonld
@@ -189,7 +189,6 @@
           "description": "Column 'id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_molecule/id/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -205,7 +204,6 @@
           "description": "Column 'name'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "drug_molecule/name/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -221,7 +219,6 @@
           "description": "Column 'maxClinicalTrialPhase'",
           "dataType": "cr:Float32",
           "source": {
-            "@id": "drug_molecule/maxClinicalTrialPhase/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -237,7 +234,6 @@
           "description": "Column 'yearOfFirstApproval'",
           "dataType": "cr:Int16",
           "source": {
-            "@id": "drug_molecule/yearOfFirstApproval/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -253,7 +249,6 @@
           "description": "Column 'hasBeenWithdrawn'",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "drug_molecule/hasBeenWithdrawn/source",
             "fileObject": {
               "@id": "file_8"
             },
@@ -277,7 +272,6 @@
           "description": "Column 'id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "targets/id/source",
             "fileSet": {
               "@id": "targets-fileset"
             },
@@ -293,7 +287,6 @@
           "description": "Column 'approvedSymbol'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "targets/approvedSymbol/source",
             "fileSet": {
               "@id": "targets-fileset"
             },
@@ -309,7 +302,6 @@
           "description": "Column 'tractabilityScore'",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "targets/tractabilityScore/source",
             "fileSet": {
               "@id": "targets-fileset"
             },
@@ -325,7 +317,6 @@
           "description": "Column 'isDriver'",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "targets/isDriver/source",
             "fileSet": {
               "@id": "targets-fileset"
             },
@@ -349,7 +340,6 @@
           "description": "Column 'studyId'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "credible_set/studyId/source",
             "fileSet": {
               "@id": "credible_set-fileset"
             },
@@ -365,7 +355,6 @@
           "description": "Column 'chromosome'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "credible_set/chromosome/source",
             "fileSet": {
               "@id": "credible_set-fileset"
             },
@@ -381,7 +370,6 @@
           "description": "Column 'position'",
           "dataType": "cr:Int32",
           "source": {
-            "@id": "credible_set/position/source",
             "fileSet": {
               "@id": "credible_set-fileset"
             },
@@ -398,7 +386,6 @@
           "cr:isArray": true,
           "dataType": "sc:Text",
           "source": {
-            "@id": "credible_set/qualityControls/source",
             "fileSet": {
               "@id": "credible_set-fileset"
             },
@@ -414,7 +401,6 @@
           "description": "Column 'locus'",
           "cr:isArray": true,
           "source": {
-            "@id": "credible_set/locus/source",
             "fileSet": {
               "@id": "credible_set-fileset"
             },
@@ -430,7 +416,6 @@
               "description": "Column 'variantId'",
               "dataType": "sc:Text",
               "source": {
-                "@id": "credible_set/locus/variantId/source",
                 "fileSet": {
                   "@id": "credible_set-fileset"
                 },
@@ -446,7 +431,6 @@
               "description": "Column 'posteriorProbability'",
               "dataType": "cr:Float64",
               "source": {
-                "@id": "credible_set/locus/posteriorProbability/source",
                 "fileSet": {
                   "@id": "credible_set-fileset"
                 },
@@ -463,7 +447,6 @@
           "name": "stats",
           "description": "Column 'stats'",
           "source": {
-            "@id": "credible_set/stats/source",
             "fileSet": {
               "@id": "credible_set-fileset"
             },
@@ -479,7 +462,6 @@
               "description": "Column 'beta'",
               "dataType": "cr:Float64",
               "source": {
-                "@id": "credible_set/stats/beta/source",
                 "fileSet": {
                   "@id": "credible_set-fileset"
                 },
@@ -495,7 +477,6 @@
               "description": "Column 'pValueExponent'",
               "dataType": "cr:Int32",
               "source": {
-                "@id": "credible_set/stats/pValueExponent/source",
                 "fileSet": {
                   "@id": "credible_set-fileset"
                 },
@@ -521,7 +502,6 @@
           "description": "Column 'targetId'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "association_by_datatype_direct/targetId/source",
             "fileSet": {
               "@id": "association_by_datatype_direct-fileset"
             },
@@ -537,7 +517,6 @@
           "description": "Column 'diseaseId'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "association_by_datatype_direct/diseaseId/source",
             "fileSet": {
               "@id": "association_by_datatype_direct-fileset"
             },
@@ -553,7 +532,6 @@
           "description": "Column 'datatypeId'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "association_by_datatype_direct/datatypeId/source",
             "fileSet": {
               "@id": "association_by_datatype_direct-fileset"
             },
@@ -569,7 +547,6 @@
           "description": "Column 'score'",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "association_by_datatype_direct/score/source",
             "fileSet": {
               "@id": "association_by_datatype_direct-fileset"
             },
@@ -585,7 +562,6 @@
           "description": "Column 'evidenceCount'",
           "dataType": "cr:Int32",
           "source": {
-            "@id": "association_by_datatype_direct/evidenceCount/source",
             "fileSet": {
               "@id": "association_by_datatype_direct-fileset"
             },
@@ -609,7 +585,6 @@
           "description": "Column 'id'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "diseases/id/source",
             "fileSet": {
               "@id": "diseases-fileset"
             },
@@ -625,7 +600,6 @@
           "description": "Column 'name'",
           "dataType": "sc:Text",
           "source": {
-            "@id": "diseases/name/source",
             "fileSet": {
               "@id": "diseases-fileset"
             },
@@ -641,7 +615,6 @@
           "description": "Column 'numChildren'",
           "dataType": "cr:Int32",
           "source": {
-            "@id": "diseases/numChildren/source",
             "fileSet": {
               "@id": "diseases-fileset"
             },
@@ -657,7 +630,6 @@
           "description": "Column 'isTherapeuticArea'",
           "dataType": "sc:Boolean",
           "source": {
-            "@id": "diseases/isTherapeuticArea/source",
             "fileSet": {
               "@id": "diseases-fileset"
             },

--- a/tests/data/output/reserved_names_croissant.jsonld
+++ b/tests/data/output/reserved_names_croissant.jsonld
@@ -1,0 +1,188 @@
+{
+  "@context": {
+    "@language": "en",
+    "@vocab": "https://schema.org/",
+    "citeAs": "cr:citeAs",
+    "column": "cr:column",
+    "conformsTo": "dct:conformsTo",
+    "cr": "http://mlcommons.org/croissant/",
+    "rai": "http://mlcommons.org/croissant/RAI/",
+    "data": {
+      "@id": "cr:data",
+      "@type": "@json"
+    },
+    "dataType": {
+      "@id": "cr:dataType",
+      "@type": "@vocab"
+    },
+    "dct": "http://purl.org/dc/terms/",
+    "examples": {
+      "@id": "cr:examples",
+      "@type": "@json"
+    },
+    "extract": "cr:extract",
+    "field": "cr:field",
+    "fileProperty": "cr:fileProperty",
+    "fileObject": "cr:fileObject",
+    "fileSet": "cr:fileSet",
+    "format": "cr:format",
+    "includes": "cr:includes",
+    "isLiveDataset": "cr:isLiveDataset",
+    "jsonPath": "cr:jsonPath",
+    "key": "cr:key",
+    "md5": "cr:md5",
+    "parentField": "cr:parentField",
+    "path": "cr:path",
+    "recordSet": "cr:recordSet",
+    "references": "cr:references",
+    "regex": "cr:regex",
+    "repeated": "cr:repeated",
+    "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
+    "sc": "https://schema.org/",
+    "separator": "cr:separator",
+    "source": "cr:source",
+    "subField": "cr:subField",
+    "transform": "cr:transform"
+  },
+  "@type": "sc:Dataset",
+  "name": "Reserved-name regression test",
+  "description": "Dataset containing 1 files (application/vnd.apache.parquet) with automatically inferred types and structure",
+  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "citeAs": "Dataset Creator. (2026). Reserved-name regression test Dataset. Generated with automated type inference.",
+  "creator": {
+    "@type": "sc:Person",
+    "name": "Test Author"
+  },
+  "datePublished": "2026-04-08T09:34:16.957326",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "url": "file:///private/var/folders/cc/x4wmyd75077d6w05q421t82r0000gn/T/pytest-of-rajnu/pytest-23/test_reserved_name_struct_fiel0/reserved_names",
+  "version": "1.0.0",
+  "distribution": [
+    {
+      "@type": "cr:FileObject",
+      "@id": "file_0",
+      "name": "part-00000.parquet",
+      "contentSize": "1800",
+      "contentUrl": "part-00000.parquet",
+      "encodingFormat": "application/vnd.apache.parquet",
+      "sha256": "29b95da6fac01a45ef56bba21bc73933170252bed69683f7088b29ca9b71455c"
+    }
+  ],
+  "recordSet": [
+    {
+      "@type": "cr:RecordSet",
+      "@id": "part-00000",
+      "name": "part-00000",
+      "description": "Records from part-00000.parquet (2 rows)",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "part-00000/id",
+          "name": "id",
+          "description": "Column 'id'",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_0"
+            },
+            "extract": {
+              "column": "id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "part-00000/metadata",
+          "name": "metadata",
+          "description": "Column 'metadata'",
+          "source": {
+            "fileObject": {
+              "@id": "file_0"
+            },
+            "extract": {
+              "column": "metadata"
+            }
+          },
+          "subField": [
+            {
+              "@type": "cr:Field",
+              "@id": "part-00000/metadata/source",
+              "name": "source",
+              "description": "Column 'source'",
+              "dataType": "sc:Text",
+              "source": {
+                "fileObject": {
+                  "@id": "file_0"
+                },
+                "extract": {
+                  "column": "metadata/source"
+                }
+              }
+            },
+            {
+              "@type": "cr:Field",
+              "@id": "part-00000/metadata/data",
+              "name": "data",
+              "description": "Column 'data'",
+              "dataType": "sc:Text",
+              "source": {
+                "fileObject": {
+                  "@id": "file_0"
+                },
+                "extract": {
+                  "column": "metadata/data"
+                }
+              }
+            },
+            {
+              "@type": "cr:Field",
+              "@id": "part-00000/metadata/field",
+              "name": "field",
+              "description": "Column 'field'",
+              "dataType": "sc:Text",
+              "source": {
+                "fileObject": {
+                  "@id": "file_0"
+                },
+                "extract": {
+                  "column": "metadata/field"
+                }
+              }
+            },
+            {
+              "@type": "cr:Field",
+              "@id": "part-00000/metadata/references",
+              "name": "references",
+              "description": "Column 'references'",
+              "dataType": "sc:Text",
+              "source": {
+                "fileObject": {
+                  "@id": "file_0"
+                },
+                "extract": {
+                  "column": "metadata/references"
+                }
+              }
+            },
+            {
+              "@type": "cr:Field",
+              "@id": "part-00000/metadata/column",
+              "name": "column",
+              "description": "Column 'column'",
+              "dataType": "sc:Text",
+              "source": {
+                "fileObject": {
+                  "@id": "file_0"
+                },
+                "extract": {
+                  "column": "metadata/column"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/output/satellite_public_health_croissant.jsonld
+++ b/tests/data/output/satellite_public_health_croissant.jsonld
@@ -181,7 +181,6 @@
           "description": "Column 'Municipality code' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Municipality_code/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -197,7 +196,6 @@
           "description": "Column 'Municipality' from metadata.csv",
           "dataType": "sc:Text",
           "source": {
-            "@id": "metadata/Municipality/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -213,7 +211,6 @@
           "description": "Column 'Population2007' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2007/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -229,7 +226,6 @@
           "description": "Column 'Population2008' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2008/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -245,7 +241,6 @@
           "description": "Column 'Population2009' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2009/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -261,7 +256,6 @@
           "description": "Column 'Population2010' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2010/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -277,7 +271,6 @@
           "description": "Column 'Population2011' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2011/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -293,7 +286,6 @@
           "description": "Column 'Population2012' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2012/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -309,7 +301,6 @@
           "description": "Column 'Population2013' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2013/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -325,7 +316,6 @@
           "description": "Column 'Population2014' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2014/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -341,7 +331,6 @@
           "description": "Column 'Population2015' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2015/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -357,7 +346,6 @@
           "description": "Column 'Population2016' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2016/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -373,7 +361,6 @@
           "description": "Column 'Population2017' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2017/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -389,7 +376,6 @@
           "description": "Column 'Population2018' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2018/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -405,7 +391,6 @@
           "description": "Column 'Population2019' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Population2019/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -421,7 +406,6 @@
           "description": "Column 'Cases2007' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2007/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -437,7 +421,6 @@
           "description": "Column 'Cases2008' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2008/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -453,7 +436,6 @@
           "description": "Column 'Cases2009' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2009/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -469,7 +451,6 @@
           "description": "Column 'Cases2010' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2010/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -485,7 +466,6 @@
           "description": "Column 'Cases2011' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2011/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -501,7 +481,6 @@
           "description": "Column 'Cases2012' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2012/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -517,7 +496,6 @@
           "description": "Column 'Cases2013' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2013/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -533,7 +511,6 @@
           "description": "Column 'Cases2014' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2014/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -549,7 +526,6 @@
           "description": "Column 'Cases2015' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2015/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -565,7 +541,6 @@
           "description": "Column 'Cases2016' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2016/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -581,7 +556,6 @@
           "description": "Column 'Cases2017' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2017/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -597,7 +571,6 @@
           "description": "Column 'Cases2018' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2018/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -613,7 +586,6 @@
           "description": "Column 'Cases2019' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/Cases2019/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -629,7 +601,6 @@
           "description": "Column 'Age0-4(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Age0-4___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -645,7 +616,6 @@
           "description": "Column 'Age5-14(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Age5-14___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -661,7 +631,6 @@
           "description": "Column 'Age15-29(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Age15-29___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -677,7 +646,6 @@
           "description": "Column 'Age>30(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Age_30___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -693,7 +661,6 @@
           "description": "Column 'AfrocolombianPopulation(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/AfrocolombianPopulation___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -709,7 +676,6 @@
           "description": "Column 'IndianPopulation(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/IndianPopulation___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -725,7 +691,6 @@
           "description": "Column 'PeoplewithDisabilities(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PeoplewithDisabilities___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -741,7 +706,6 @@
           "description": "Column 'Peoplewhocannotreadorwrite(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Peoplewhocannotreadorwrite___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -757,7 +721,6 @@
           "description": "Column 'Secondary/HigherEducation(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Secondary_HigherEducation___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -773,7 +736,6 @@
           "description": "Column 'Employedpopulation(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Employedpopulation___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -789,7 +751,6 @@
           "description": "Column 'Unemployedpopulation(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Unemployedpopulation___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -805,7 +766,6 @@
           "description": "Column 'Peopledoinghousework(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Peopledoinghousework___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -821,7 +781,6 @@
           "description": "Column 'Retiredpeople(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Retiredpeople___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -837,7 +796,6 @@
           "description": "Column 'Men(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Men___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -853,7 +811,6 @@
           "description": "Column 'Women(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Women___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -869,7 +826,6 @@
           "description": "Column 'Householdswithoutwateraccess(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Householdswithoutwateraccess___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -885,7 +841,6 @@
           "description": "Column 'Householdswithoutinternetaccess(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Householdswithoutinternetaccess___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -901,7 +856,6 @@
           "description": "Column 'Buildingstratification1(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Buildingstratification1___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -917,7 +871,6 @@
           "description": "Column 'Buildingstratification2(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Buildingstratification2___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -933,7 +886,6 @@
           "description": "Column 'Buildingstratification3(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Buildingstratification3___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -949,7 +901,6 @@
           "description": "Column 'Buildingstratification4(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Buildingstratification4___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -965,7 +916,6 @@
           "description": "Column 'Buildingstratification5(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Buildingstratification5___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -981,7 +931,6 @@
           "description": "Column 'Buildingstratification6(%)' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/Buildingstratification6___/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -997,7 +946,6 @@
           "description": "Column 'NumberofhospitalsperKm2' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/NumberofhospitalsperKm2/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1013,7 +961,6 @@
           "description": "Column 'NumberofhousesperKm2' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/NumberofhousesperKm2/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1029,7 +976,6 @@
           "description": "Column 'TEMPERATURE_jan_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1045,7 +991,6 @@
           "description": "Column 'TEMPERATURE_feb_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1061,7 +1006,6 @@
           "description": "Column 'TEMPERATURE_mar_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1077,7 +1021,6 @@
           "description": "Column 'TEMPERATURE_apr_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1093,7 +1036,6 @@
           "description": "Column 'TEMPERATURE_may_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1109,7 +1051,6 @@
           "description": "Column 'TEMPERATURE_jun_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1125,7 +1066,6 @@
           "description": "Column 'TEMPERATURE_jul_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1141,7 +1081,6 @@
           "description": "Column 'TEMPERATURE_aug_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1157,7 +1096,6 @@
           "description": "Column 'TEMPERATURE_sep_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1173,7 +1111,6 @@
           "description": "Column 'TEMPERATURE_oct_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1189,7 +1126,6 @@
           "description": "Column 'TEMPERATURE_nov_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1205,7 +1141,6 @@
           "description": "Column 'TEMPERATURE_dec_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1221,7 +1156,6 @@
           "description": "Column 'TEMPERATURE_jan_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1237,7 +1171,6 @@
           "description": "Column 'TEMPERATURE_feb_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1253,7 +1186,6 @@
           "description": "Column 'TEMPERATURE_mar_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1269,7 +1201,6 @@
           "description": "Column 'TEMPERATURE_apr_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1285,7 +1216,6 @@
           "description": "Column 'TEMPERATURE_may_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1301,7 +1231,6 @@
           "description": "Column 'TEMPERATURE_jun_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1317,7 +1246,6 @@
           "description": "Column 'TEMPERATURE_jul_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1333,7 +1261,6 @@
           "description": "Column 'TEMPERATURE_aug_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1349,7 +1276,6 @@
           "description": "Column 'TEMPERATURE_sep_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1365,7 +1291,6 @@
           "description": "Column 'TEMPERATURE_oct_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1381,7 +1306,6 @@
           "description": "Column 'TEMPERATURE_nov_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1397,7 +1321,6 @@
           "description": "Column 'TEMPERATURE_dec_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1413,7 +1336,6 @@
           "description": "Column 'TEMPERATURE_jan_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1429,7 +1351,6 @@
           "description": "Column 'TEMPERATURE_feb_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1445,7 +1366,6 @@
           "description": "Column 'TEMPERATURE_mar_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1461,7 +1381,6 @@
           "description": "Column 'TEMPERATURE_apr_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1477,7 +1396,6 @@
           "description": "Column 'TEMPERATURE_may_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1493,7 +1411,6 @@
           "description": "Column 'TEMPERATURE_jun_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1509,7 +1426,6 @@
           "description": "Column 'TEMPERATURE_jul_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1525,7 +1441,6 @@
           "description": "Column 'TEMPERATURE_aug_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1541,7 +1456,6 @@
           "description": "Column 'TEMPERATURE_sep_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1557,7 +1471,6 @@
           "description": "Column 'TEMPERATURE_oct_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1573,7 +1486,6 @@
           "description": "Column 'TEMPERATURE_nov_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1589,7 +1501,6 @@
           "description": "Column 'TEMPERATURE_dec_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1605,7 +1516,6 @@
           "description": "Column 'TEMPERATURE_jan_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1621,7 +1531,6 @@
           "description": "Column 'TEMPERATURE_feb_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1637,7 +1546,6 @@
           "description": "Column 'TEMPERATURE_mar_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1653,7 +1561,6 @@
           "description": "Column 'TEMPERATURE_apr_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1669,7 +1576,6 @@
           "description": "Column 'TEMPERATURE_may_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1685,7 +1591,6 @@
           "description": "Column 'TEMPERATURE_jun_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1701,7 +1606,6 @@
           "description": "Column 'TEMPERATURE_jul_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1717,7 +1621,6 @@
           "description": "Column 'TEMPERATURE_aug_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1733,7 +1636,6 @@
           "description": "Column 'TEMPERATURE_sep_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1749,7 +1651,6 @@
           "description": "Column 'TEMPERATURE_oct_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1765,7 +1666,6 @@
           "description": "Column 'TEMPERATURE_nov_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1781,7 +1681,6 @@
           "description": "Column 'TEMPERATURE_dec_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1797,7 +1696,6 @@
           "description": "Column 'TEMPERATURE_jan_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1813,7 +1711,6 @@
           "description": "Column 'TEMPERATURE_feb_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1829,7 +1726,6 @@
           "description": "Column 'TEMPERATURE_mar_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1845,7 +1741,6 @@
           "description": "Column 'TEMPERATURE_apr_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1861,7 +1756,6 @@
           "description": "Column 'TEMPERATURE_may_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1877,7 +1771,6 @@
           "description": "Column 'TEMPERATURE_jun_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1893,7 +1786,6 @@
           "description": "Column 'TEMPERATURE_jul_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1909,7 +1801,6 @@
           "description": "Column 'TEMPERATURE_aug_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1925,7 +1816,6 @@
           "description": "Column 'TEMPERATURE_sep_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1941,7 +1831,6 @@
           "description": "Column 'TEMPERATURE_oct_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1957,7 +1846,6 @@
           "description": "Column 'TEMPERATURE_nov_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1973,7 +1861,6 @@
           "description": "Column 'TEMPERATURE_dec_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -1989,7 +1876,6 @@
           "description": "Column 'TEMPERATURE_jan_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2005,7 +1891,6 @@
           "description": "Column 'TEMPERATURE_feb_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2021,7 +1906,6 @@
           "description": "Column 'TEMPERATURE_mar_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2037,7 +1921,6 @@
           "description": "Column 'TEMPERATURE_apr_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2053,7 +1936,6 @@
           "description": "Column 'TEMPERATURE_may_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2069,7 +1951,6 @@
           "description": "Column 'TEMPERATURE_jun_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2085,7 +1966,6 @@
           "description": "Column 'TEMPERATURE_jul_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2101,7 +1981,6 @@
           "description": "Column 'TEMPERATURE_aug_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2117,7 +1996,6 @@
           "description": "Column 'TEMPERATURE_sep_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2133,7 +2011,6 @@
           "description": "Column 'TEMPERATURE_oct_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2149,7 +2026,6 @@
           "description": "Column 'TEMPERATURE_nov_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2165,7 +2041,6 @@
           "description": "Column 'TEMPERATURE_dec_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2181,7 +2056,6 @@
           "description": "Column 'TEMPERATURE_jan_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2197,7 +2071,6 @@
           "description": "Column 'TEMPERATURE_feb_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2213,7 +2086,6 @@
           "description": "Column 'TEMPERATURE_mar_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2229,7 +2101,6 @@
           "description": "Column 'TEMPERATURE_apr_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2245,7 +2116,6 @@
           "description": "Column 'TEMPERATURE_may_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2261,7 +2131,6 @@
           "description": "Column 'TEMPERATURE_jun_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2277,7 +2146,6 @@
           "description": "Column 'TEMPERATURE_jul_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2293,7 +2161,6 @@
           "description": "Column 'TEMPERATURE_aug_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2309,7 +2176,6 @@
           "description": "Column 'TEMPERATURE_sep_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2325,7 +2191,6 @@
           "description": "Column 'TEMPERATURE_oct_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2341,7 +2206,6 @@
           "description": "Column 'TEMPERATURE_nov_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2357,7 +2221,6 @@
           "description": "Column 'TEMPERATURE_dec_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2373,7 +2236,6 @@
           "description": "Column 'TEMPERATURE_jan_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2389,7 +2251,6 @@
           "description": "Column 'TEMPERATURE_feb_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2405,7 +2266,6 @@
           "description": "Column 'TEMPERATURE_mar_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2421,7 +2281,6 @@
           "description": "Column 'TEMPERATURE_apr_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2437,7 +2296,6 @@
           "description": "Column 'TEMPERATURE_may_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2453,7 +2311,6 @@
           "description": "Column 'TEMPERATURE_jun_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2469,7 +2326,6 @@
           "description": "Column 'TEMPERATURE_jul_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2485,7 +2341,6 @@
           "description": "Column 'TEMPERATURE_aug_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2501,7 +2356,6 @@
           "description": "Column 'TEMPERATURE_sep_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2517,7 +2371,6 @@
           "description": "Column 'TEMPERATURE_oct_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2533,7 +2386,6 @@
           "description": "Column 'TEMPERATURE_nov_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2549,7 +2401,6 @@
           "description": "Column 'TEMPERATURE_dec_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2565,7 +2416,6 @@
           "description": "Column 'TEMPERATURE_jan_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2581,7 +2431,6 @@
           "description": "Column 'TEMPERATURE_feb_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2597,7 +2446,6 @@
           "description": "Column 'TEMPERATURE_mar_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2613,7 +2461,6 @@
           "description": "Column 'TEMPERATURE_apr_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2629,7 +2476,6 @@
           "description": "Column 'TEMPERATURE_may_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2645,7 +2491,6 @@
           "description": "Column 'TEMPERATURE_jun_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2661,7 +2506,6 @@
           "description": "Column 'TEMPERATURE_jul_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2677,7 +2521,6 @@
           "description": "Column 'TEMPERATURE_aug_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2693,7 +2536,6 @@
           "description": "Column 'TEMPERATURE_sep_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2709,7 +2551,6 @@
           "description": "Column 'TEMPERATURE_oct_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2725,7 +2566,6 @@
           "description": "Column 'TEMPERATURE_nov_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2741,7 +2581,6 @@
           "description": "Column 'TEMPERATURE_dec_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2757,7 +2596,6 @@
           "description": "Column 'TEMPERATURE_jan_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2773,7 +2611,6 @@
           "description": "Column 'TEMPERATURE_feb_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2789,7 +2626,6 @@
           "description": "Column 'TEMPERATURE_mar_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2805,7 +2641,6 @@
           "description": "Column 'TEMPERATURE_apr_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2821,7 +2656,6 @@
           "description": "Column 'TEMPERATURE_may_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2837,7 +2671,6 @@
           "description": "Column 'TEMPERATURE_jun_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2853,7 +2686,6 @@
           "description": "Column 'TEMPERATURE_jul_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2869,7 +2701,6 @@
           "description": "Column 'TEMPERATURE_aug_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2885,7 +2716,6 @@
           "description": "Column 'TEMPERATURE_sep_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2901,7 +2731,6 @@
           "description": "Column 'TEMPERATURE_oct_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2917,7 +2746,6 @@
           "description": "Column 'TEMPERATURE_nov_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2933,7 +2761,6 @@
           "description": "Column 'TEMPERATURE_dec_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2949,7 +2776,6 @@
           "description": "Column 'TEMPERATURE_jan_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2965,7 +2791,6 @@
           "description": "Column 'TEMPERATURE_feb_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2981,7 +2806,6 @@
           "description": "Column 'TEMPERATURE_mar_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -2997,7 +2821,6 @@
           "description": "Column 'TEMPERATURE_apr_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3013,7 +2836,6 @@
           "description": "Column 'TEMPERATURE_may_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3029,7 +2851,6 @@
           "description": "Column 'TEMPERATURE_jun_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3045,7 +2866,6 @@
           "description": "Column 'TEMPERATURE_jul_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3061,7 +2881,6 @@
           "description": "Column 'TEMPERATURE_aug_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3077,7 +2896,6 @@
           "description": "Column 'TEMPERATURE_sep_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3093,7 +2911,6 @@
           "description": "Column 'TEMPERATURE_oct_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3109,7 +2926,6 @@
           "description": "Column 'TEMPERATURE_nov_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3125,7 +2941,6 @@
           "description": "Column 'TEMPERATURE_dec_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3141,7 +2956,6 @@
           "description": "Column 'TEMPERATURE_jan_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jan_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3157,7 +2971,6 @@
           "description": "Column 'TEMPERATURE_feb_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_feb_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3173,7 +2986,6 @@
           "description": "Column 'TEMPERATURE_mar_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_mar_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3189,7 +3001,6 @@
           "description": "Column 'TEMPERATURE_apr_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_apr_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3205,7 +3016,6 @@
           "description": "Column 'TEMPERATURE_may_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_may_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3221,7 +3031,6 @@
           "description": "Column 'TEMPERATURE_jun_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jun_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3237,7 +3046,6 @@
           "description": "Column 'TEMPERATURE_jul_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_jul_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3253,7 +3061,6 @@
           "description": "Column 'TEMPERATURE_aug_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_aug_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3269,7 +3076,6 @@
           "description": "Column 'TEMPERATURE_sep_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_sep_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3285,7 +3091,6 @@
           "description": "Column 'TEMPERATURE_oct_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_oct_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3301,7 +3106,6 @@
           "description": "Column 'TEMPERATURE_nov_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_nov_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3317,7 +3121,6 @@
           "description": "Column 'TEMPERATURE_dec_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/TEMPERATURE_dec_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3333,7 +3136,6 @@
           "description": "Column 'PRECIPITATION_jan_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3349,7 +3151,6 @@
           "description": "Column 'PRECIPITATION_feb_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3365,7 +3166,6 @@
           "description": "Column 'PRECIPITATION_mar_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3381,7 +3181,6 @@
           "description": "Column 'PRECIPITATION_apr_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3397,7 +3196,6 @@
           "description": "Column 'PRECIPITATION_may_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3413,7 +3211,6 @@
           "description": "Column 'PRECIPITATION_jun_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3429,7 +3226,6 @@
           "description": "Column 'PRECIPITATION_jul_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3445,7 +3241,6 @@
           "description": "Column 'PRECIPITATION_aug_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3461,7 +3256,6 @@
           "description": "Column 'PRECIPITATION_sep_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3477,7 +3271,6 @@
           "description": "Column 'PRECIPITATION_oct_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3493,7 +3286,6 @@
           "description": "Column 'PRECIPITATION_nov_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3509,7 +3301,6 @@
           "description": "Column 'PRECIPITATION_dec_07' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3525,7 +3316,6 @@
           "description": "Column 'PRECIPITATION_jan_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3541,7 +3331,6 @@
           "description": "Column 'PRECIPITATION_feb_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3557,7 +3346,6 @@
           "description": "Column 'PRECIPITATION_mar_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3573,7 +3361,6 @@
           "description": "Column 'PRECIPITATION_apr_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3589,7 +3376,6 @@
           "description": "Column 'PRECIPITATION_may_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3605,7 +3391,6 @@
           "description": "Column 'PRECIPITATION_jun_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3621,7 +3406,6 @@
           "description": "Column 'PRECIPITATION_jul_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3637,7 +3421,6 @@
           "description": "Column 'PRECIPITATION_aug_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3653,7 +3436,6 @@
           "description": "Column 'PRECIPITATION_sep_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3669,7 +3451,6 @@
           "description": "Column 'PRECIPITATION_oct_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3685,7 +3466,6 @@
           "description": "Column 'PRECIPITATION_nov_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3701,7 +3481,6 @@
           "description": "Column 'PRECIPITATION_dec_08' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3717,7 +3496,6 @@
           "description": "Column 'PRECIPITATION_jan_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3733,7 +3511,6 @@
           "description": "Column 'PRECIPITATION_feb_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3749,7 +3526,6 @@
           "description": "Column 'PRECIPITATION_mar_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3765,7 +3541,6 @@
           "description": "Column 'PRECIPITATION_apr_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3781,7 +3556,6 @@
           "description": "Column 'PRECIPITATION_may_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3797,7 +3571,6 @@
           "description": "Column 'PRECIPITATION_jun_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3813,7 +3586,6 @@
           "description": "Column 'PRECIPITATION_jul_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3829,7 +3601,6 @@
           "description": "Column 'PRECIPITATION_aug_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3845,7 +3616,6 @@
           "description": "Column 'PRECIPITATION_sep_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3861,7 +3631,6 @@
           "description": "Column 'PRECIPITATION_oct_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3877,7 +3646,6 @@
           "description": "Column 'PRECIPITATION_nov_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3893,7 +3661,6 @@
           "description": "Column 'PRECIPITATION_dec_09' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3909,7 +3676,6 @@
           "description": "Column 'PRECIPITATION_jan_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3925,7 +3691,6 @@
           "description": "Column 'PRECIPITATION_feb_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3941,7 +3706,6 @@
           "description": "Column 'PRECIPITATION_mar_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3957,7 +3721,6 @@
           "description": "Column 'PRECIPITATION_apr_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3973,7 +3736,6 @@
           "description": "Column 'PRECIPITATION_may_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -3989,7 +3751,6 @@
           "description": "Column 'PRECIPITATION_jun_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4005,7 +3766,6 @@
           "description": "Column 'PRECIPITATION_jul_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4021,7 +3781,6 @@
           "description": "Column 'PRECIPITATION_aug_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4037,7 +3796,6 @@
           "description": "Column 'PRECIPITATION_sep_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4053,7 +3811,6 @@
           "description": "Column 'PRECIPITATION_oct_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4069,7 +3826,6 @@
           "description": "Column 'PRECIPITATION_nov_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4085,7 +3841,6 @@
           "description": "Column 'PRECIPITATION_dec_10' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4101,7 +3856,6 @@
           "description": "Column 'PRECIPITATION_jan_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4117,7 +3871,6 @@
           "description": "Column 'PRECIPITATION_feb_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4133,7 +3886,6 @@
           "description": "Column 'PRECIPITATION_mar_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4149,7 +3901,6 @@
           "description": "Column 'PRECIPITATION_apr_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4165,7 +3916,6 @@
           "description": "Column 'PRECIPITATION_may_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4181,7 +3931,6 @@
           "description": "Column 'PRECIPITATION_jun_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4197,7 +3946,6 @@
           "description": "Column 'PRECIPITATION_jul_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4213,7 +3961,6 @@
           "description": "Column 'PRECIPITATION_aug_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4229,7 +3976,6 @@
           "description": "Column 'PRECIPITATION_sep_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4245,7 +3991,6 @@
           "description": "Column 'PRECIPITATION_oct_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4261,7 +4006,6 @@
           "description": "Column 'PRECIPITATION_nov_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4277,7 +4021,6 @@
           "description": "Column 'PRECIPITATION_dec_11' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4293,7 +4036,6 @@
           "description": "Column 'PRECIPITATION_jan_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4309,7 +4051,6 @@
           "description": "Column 'PRECIPITATION_feb_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4325,7 +4066,6 @@
           "description": "Column 'PRECIPITATION_mar_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4341,7 +4081,6 @@
           "description": "Column 'PRECIPITATION_apr_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4357,7 +4096,6 @@
           "description": "Column 'PRECIPITATION_may_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4373,7 +4111,6 @@
           "description": "Column 'PRECIPITATION_jun_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4389,7 +4126,6 @@
           "description": "Column 'PRECIPITATION_jul_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4405,7 +4141,6 @@
           "description": "Column 'PRECIPITATION_aug_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4421,7 +4156,6 @@
           "description": "Column 'PRECIPITATION_sep_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4437,7 +4171,6 @@
           "description": "Column 'PRECIPITATION_oct_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4453,7 +4186,6 @@
           "description": "Column 'PRECIPITATION_nov_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4469,7 +4201,6 @@
           "description": "Column 'PRECIPITATION_dec_12' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4485,7 +4216,6 @@
           "description": "Column 'PRECIPITATION_jan_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4501,7 +4231,6 @@
           "description": "Column 'PRECIPITATION_feb_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4517,7 +4246,6 @@
           "description": "Column 'PRECIPITATION_mar_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4533,7 +4261,6 @@
           "description": "Column 'PRECIPITATION_apr_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4549,7 +4276,6 @@
           "description": "Column 'PRECIPITATION_may_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4565,7 +4291,6 @@
           "description": "Column 'PRECIPITATION_jun_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4581,7 +4306,6 @@
           "description": "Column 'PRECIPITATION_jul_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4597,7 +4321,6 @@
           "description": "Column 'PRECIPITATION_aug_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4613,7 +4336,6 @@
           "description": "Column 'PRECIPITATION_sep_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4629,7 +4351,6 @@
           "description": "Column 'PRECIPITATION_oct_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4645,7 +4366,6 @@
           "description": "Column 'PRECIPITATION_nov_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4661,7 +4381,6 @@
           "description": "Column 'PRECIPITATION_dec_13' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4677,7 +4396,6 @@
           "description": "Column 'PRECIPITATION_jan_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4693,7 +4411,6 @@
           "description": "Column 'PRECIPITATION_feb_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4709,7 +4426,6 @@
           "description": "Column 'PRECIPITATION_mar_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4725,7 +4441,6 @@
           "description": "Column 'PRECIPITATION_apr_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4741,7 +4456,6 @@
           "description": "Column 'PRECIPITATION_may_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4757,7 +4471,6 @@
           "description": "Column 'PRECIPITATION_jun_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4773,7 +4486,6 @@
           "description": "Column 'PRECIPITATION_jul_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4789,7 +4501,6 @@
           "description": "Column 'PRECIPITATION_aug_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4805,7 +4516,6 @@
           "description": "Column 'PRECIPITATION_sep_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4821,7 +4531,6 @@
           "description": "Column 'PRECIPITATION_oct_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4837,7 +4546,6 @@
           "description": "Column 'PRECIPITATION_nov_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4853,7 +4561,6 @@
           "description": "Column 'PRECIPITATION_dec_14' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4869,7 +4576,6 @@
           "description": "Column 'PRECIPITATION_jan_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4885,7 +4591,6 @@
           "description": "Column 'PRECIPITATION_feb_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4901,7 +4606,6 @@
           "description": "Column 'PRECIPITATION_mar_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4917,7 +4621,6 @@
           "description": "Column 'PRECIPITATION_apr_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4933,7 +4636,6 @@
           "description": "Column 'PRECIPITATION_may_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4949,7 +4651,6 @@
           "description": "Column 'PRECIPITATION_jun_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4965,7 +4666,6 @@
           "description": "Column 'PRECIPITATION_jul_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4981,7 +4681,6 @@
           "description": "Column 'PRECIPITATION_aug_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -4997,7 +4696,6 @@
           "description": "Column 'PRECIPITATION_sep_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5013,7 +4711,6 @@
           "description": "Column 'PRECIPITATION_oct_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5029,7 +4726,6 @@
           "description": "Column 'PRECIPITATION_nov_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5045,7 +4741,6 @@
           "description": "Column 'PRECIPITATION_dec_15' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5061,7 +4756,6 @@
           "description": "Column 'PRECIPITATION_jan_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5077,7 +4771,6 @@
           "description": "Column 'PRECIPITATION_feb_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5093,7 +4786,6 @@
           "description": "Column 'PRECIPITATION_mar_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5109,7 +4801,6 @@
           "description": "Column 'PRECIPITATION_apr_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5125,7 +4816,6 @@
           "description": "Column 'PRECIPITATION_may_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5141,7 +4831,6 @@
           "description": "Column 'PRECIPITATION_jun_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5157,7 +4846,6 @@
           "description": "Column 'PRECIPITATION_jul_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5173,7 +4861,6 @@
           "description": "Column 'PRECIPITATION_aug_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5189,7 +4876,6 @@
           "description": "Column 'PRECIPITATION_sep_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5205,7 +4891,6 @@
           "description": "Column 'PRECIPITATION_oct_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5221,7 +4906,6 @@
           "description": "Column 'PRECIPITATION_nov_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5237,7 +4921,6 @@
           "description": "Column 'PRECIPITATION_dec_16' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5253,7 +4936,6 @@
           "description": "Column 'PRECIPITATION_jan_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5269,7 +4951,6 @@
           "description": "Column 'PRECIPITATION_feb_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5285,7 +4966,6 @@
           "description": "Column 'PRECIPITATION_mar_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5301,7 +4981,6 @@
           "description": "Column 'PRECIPITATION_apr_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5317,7 +4996,6 @@
           "description": "Column 'PRECIPITATION_may_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5333,7 +5011,6 @@
           "description": "Column 'PRECIPITATION_jun_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5349,7 +5026,6 @@
           "description": "Column 'PRECIPITATION_jul_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5365,7 +5041,6 @@
           "description": "Column 'PRECIPITATION_aug_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5381,7 +5056,6 @@
           "description": "Column 'PRECIPITATION_sep_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5397,7 +5071,6 @@
           "description": "Column 'PRECIPITATION_oct_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5413,7 +5086,6 @@
           "description": "Column 'PRECIPITATION_nov_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5429,7 +5101,6 @@
           "description": "Column 'PRECIPITATION_dec_17' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5445,7 +5116,6 @@
           "description": "Column 'PRECIPITATION_jan_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jan_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5461,7 +5131,6 @@
           "description": "Column 'PRECIPITATION_feb_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_feb_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5477,7 +5146,6 @@
           "description": "Column 'PRECIPITATION_mar_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_mar_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5493,7 +5161,6 @@
           "description": "Column 'PRECIPITATION_apr_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_apr_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5509,7 +5176,6 @@
           "description": "Column 'PRECIPITATION_may_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_may_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5525,7 +5191,6 @@
           "description": "Column 'PRECIPITATION_jun_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jun_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5541,7 +5206,6 @@
           "description": "Column 'PRECIPITATION_jul_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_jul_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5557,7 +5221,6 @@
           "description": "Column 'PRECIPITATION_aug_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_aug_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5573,7 +5236,6 @@
           "description": "Column 'PRECIPITATION_sep_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_sep_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5589,7 +5251,6 @@
           "description": "Column 'PRECIPITATION_oct_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_oct_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5605,7 +5266,6 @@
           "description": "Column 'PRECIPITATION_nov_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_nov_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5621,7 +5281,6 @@
           "description": "Column 'PRECIPITATION_dec_18' from metadata.csv",
           "dataType": "cr:Float64",
           "source": {
-            "@id": "metadata/PRECIPITATION_dec_18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5637,7 +5296,6 @@
           "description": "Column '2007/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5653,7 +5311,6 @@
           "description": "Column '2007/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5669,7 +5326,6 @@
           "description": "Column '2007/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5685,7 +5341,6 @@
           "description": "Column '2007/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5701,7 +5356,6 @@
           "description": "Column '2007/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5717,7 +5371,6 @@
           "description": "Column '2007/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5733,7 +5386,6 @@
           "description": "Column '2007/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5749,7 +5401,6 @@
           "description": "Column '2007/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5765,7 +5416,6 @@
           "description": "Column '2007/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5781,7 +5431,6 @@
           "description": "Column '2007/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5797,7 +5446,6 @@
           "description": "Column '2007/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5813,7 +5461,6 @@
           "description": "Column '2007/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5829,7 +5476,6 @@
           "description": "Column '2007/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5845,7 +5491,6 @@
           "description": "Column '2007/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5861,7 +5506,6 @@
           "description": "Column '2007/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5877,7 +5521,6 @@
           "description": "Column '2007/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5893,7 +5536,6 @@
           "description": "Column '2007/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5909,7 +5551,6 @@
           "description": "Column '2007/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5925,7 +5566,6 @@
           "description": "Column '2007/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5941,7 +5581,6 @@
           "description": "Column '2007/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5957,7 +5596,6 @@
           "description": "Column '2007/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5973,7 +5611,6 @@
           "description": "Column '2007/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -5989,7 +5626,6 @@
           "description": "Column '2007/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6005,7 +5641,6 @@
           "description": "Column '2007/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6021,7 +5656,6 @@
           "description": "Column '2007/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6037,7 +5671,6 @@
           "description": "Column '2007/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6053,7 +5686,6 @@
           "description": "Column '2007/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6069,7 +5701,6 @@
           "description": "Column '2007/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6085,7 +5716,6 @@
           "description": "Column '2007/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6101,7 +5731,6 @@
           "description": "Column '2007/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6117,7 +5746,6 @@
           "description": "Column '2007/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6133,7 +5761,6 @@
           "description": "Column '2007/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6149,7 +5776,6 @@
           "description": "Column '2007/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6165,7 +5791,6 @@
           "description": "Column '2007/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6181,7 +5806,6 @@
           "description": "Column '2007/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6197,7 +5821,6 @@
           "description": "Column '2007/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6213,7 +5836,6 @@
           "description": "Column '2007/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6229,7 +5851,6 @@
           "description": "Column '2007/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6245,7 +5866,6 @@
           "description": "Column '2007/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6261,7 +5881,6 @@
           "description": "Column '2007/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6277,7 +5896,6 @@
           "description": "Column '2007/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6293,7 +5911,6 @@
           "description": "Column '2007/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6309,7 +5926,6 @@
           "description": "Column '2007/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6325,7 +5941,6 @@
           "description": "Column '2007/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6341,7 +5956,6 @@
           "description": "Column '2007/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6357,7 +5971,6 @@
           "description": "Column '2007/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6373,7 +5986,6 @@
           "description": "Column '2007/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6389,7 +6001,6 @@
           "description": "Column '2007/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6405,7 +6016,6 @@
           "description": "Column '2007/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6421,7 +6031,6 @@
           "description": "Column '2007/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6437,7 +6046,6 @@
           "description": "Column '2007/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6453,7 +6061,6 @@
           "description": "Column '2007/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2007_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6469,7 +6076,6 @@
           "description": "Column '2008/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6485,7 +6091,6 @@
           "description": "Column '2008/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6501,7 +6106,6 @@
           "description": "Column '2008/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6517,7 +6121,6 @@
           "description": "Column '2008/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6533,7 +6136,6 @@
           "description": "Column '2008/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6549,7 +6151,6 @@
           "description": "Column '2008/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6565,7 +6166,6 @@
           "description": "Column '2008/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6581,7 +6181,6 @@
           "description": "Column '2008/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6597,7 +6196,6 @@
           "description": "Column '2008/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6613,7 +6211,6 @@
           "description": "Column '2008/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6629,7 +6226,6 @@
           "description": "Column '2008/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6645,7 +6241,6 @@
           "description": "Column '2008/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6661,7 +6256,6 @@
           "description": "Column '2008/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6677,7 +6271,6 @@
           "description": "Column '2008/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6693,7 +6286,6 @@
           "description": "Column '2008/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6709,7 +6301,6 @@
           "description": "Column '2008/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6725,7 +6316,6 @@
           "description": "Column '2008/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6741,7 +6331,6 @@
           "description": "Column '2008/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6757,7 +6346,6 @@
           "description": "Column '2008/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6773,7 +6361,6 @@
           "description": "Column '2008/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6789,7 +6376,6 @@
           "description": "Column '2008/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6805,7 +6391,6 @@
           "description": "Column '2008/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6821,7 +6406,6 @@
           "description": "Column '2008/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6837,7 +6421,6 @@
           "description": "Column '2008/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6853,7 +6436,6 @@
           "description": "Column '2008/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6869,7 +6451,6 @@
           "description": "Column '2008/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6885,7 +6466,6 @@
           "description": "Column '2008/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6901,7 +6481,6 @@
           "description": "Column '2008/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6917,7 +6496,6 @@
           "description": "Column '2008/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6933,7 +6511,6 @@
           "description": "Column '2008/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6949,7 +6526,6 @@
           "description": "Column '2008/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6965,7 +6541,6 @@
           "description": "Column '2008/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6981,7 +6556,6 @@
           "description": "Column '2008/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -6997,7 +6571,6 @@
           "description": "Column '2008/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7013,7 +6586,6 @@
           "description": "Column '2008/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7029,7 +6601,6 @@
           "description": "Column '2008/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7045,7 +6616,6 @@
           "description": "Column '2008/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7061,7 +6631,6 @@
           "description": "Column '2008/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7077,7 +6646,6 @@
           "description": "Column '2008/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7093,7 +6661,6 @@
           "description": "Column '2008/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7109,7 +6676,6 @@
           "description": "Column '2008/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7125,7 +6691,6 @@
           "description": "Column '2008/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7141,7 +6706,6 @@
           "description": "Column '2008/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7157,7 +6721,6 @@
           "description": "Column '2008/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7173,7 +6736,6 @@
           "description": "Column '2008/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7189,7 +6751,6 @@
           "description": "Column '2008/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7205,7 +6766,6 @@
           "description": "Column '2008/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7221,7 +6781,6 @@
           "description": "Column '2008/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7237,7 +6796,6 @@
           "description": "Column '2008/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7253,7 +6811,6 @@
           "description": "Column '2008/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7269,7 +6826,6 @@
           "description": "Column '2008/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7285,7 +6841,6 @@
           "description": "Column '2008/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2008_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7301,7 +6856,6 @@
           "description": "Column '2009/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7317,7 +6871,6 @@
           "description": "Column '2009/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7333,7 +6886,6 @@
           "description": "Column '2009/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7349,7 +6901,6 @@
           "description": "Column '2009/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7365,7 +6916,6 @@
           "description": "Column '2009/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7381,7 +6931,6 @@
           "description": "Column '2009/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7397,7 +6946,6 @@
           "description": "Column '2009/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7413,7 +6961,6 @@
           "description": "Column '2009/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7429,7 +6976,6 @@
           "description": "Column '2009/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7445,7 +6991,6 @@
           "description": "Column '2009/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7461,7 +7006,6 @@
           "description": "Column '2009/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7477,7 +7021,6 @@
           "description": "Column '2009/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7493,7 +7036,6 @@
           "description": "Column '2009/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7509,7 +7051,6 @@
           "description": "Column '2009/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7525,7 +7066,6 @@
           "description": "Column '2009/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7541,7 +7081,6 @@
           "description": "Column '2009/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7557,7 +7096,6 @@
           "description": "Column '2009/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7573,7 +7111,6 @@
           "description": "Column '2009/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7589,7 +7126,6 @@
           "description": "Column '2009/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7605,7 +7141,6 @@
           "description": "Column '2009/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7621,7 +7156,6 @@
           "description": "Column '2009/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7637,7 +7171,6 @@
           "description": "Column '2009/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7653,7 +7186,6 @@
           "description": "Column '2009/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7669,7 +7201,6 @@
           "description": "Column '2009/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7685,7 +7216,6 @@
           "description": "Column '2009/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7701,7 +7231,6 @@
           "description": "Column '2009/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7717,7 +7246,6 @@
           "description": "Column '2009/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7733,7 +7261,6 @@
           "description": "Column '2009/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7749,7 +7276,6 @@
           "description": "Column '2009/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7765,7 +7291,6 @@
           "description": "Column '2009/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7781,7 +7306,6 @@
           "description": "Column '2009/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7797,7 +7321,6 @@
           "description": "Column '2009/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7813,7 +7336,6 @@
           "description": "Column '2009/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7829,7 +7351,6 @@
           "description": "Column '2009/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7845,7 +7366,6 @@
           "description": "Column '2009/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7861,7 +7381,6 @@
           "description": "Column '2009/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7877,7 +7396,6 @@
           "description": "Column '2009/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7893,7 +7411,6 @@
           "description": "Column '2009/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7909,7 +7426,6 @@
           "description": "Column '2009/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7925,7 +7441,6 @@
           "description": "Column '2009/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7941,7 +7456,6 @@
           "description": "Column '2009/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7957,7 +7471,6 @@
           "description": "Column '2009/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7973,7 +7486,6 @@
           "description": "Column '2009/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -7989,7 +7501,6 @@
           "description": "Column '2009/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8005,7 +7516,6 @@
           "description": "Column '2009/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8021,7 +7531,6 @@
           "description": "Column '2009/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8037,7 +7546,6 @@
           "description": "Column '2009/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8053,7 +7561,6 @@
           "description": "Column '2009/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8069,7 +7576,6 @@
           "description": "Column '2009/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8085,7 +7591,6 @@
           "description": "Column '2009/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8101,7 +7606,6 @@
           "description": "Column '2009/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8117,7 +7621,6 @@
           "description": "Column '2009/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2009_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8133,7 +7636,6 @@
           "description": "Column '2010/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8149,7 +7651,6 @@
           "description": "Column '2010/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8165,7 +7666,6 @@
           "description": "Column '2010/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8181,7 +7681,6 @@
           "description": "Column '2010/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8197,7 +7696,6 @@
           "description": "Column '2010/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8213,7 +7711,6 @@
           "description": "Column '2010/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8229,7 +7726,6 @@
           "description": "Column '2010/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8245,7 +7741,6 @@
           "description": "Column '2010/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8261,7 +7756,6 @@
           "description": "Column '2010/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8277,7 +7771,6 @@
           "description": "Column '2010/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8293,7 +7786,6 @@
           "description": "Column '2010/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8309,7 +7801,6 @@
           "description": "Column '2010/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8325,7 +7816,6 @@
           "description": "Column '2010/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8341,7 +7831,6 @@
           "description": "Column '2010/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8357,7 +7846,6 @@
           "description": "Column '2010/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8373,7 +7861,6 @@
           "description": "Column '2010/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8389,7 +7876,6 @@
           "description": "Column '2010/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8405,7 +7891,6 @@
           "description": "Column '2010/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8421,7 +7906,6 @@
           "description": "Column '2010/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8437,7 +7921,6 @@
           "description": "Column '2010/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8453,7 +7936,6 @@
           "description": "Column '2010/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8469,7 +7951,6 @@
           "description": "Column '2010/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8485,7 +7966,6 @@
           "description": "Column '2010/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8501,7 +7981,6 @@
           "description": "Column '2010/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8517,7 +7996,6 @@
           "description": "Column '2010/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8533,7 +8011,6 @@
           "description": "Column '2010/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8549,7 +8026,6 @@
           "description": "Column '2010/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8565,7 +8041,6 @@
           "description": "Column '2010/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8581,7 +8056,6 @@
           "description": "Column '2010/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8597,7 +8071,6 @@
           "description": "Column '2010/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8613,7 +8086,6 @@
           "description": "Column '2010/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8629,7 +8101,6 @@
           "description": "Column '2010/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8645,7 +8116,6 @@
           "description": "Column '2010/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8661,7 +8131,6 @@
           "description": "Column '2010/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8677,7 +8146,6 @@
           "description": "Column '2010/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8693,7 +8161,6 @@
           "description": "Column '2010/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8709,7 +8176,6 @@
           "description": "Column '2010/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8725,7 +8191,6 @@
           "description": "Column '2010/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8741,7 +8206,6 @@
           "description": "Column '2010/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8757,7 +8221,6 @@
           "description": "Column '2010/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8773,7 +8236,6 @@
           "description": "Column '2010/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8789,7 +8251,6 @@
           "description": "Column '2010/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8805,7 +8266,6 @@
           "description": "Column '2010/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8821,7 +8281,6 @@
           "description": "Column '2010/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8837,7 +8296,6 @@
           "description": "Column '2010/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8853,7 +8311,6 @@
           "description": "Column '2010/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8869,7 +8326,6 @@
           "description": "Column '2010/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8885,7 +8341,6 @@
           "description": "Column '2010/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8901,7 +8356,6 @@
           "description": "Column '2010/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8917,7 +8371,6 @@
           "description": "Column '2010/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8933,7 +8386,6 @@
           "description": "Column '2010/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8949,7 +8401,6 @@
           "description": "Column '2010/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2010_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8965,7 +8416,6 @@
           "description": "Column '2011/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8981,7 +8431,6 @@
           "description": "Column '2011/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -8997,7 +8446,6 @@
           "description": "Column '2011/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9013,7 +8461,6 @@
           "description": "Column '2011/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9029,7 +8476,6 @@
           "description": "Column '2011/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9045,7 +8491,6 @@
           "description": "Column '2011/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9061,7 +8506,6 @@
           "description": "Column '2011/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9077,7 +8521,6 @@
           "description": "Column '2011/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9093,7 +8536,6 @@
           "description": "Column '2011/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9109,7 +8551,6 @@
           "description": "Column '2011/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9125,7 +8566,6 @@
           "description": "Column '2011/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9141,7 +8581,6 @@
           "description": "Column '2011/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9157,7 +8596,6 @@
           "description": "Column '2011/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9173,7 +8611,6 @@
           "description": "Column '2011/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9189,7 +8626,6 @@
           "description": "Column '2011/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9205,7 +8641,6 @@
           "description": "Column '2011/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9221,7 +8656,6 @@
           "description": "Column '2011/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9237,7 +8671,6 @@
           "description": "Column '2011/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9253,7 +8686,6 @@
           "description": "Column '2011/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9269,7 +8701,6 @@
           "description": "Column '2011/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9285,7 +8716,6 @@
           "description": "Column '2011/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9301,7 +8731,6 @@
           "description": "Column '2011/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9317,7 +8746,6 @@
           "description": "Column '2011/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9333,7 +8761,6 @@
           "description": "Column '2011/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9349,7 +8776,6 @@
           "description": "Column '2011/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9365,7 +8791,6 @@
           "description": "Column '2011/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9381,7 +8806,6 @@
           "description": "Column '2011/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9397,7 +8821,6 @@
           "description": "Column '2011/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9413,7 +8836,6 @@
           "description": "Column '2011/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9429,7 +8851,6 @@
           "description": "Column '2011/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9445,7 +8866,6 @@
           "description": "Column '2011/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9461,7 +8881,6 @@
           "description": "Column '2011/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9477,7 +8896,6 @@
           "description": "Column '2011/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9493,7 +8911,6 @@
           "description": "Column '2011/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9509,7 +8926,6 @@
           "description": "Column '2011/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9525,7 +8941,6 @@
           "description": "Column '2011/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9541,7 +8956,6 @@
           "description": "Column '2011/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9557,7 +8971,6 @@
           "description": "Column '2011/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9573,7 +8986,6 @@
           "description": "Column '2011/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9589,7 +9001,6 @@
           "description": "Column '2011/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9605,7 +9016,6 @@
           "description": "Column '2011/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9621,7 +9031,6 @@
           "description": "Column '2011/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9637,7 +9046,6 @@
           "description": "Column '2011/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9653,7 +9061,6 @@
           "description": "Column '2011/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9669,7 +9076,6 @@
           "description": "Column '2011/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9685,7 +9091,6 @@
           "description": "Column '2011/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9701,7 +9106,6 @@
           "description": "Column '2011/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9717,7 +9121,6 @@
           "description": "Column '2011/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9733,7 +9136,6 @@
           "description": "Column '2011/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9749,7 +9151,6 @@
           "description": "Column '2011/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9765,7 +9166,6 @@
           "description": "Column '2011/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9781,7 +9181,6 @@
           "description": "Column '2011/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2011_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9797,7 +9196,6 @@
           "description": "Column '2012/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9813,7 +9211,6 @@
           "description": "Column '2012/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9829,7 +9226,6 @@
           "description": "Column '2012/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9845,7 +9241,6 @@
           "description": "Column '2012/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9861,7 +9256,6 @@
           "description": "Column '2012/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9877,7 +9271,6 @@
           "description": "Column '2012/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9893,7 +9286,6 @@
           "description": "Column '2012/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9909,7 +9301,6 @@
           "description": "Column '2012/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9925,7 +9316,6 @@
           "description": "Column '2012/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9941,7 +9331,6 @@
           "description": "Column '2012/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9957,7 +9346,6 @@
           "description": "Column '2012/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9973,7 +9361,6 @@
           "description": "Column '2012/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -9989,7 +9376,6 @@
           "description": "Column '2012/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10005,7 +9391,6 @@
           "description": "Column '2012/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10021,7 +9406,6 @@
           "description": "Column '2012/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10037,7 +9421,6 @@
           "description": "Column '2012/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10053,7 +9436,6 @@
           "description": "Column '2012/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10069,7 +9451,6 @@
           "description": "Column '2012/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10085,7 +9466,6 @@
           "description": "Column '2012/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10101,7 +9481,6 @@
           "description": "Column '2012/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10117,7 +9496,6 @@
           "description": "Column '2012/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10133,7 +9511,6 @@
           "description": "Column '2012/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10149,7 +9526,6 @@
           "description": "Column '2012/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10165,7 +9541,6 @@
           "description": "Column '2012/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10181,7 +9556,6 @@
           "description": "Column '2012/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10197,7 +9571,6 @@
           "description": "Column '2012/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10213,7 +9586,6 @@
           "description": "Column '2012/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10229,7 +9601,6 @@
           "description": "Column '2012/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10245,7 +9616,6 @@
           "description": "Column '2012/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10261,7 +9631,6 @@
           "description": "Column '2012/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10277,7 +9646,6 @@
           "description": "Column '2012/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10293,7 +9661,6 @@
           "description": "Column '2012/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10309,7 +9676,6 @@
           "description": "Column '2012/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10325,7 +9691,6 @@
           "description": "Column '2012/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10341,7 +9706,6 @@
           "description": "Column '2012/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10357,7 +9721,6 @@
           "description": "Column '2012/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10373,7 +9736,6 @@
           "description": "Column '2012/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10389,7 +9751,6 @@
           "description": "Column '2012/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10405,7 +9766,6 @@
           "description": "Column '2012/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10421,7 +9781,6 @@
           "description": "Column '2012/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10437,7 +9796,6 @@
           "description": "Column '2012/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10453,7 +9811,6 @@
           "description": "Column '2012/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10469,7 +9826,6 @@
           "description": "Column '2012/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10485,7 +9841,6 @@
           "description": "Column '2012/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10501,7 +9856,6 @@
           "description": "Column '2012/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10517,7 +9871,6 @@
           "description": "Column '2012/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10533,7 +9886,6 @@
           "description": "Column '2012/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10549,7 +9901,6 @@
           "description": "Column '2012/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10565,7 +9916,6 @@
           "description": "Column '2012/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10581,7 +9931,6 @@
           "description": "Column '2012/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10597,7 +9946,6 @@
           "description": "Column '2012/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10613,7 +9961,6 @@
           "description": "Column '2012/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2012_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10629,7 +9976,6 @@
           "description": "Column '2013/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10645,7 +9991,6 @@
           "description": "Column '2013/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10661,7 +10006,6 @@
           "description": "Column '2013/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10677,7 +10021,6 @@
           "description": "Column '2013/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10693,7 +10036,6 @@
           "description": "Column '2013/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10709,7 +10051,6 @@
           "description": "Column '2013/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10725,7 +10066,6 @@
           "description": "Column '2013/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10741,7 +10081,6 @@
           "description": "Column '2013/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10757,7 +10096,6 @@
           "description": "Column '2013/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10773,7 +10111,6 @@
           "description": "Column '2013/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10789,7 +10126,6 @@
           "description": "Column '2013/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10805,7 +10141,6 @@
           "description": "Column '2013/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10821,7 +10156,6 @@
           "description": "Column '2013/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10837,7 +10171,6 @@
           "description": "Column '2013/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10853,7 +10186,6 @@
           "description": "Column '2013/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10869,7 +10201,6 @@
           "description": "Column '2013/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10885,7 +10216,6 @@
           "description": "Column '2013/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10901,7 +10231,6 @@
           "description": "Column '2013/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10917,7 +10246,6 @@
           "description": "Column '2013/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10933,7 +10261,6 @@
           "description": "Column '2013/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10949,7 +10276,6 @@
           "description": "Column '2013/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10965,7 +10291,6 @@
           "description": "Column '2013/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10981,7 +10306,6 @@
           "description": "Column '2013/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -10997,7 +10321,6 @@
           "description": "Column '2013/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11013,7 +10336,6 @@
           "description": "Column '2013/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11029,7 +10351,6 @@
           "description": "Column '2013/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11045,7 +10366,6 @@
           "description": "Column '2013/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11061,7 +10381,6 @@
           "description": "Column '2013/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11077,7 +10396,6 @@
           "description": "Column '2013/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11093,7 +10411,6 @@
           "description": "Column '2013/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11109,7 +10426,6 @@
           "description": "Column '2013/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11125,7 +10441,6 @@
           "description": "Column '2013/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11141,7 +10456,6 @@
           "description": "Column '2013/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11157,7 +10471,6 @@
           "description": "Column '2013/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11173,7 +10486,6 @@
           "description": "Column '2013/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11189,7 +10501,6 @@
           "description": "Column '2013/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11205,7 +10516,6 @@
           "description": "Column '2013/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11221,7 +10531,6 @@
           "description": "Column '2013/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11237,7 +10546,6 @@
           "description": "Column '2013/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11253,7 +10561,6 @@
           "description": "Column '2013/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11269,7 +10576,6 @@
           "description": "Column '2013/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11285,7 +10591,6 @@
           "description": "Column '2013/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11301,7 +10606,6 @@
           "description": "Column '2013/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11317,7 +10621,6 @@
           "description": "Column '2013/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11333,7 +10636,6 @@
           "description": "Column '2013/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11349,7 +10651,6 @@
           "description": "Column '2013/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11365,7 +10666,6 @@
           "description": "Column '2013/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11381,7 +10681,6 @@
           "description": "Column '2013/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11397,7 +10696,6 @@
           "description": "Column '2013/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11413,7 +10711,6 @@
           "description": "Column '2013/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11429,7 +10726,6 @@
           "description": "Column '2013/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11445,7 +10741,6 @@
           "description": "Column '2013/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2013_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11461,7 +10756,6 @@
           "description": "Column '2014/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11477,7 +10771,6 @@
           "description": "Column '2014/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11493,7 +10786,6 @@
           "description": "Column '2014/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11509,7 +10801,6 @@
           "description": "Column '2014/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11525,7 +10816,6 @@
           "description": "Column '2014/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11541,7 +10831,6 @@
           "description": "Column '2014/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11557,7 +10846,6 @@
           "description": "Column '2014/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11573,7 +10861,6 @@
           "description": "Column '2014/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11589,7 +10876,6 @@
           "description": "Column '2014/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11605,7 +10891,6 @@
           "description": "Column '2014/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11621,7 +10906,6 @@
           "description": "Column '2014/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11637,7 +10921,6 @@
           "description": "Column '2014/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11653,7 +10936,6 @@
           "description": "Column '2014/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11669,7 +10951,6 @@
           "description": "Column '2014/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11685,7 +10966,6 @@
           "description": "Column '2014/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11701,7 +10981,6 @@
           "description": "Column '2014/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11717,7 +10996,6 @@
           "description": "Column '2014/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11733,7 +11011,6 @@
           "description": "Column '2014/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11749,7 +11026,6 @@
           "description": "Column '2014/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11765,7 +11041,6 @@
           "description": "Column '2014/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11781,7 +11056,6 @@
           "description": "Column '2014/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11797,7 +11071,6 @@
           "description": "Column '2014/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11813,7 +11086,6 @@
           "description": "Column '2014/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11829,7 +11101,6 @@
           "description": "Column '2014/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11845,7 +11116,6 @@
           "description": "Column '2014/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11861,7 +11131,6 @@
           "description": "Column '2014/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11877,7 +11146,6 @@
           "description": "Column '2014/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11893,7 +11161,6 @@
           "description": "Column '2014/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11909,7 +11176,6 @@
           "description": "Column '2014/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11925,7 +11191,6 @@
           "description": "Column '2014/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11941,7 +11206,6 @@
           "description": "Column '2014/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11957,7 +11221,6 @@
           "description": "Column '2014/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11973,7 +11236,6 @@
           "description": "Column '2014/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -11989,7 +11251,6 @@
           "description": "Column '2014/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12005,7 +11266,6 @@
           "description": "Column '2014/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12021,7 +11281,6 @@
           "description": "Column '2014/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12037,7 +11296,6 @@
           "description": "Column '2014/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12053,7 +11311,6 @@
           "description": "Column '2014/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12069,7 +11326,6 @@
           "description": "Column '2014/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12085,7 +11341,6 @@
           "description": "Column '2014/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12101,7 +11356,6 @@
           "description": "Column '2014/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12117,7 +11371,6 @@
           "description": "Column '2014/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12133,7 +11386,6 @@
           "description": "Column '2014/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12149,7 +11401,6 @@
           "description": "Column '2014/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12165,7 +11416,6 @@
           "description": "Column '2014/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12181,7 +11431,6 @@
           "description": "Column '2014/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12197,7 +11446,6 @@
           "description": "Column '2014/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12213,7 +11461,6 @@
           "description": "Column '2014/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12229,7 +11476,6 @@
           "description": "Column '2014/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12245,7 +11491,6 @@
           "description": "Column '2014/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12261,7 +11506,6 @@
           "description": "Column '2014/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12277,7 +11521,6 @@
           "description": "Column '2014/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2014_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12293,7 +11536,6 @@
           "description": "Column '2015/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12309,7 +11551,6 @@
           "description": "Column '2015/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12325,7 +11566,6 @@
           "description": "Column '2015/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12341,7 +11581,6 @@
           "description": "Column '2015/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12357,7 +11596,6 @@
           "description": "Column '2015/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12373,7 +11611,6 @@
           "description": "Column '2015/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12389,7 +11626,6 @@
           "description": "Column '2015/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12405,7 +11641,6 @@
           "description": "Column '2015/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12421,7 +11656,6 @@
           "description": "Column '2015/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12437,7 +11671,6 @@
           "description": "Column '2015/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12453,7 +11686,6 @@
           "description": "Column '2015/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12469,7 +11701,6 @@
           "description": "Column '2015/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12485,7 +11716,6 @@
           "description": "Column '2015/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12501,7 +11731,6 @@
           "description": "Column '2015/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12517,7 +11746,6 @@
           "description": "Column '2015/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12533,7 +11761,6 @@
           "description": "Column '2015/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12549,7 +11776,6 @@
           "description": "Column '2015/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12565,7 +11791,6 @@
           "description": "Column '2015/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12581,7 +11806,6 @@
           "description": "Column '2015/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12597,7 +11821,6 @@
           "description": "Column '2015/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12613,7 +11836,6 @@
           "description": "Column '2015/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12629,7 +11851,6 @@
           "description": "Column '2015/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12645,7 +11866,6 @@
           "description": "Column '2015/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12661,7 +11881,6 @@
           "description": "Column '2015/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12677,7 +11896,6 @@
           "description": "Column '2015/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12693,7 +11911,6 @@
           "description": "Column '2015/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12709,7 +11926,6 @@
           "description": "Column '2015/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12725,7 +11941,6 @@
           "description": "Column '2015/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12741,7 +11956,6 @@
           "description": "Column '2015/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12757,7 +11971,6 @@
           "description": "Column '2015/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12773,7 +11986,6 @@
           "description": "Column '2015/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12789,7 +12001,6 @@
           "description": "Column '2015/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12805,7 +12016,6 @@
           "description": "Column '2015/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12821,7 +12031,6 @@
           "description": "Column '2015/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12837,7 +12046,6 @@
           "description": "Column '2015/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12853,7 +12061,6 @@
           "description": "Column '2015/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12869,7 +12076,6 @@
           "description": "Column '2015/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12885,7 +12091,6 @@
           "description": "Column '2015/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12901,7 +12106,6 @@
           "description": "Column '2015/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12917,7 +12121,6 @@
           "description": "Column '2015/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12933,7 +12136,6 @@
           "description": "Column '2015/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12949,7 +12151,6 @@
           "description": "Column '2015/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12965,7 +12166,6 @@
           "description": "Column '2015/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12981,7 +12181,6 @@
           "description": "Column '2015/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -12997,7 +12196,6 @@
           "description": "Column '2015/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13013,7 +12211,6 @@
           "description": "Column '2015/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13029,7 +12226,6 @@
           "description": "Column '2015/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13045,7 +12241,6 @@
           "description": "Column '2015/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13061,7 +12256,6 @@
           "description": "Column '2015/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13077,7 +12271,6 @@
           "description": "Column '2015/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13093,7 +12286,6 @@
           "description": "Column '2015/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13109,7 +12301,6 @@
           "description": "Column '2015/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2015_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13125,7 +12316,6 @@
           "description": "Column '2016/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13141,7 +12331,6 @@
           "description": "Column '2016/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13157,7 +12346,6 @@
           "description": "Column '2016/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13173,7 +12361,6 @@
           "description": "Column '2016/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13189,7 +12376,6 @@
           "description": "Column '2016/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13205,7 +12391,6 @@
           "description": "Column '2016/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13221,7 +12406,6 @@
           "description": "Column '2016/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13237,7 +12421,6 @@
           "description": "Column '2016/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13253,7 +12436,6 @@
           "description": "Column '2016/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13269,7 +12451,6 @@
           "description": "Column '2016/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13285,7 +12466,6 @@
           "description": "Column '2016/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13301,7 +12481,6 @@
           "description": "Column '2016/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13317,7 +12496,6 @@
           "description": "Column '2016/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13333,7 +12511,6 @@
           "description": "Column '2016/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13349,7 +12526,6 @@
           "description": "Column '2016/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13365,7 +12541,6 @@
           "description": "Column '2016/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13381,7 +12556,6 @@
           "description": "Column '2016/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13397,7 +12571,6 @@
           "description": "Column '2016/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13413,7 +12586,6 @@
           "description": "Column '2016/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13429,7 +12601,6 @@
           "description": "Column '2016/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13445,7 +12616,6 @@
           "description": "Column '2016/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13461,7 +12631,6 @@
           "description": "Column '2016/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13477,7 +12646,6 @@
           "description": "Column '2016/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13493,7 +12661,6 @@
           "description": "Column '2016/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13509,7 +12676,6 @@
           "description": "Column '2016/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13525,7 +12691,6 @@
           "description": "Column '2016/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13541,7 +12706,6 @@
           "description": "Column '2016/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13557,7 +12721,6 @@
           "description": "Column '2016/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13573,7 +12736,6 @@
           "description": "Column '2016/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13589,7 +12751,6 @@
           "description": "Column '2016/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13605,7 +12766,6 @@
           "description": "Column '2016/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13621,7 +12781,6 @@
           "description": "Column '2016/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13637,7 +12796,6 @@
           "description": "Column '2016/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13653,7 +12811,6 @@
           "description": "Column '2016/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13669,7 +12826,6 @@
           "description": "Column '2016/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13685,7 +12841,6 @@
           "description": "Column '2016/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13701,7 +12856,6 @@
           "description": "Column '2016/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13717,7 +12871,6 @@
           "description": "Column '2016/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13733,7 +12886,6 @@
           "description": "Column '2016/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13749,7 +12901,6 @@
           "description": "Column '2016/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13765,7 +12916,6 @@
           "description": "Column '2016/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13781,7 +12931,6 @@
           "description": "Column '2016/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13797,7 +12946,6 @@
           "description": "Column '2016/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13813,7 +12961,6 @@
           "description": "Column '2016/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13829,7 +12976,6 @@
           "description": "Column '2016/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13845,7 +12991,6 @@
           "description": "Column '2016/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13861,7 +13006,6 @@
           "description": "Column '2016/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13877,7 +13021,6 @@
           "description": "Column '2016/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13893,7 +13036,6 @@
           "description": "Column '2016/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13909,7 +13051,6 @@
           "description": "Column '2016/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13925,7 +13066,6 @@
           "description": "Column '2016/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13941,7 +13081,6 @@
           "description": "Column '2016/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2016_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13957,7 +13096,6 @@
           "description": "Column '2017/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13973,7 +13111,6 @@
           "description": "Column '2017/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -13989,7 +13126,6 @@
           "description": "Column '2017/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14005,7 +13141,6 @@
           "description": "Column '2017/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14021,7 +13156,6 @@
           "description": "Column '2017/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14037,7 +13171,6 @@
           "description": "Column '2017/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14053,7 +13186,6 @@
           "description": "Column '2017/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14069,7 +13201,6 @@
           "description": "Column '2017/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14085,7 +13216,6 @@
           "description": "Column '2017/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14101,7 +13231,6 @@
           "description": "Column '2017/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14117,7 +13246,6 @@
           "description": "Column '2017/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14133,7 +13261,6 @@
           "description": "Column '2017/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14149,7 +13276,6 @@
           "description": "Column '2017/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14165,7 +13291,6 @@
           "description": "Column '2017/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14181,7 +13306,6 @@
           "description": "Column '2017/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14197,7 +13321,6 @@
           "description": "Column '2017/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14213,7 +13336,6 @@
           "description": "Column '2017/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14229,7 +13351,6 @@
           "description": "Column '2017/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14245,7 +13366,6 @@
           "description": "Column '2017/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14261,7 +13381,6 @@
           "description": "Column '2017/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14277,7 +13396,6 @@
           "description": "Column '2017/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14293,7 +13411,6 @@
           "description": "Column '2017/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14309,7 +13426,6 @@
           "description": "Column '2017/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14325,7 +13441,6 @@
           "description": "Column '2017/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14341,7 +13456,6 @@
           "description": "Column '2017/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14357,7 +13471,6 @@
           "description": "Column '2017/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14373,7 +13486,6 @@
           "description": "Column '2017/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14389,7 +13501,6 @@
           "description": "Column '2017/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14405,7 +13516,6 @@
           "description": "Column '2017/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14421,7 +13531,6 @@
           "description": "Column '2017/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14437,7 +13546,6 @@
           "description": "Column '2017/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14453,7 +13561,6 @@
           "description": "Column '2017/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14469,7 +13576,6 @@
           "description": "Column '2017/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14485,7 +13591,6 @@
           "description": "Column '2017/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14501,7 +13606,6 @@
           "description": "Column '2017/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14517,7 +13621,6 @@
           "description": "Column '2017/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14533,7 +13636,6 @@
           "description": "Column '2017/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14549,7 +13651,6 @@
           "description": "Column '2017/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14565,7 +13666,6 @@
           "description": "Column '2017/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14581,7 +13681,6 @@
           "description": "Column '2017/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14597,7 +13696,6 @@
           "description": "Column '2017/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14613,7 +13711,6 @@
           "description": "Column '2017/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14629,7 +13726,6 @@
           "description": "Column '2017/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14645,7 +13741,6 @@
           "description": "Column '2017/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14661,7 +13756,6 @@
           "description": "Column '2017/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14677,7 +13771,6 @@
           "description": "Column '2017/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14693,7 +13786,6 @@
           "description": "Column '2017/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14709,7 +13801,6 @@
           "description": "Column '2017/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14725,7 +13816,6 @@
           "description": "Column '2017/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14741,7 +13831,6 @@
           "description": "Column '2017/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14757,7 +13846,6 @@
           "description": "Column '2017/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14773,7 +13861,6 @@
           "description": "Column '2017/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2017_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14789,7 +13876,6 @@
           "description": "Column '2018/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14805,7 +13891,6 @@
           "description": "Column '2018/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14821,7 +13906,6 @@
           "description": "Column '2018/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14837,7 +13921,6 @@
           "description": "Column '2018/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14853,7 +13936,6 @@
           "description": "Column '2018/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14869,7 +13951,6 @@
           "description": "Column '2018/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14885,7 +13966,6 @@
           "description": "Column '2018/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14901,7 +13981,6 @@
           "description": "Column '2018/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14917,7 +13996,6 @@
           "description": "Column '2018/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14933,7 +14011,6 @@
           "description": "Column '2018/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14949,7 +14026,6 @@
           "description": "Column '2018/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14965,7 +14041,6 @@
           "description": "Column '2018/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14981,7 +14056,6 @@
           "description": "Column '2018/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -14997,7 +14071,6 @@
           "description": "Column '2018/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15013,7 +14086,6 @@
           "description": "Column '2018/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15029,7 +14101,6 @@
           "description": "Column '2018/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15045,7 +14116,6 @@
           "description": "Column '2018/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15061,7 +14131,6 @@
           "description": "Column '2018/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15077,7 +14146,6 @@
           "description": "Column '2018/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15093,7 +14161,6 @@
           "description": "Column '2018/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15109,7 +14176,6 @@
           "description": "Column '2018/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15125,7 +14191,6 @@
           "description": "Column '2018/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15141,7 +14206,6 @@
           "description": "Column '2018/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15157,7 +14221,6 @@
           "description": "Column '2018/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15173,7 +14236,6 @@
           "description": "Column '2018/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15189,7 +14251,6 @@
           "description": "Column '2018/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15205,7 +14266,6 @@
           "description": "Column '2018/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15221,7 +14281,6 @@
           "description": "Column '2018/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15237,7 +14296,6 @@
           "description": "Column '2018/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15253,7 +14311,6 @@
           "description": "Column '2018/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15269,7 +14326,6 @@
           "description": "Column '2018/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15285,7 +14341,6 @@
           "description": "Column '2018/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15301,7 +14356,6 @@
           "description": "Column '2018/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15317,7 +14371,6 @@
           "description": "Column '2018/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15333,7 +14386,6 @@
           "description": "Column '2018/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15349,7 +14401,6 @@
           "description": "Column '2018/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15365,7 +14416,6 @@
           "description": "Column '2018/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15381,7 +14431,6 @@
           "description": "Column '2018/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15397,7 +14446,6 @@
           "description": "Column '2018/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15413,7 +14461,6 @@
           "description": "Column '2018/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15429,7 +14476,6 @@
           "description": "Column '2018/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15445,7 +14491,6 @@
           "description": "Column '2018/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15461,7 +14506,6 @@
           "description": "Column '2018/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15477,7 +14521,6 @@
           "description": "Column '2018/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15493,7 +14536,6 @@
           "description": "Column '2018/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15509,7 +14551,6 @@
           "description": "Column '2018/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15525,7 +14566,6 @@
           "description": "Column '2018/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15541,7 +14581,6 @@
           "description": "Column '2018/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15557,7 +14596,6 @@
           "description": "Column '2018/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15573,7 +14611,6 @@
           "description": "Column '2018/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15589,7 +14626,6 @@
           "description": "Column '2018/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15605,7 +14641,6 @@
           "description": "Column '2018/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2018_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15621,7 +14656,6 @@
           "description": "Column '2019/w01' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w01/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15637,7 +14671,6 @@
           "description": "Column '2019/w02' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w02/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15653,7 +14686,6 @@
           "description": "Column '2019/w03' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w03/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15669,7 +14701,6 @@
           "description": "Column '2019/w04' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w04/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15685,7 +14716,6 @@
           "description": "Column '2019/w05' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w05/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15701,7 +14731,6 @@
           "description": "Column '2019/w06' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w06/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15717,7 +14746,6 @@
           "description": "Column '2019/w07' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w07/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15733,7 +14761,6 @@
           "description": "Column '2019/w08' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w08/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15749,7 +14776,6 @@
           "description": "Column '2019/w09' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w09/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15765,7 +14791,6 @@
           "description": "Column '2019/w10' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w10/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15781,7 +14806,6 @@
           "description": "Column '2019/w11' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w11/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15797,7 +14821,6 @@
           "description": "Column '2019/w12' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w12/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15813,7 +14836,6 @@
           "description": "Column '2019/w13' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w13/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15829,7 +14851,6 @@
           "description": "Column '2019/w14' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w14/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15845,7 +14866,6 @@
           "description": "Column '2019/w15' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w15/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15861,7 +14881,6 @@
           "description": "Column '2019/w16' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w16/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15877,7 +14896,6 @@
           "description": "Column '2019/w17' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w17/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15893,7 +14911,6 @@
           "description": "Column '2019/w18' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w18/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15909,7 +14926,6 @@
           "description": "Column '2019/w19' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w19/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15925,7 +14941,6 @@
           "description": "Column '2019/w20' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w20/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15941,7 +14956,6 @@
           "description": "Column '2019/w21' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w21/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15957,7 +14971,6 @@
           "description": "Column '2019/w22' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w22/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15973,7 +14986,6 @@
           "description": "Column '2019/w23' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w23/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -15989,7 +15001,6 @@
           "description": "Column '2019/w24' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w24/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16005,7 +15016,6 @@
           "description": "Column '2019/w25' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w25/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16021,7 +15031,6 @@
           "description": "Column '2019/w26' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w26/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16037,7 +15046,6 @@
           "description": "Column '2019/w27' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w27/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16053,7 +15061,6 @@
           "description": "Column '2019/w28' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w28/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16069,7 +15076,6 @@
           "description": "Column '2019/w29' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w29/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16085,7 +15091,6 @@
           "description": "Column '2019/w30' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w30/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16101,7 +15106,6 @@
           "description": "Column '2019/w31' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w31/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16117,7 +15121,6 @@
           "description": "Column '2019/w32' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w32/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16133,7 +15136,6 @@
           "description": "Column '2019/w33' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w33/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16149,7 +15151,6 @@
           "description": "Column '2019/w34' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w34/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16165,7 +15166,6 @@
           "description": "Column '2019/w35' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w35/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16181,7 +15181,6 @@
           "description": "Column '2019/w36' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w36/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16197,7 +15196,6 @@
           "description": "Column '2019/w37' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w37/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16213,7 +15211,6 @@
           "description": "Column '2019/w38' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w38/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16229,7 +15226,6 @@
           "description": "Column '2019/w39' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w39/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16245,7 +15241,6 @@
           "description": "Column '2019/w40' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w40/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16261,7 +15256,6 @@
           "description": "Column '2019/w41' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w41/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16277,7 +15271,6 @@
           "description": "Column '2019/w42' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w42/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16293,7 +15286,6 @@
           "description": "Column '2019/w43' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w43/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16309,7 +15301,6 @@
           "description": "Column '2019/w44' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w44/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16325,7 +15316,6 @@
           "description": "Column '2019/w45' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w45/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16341,7 +15331,6 @@
           "description": "Column '2019/w46' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w46/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16357,7 +15346,6 @@
           "description": "Column '2019/w47' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w47/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16373,7 +15361,6 @@
           "description": "Column '2019/w48' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w48/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16389,7 +15376,6 @@
           "description": "Column '2019/w49' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w49/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16405,7 +15391,6 @@
           "description": "Column '2019/w50' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w50/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16421,7 +15406,6 @@
           "description": "Column '2019/w51' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w51/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16437,7 +15421,6 @@
           "description": "Column '2019/w52' from metadata.csv",
           "dataType": "cr:Int64",
           "source": {
-            "@id": "metadata/2019_w52/source",
             "fileObject": {
               "@id": "file_0"
             },
@@ -16461,7 +15444,6 @@
           "description": "Image content (10 files, TIFF (10))",
           "dataType": "sc:ImageObject",
           "source": {
-            "@id": "images/image_content/source",
             "fileSet": {
               "@id": "image-files"
             },

--- a/tests/test_reserved_field_names.py
+++ b/tests/test_reserved_field_names.py
@@ -1,0 +1,138 @@
+"""Regression test for JSON-LD node identifier collisions.
+
+This test exercises nested (struct) columns whose sub-fields use names that can
+be confused with Croissant/JSON-LD terms (e.g., ``source``). The generator must
+produce Croissant metadata that validates and does not contain duplicate node
+``@id`` values within the same graph.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from croissant_baker.__main__ import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def output_dir() -> Path:
+    output_path = Path(__file__).parent / "data" / "output"
+    output_path.mkdir(parents=True, exist_ok=True)
+    return output_path
+
+
+@pytest.fixture
+def reserved_name_parquet_path(tmp_path: Path) -> Path:
+    """Parquet dataset with struct sub-fields whose names collide with
+    Croissant JSON-LD context terms: source, data, field, references, column.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    schema = pa.schema(
+        [
+            ("id", pa.string()),
+            (
+                "metadata",
+                pa.struct(
+                    [
+                        pa.field("source", pa.string()),
+                        pa.field("data", pa.string()),
+                        pa.field("field", pa.string()),
+                        pa.field("references", pa.string()),
+                        pa.field("column", pa.string()),
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    table = pa.table(
+        {
+            "id": ["row1", "row2"],
+            "metadata": [
+                {
+                    "source": "src_a",
+                    "data": "dat_a",
+                    "field": "fld_a",
+                    "references": "ref_a",
+                    "column": "col_a",
+                },
+                {
+                    "source": "src_b",
+                    "data": "dat_b",
+                    "field": "fld_b",
+                    "references": "ref_b",
+                    "column": "col_b",
+                },
+            ],
+        },
+        schema=schema,
+    )
+
+    out = tmp_path / "reserved_names"
+    out.mkdir()
+    pq.write_table(table, out / "part-00000.parquet")
+    return out
+
+
+def test_reserved_name_struct_fields_validate(
+    reserved_name_parquet_path: Path, output_dir: Path
+) -> None:
+    """Generation + mlcroissant validation must succeed when struct sub-fields
+    are named 'source', 'data', 'field', 'references', or 'column'."""
+    output_file = output_dir / "reserved_names_croissant.jsonld"
+
+    result = runner.invoke(
+        app,
+        [
+            "-i",
+            str(reserved_name_parquet_path),
+            "-o",
+            str(output_file),
+            "--name",
+            "Reserved-name regression test",
+            "--creator",
+            "Test Author",
+        ],
+    )
+
+    assert result.exit_code == 0, f"Generation failed:\n{result.stdout}"
+    assert output_file.exists()
+
+    with open(output_file) as f:
+        metadata = json.load(f)
+
+    rs = metadata["recordSet"]
+    assert len(rs) == 1
+
+    top_fields = {f["name"] for f in rs[0]["field"]}
+    assert "metadata" in top_fields
+
+    meta_field = next(f for f in rs[0]["field"] if f["name"] == "metadata")
+    sub_names = {sf["name"] for sf in meta_field["subField"]}
+    assert sub_names == {"source", "data", "field", "references", "column"}
+
+    # The actual bug: verify all node @id values in the RecordSet are unique.
+    # Only collect from objects that define a node (@type present), not bare
+    # JSON-LD references like {"@id": "file_0"}.
+    node_ids: list[str] = []
+
+    def _collect_node_ids(obj: object) -> None:
+        if isinstance(obj, dict):
+            if "@id" in obj and "@type" in obj:
+                node_ids.append(obj["@id"])
+            for v in obj.values():
+                _collect_node_ids(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _collect_node_ids(item)
+
+    _collect_node_ids(rs[0])
+    assert len(node_ids) == len(set(node_ids)), (
+        f"Duplicate node @id values found: "
+        f"{[x for x in node_ids if node_ids.count(x) > 1]}"
+    )


### PR DESCRIPTION
### Problem
Croissant Maker previously assigned deterministic @id values to cr:Source nodes using the pattern {field_id}/source. If a nested/struct column contains a child field literally named source, the child Field and the parent Source can end up sharing the same @id string (two different nodes, one identifier). JSON-LD requires @id uniqueness; duplicates can lead to mlcroissant graph overwrites and validation failures.

### Example

- Parent struct field: record/metadata
- Child field named source: record/metadata/source
- Old behavior also created a Source with @id = record/metadata/source → collision

### Fix
Remove explicit id= from mlc.Source(...) objects. Sources are now emitted as anonymous (blank) nodes embedded under their parent Field, avoiding global @id collisions by construction and matching standard JSON-LD usage for inline nodes.

### What changed
Remove id= from all mlc.Source() creation sites in src/croissant_baker/metadata_generator.py
Add regression test tests/test_reserved_field_names.py using a small synthetic Parquet dataset with a struct column containing collision-prone subfield names (including source)
Regenerate committed Croissant JSON-LD outputs under tests/data/output/

### Test plan
PYTHONPATH=src uv run pytest -v (all tests pass locally)