### PR TITLE
refactor: implement build_croissant protocol on all FileTypeHandlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,8 @@ cython_debug/
 # AI assistant context files
 CLAUDE.md
 
+# Planning
+.planning/
+
 # Large reference outputs not under version control
 tests/data/output/open_targets_official_croissant.json

--- a/src/croissant_baker/handlers/base_handler.py
+++ b/src/croissant_baker/handlers/base_handler.py
@@ -59,7 +59,11 @@ class FileTypeHandler(ABC):
         pass
 
     @abstractmethod
-    def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
+    def build_croissant(
+        self,
+        file_metas: list[dict],
+        file_ids: list[str],
+    ) -> tuple[list, list]:  # (list[FileSet], list[RecordSet])
         """Build Croissant FileSets and RecordSets for all files this handler processed.
 
         Called once per handler after the FileObject loop. Receives all metadata

--- a/src/croissant_baker/handlers/base_handler.py
+++ b/src/croissant_baker/handlers/base_handler.py
@@ -8,12 +8,16 @@ class FileTypeHandler(ABC):
     """
     Abstract base class for file type handlers.
 
-    Each handler is responsible for:
-    - Detecting if it can process a specific file type
-    - Extracting comprehensive metadata from files it handles
+    Each handler is responsible for three things:
+    - can_handle: decide if this handler owns a given file
+    - extract_metadata: extract raw metadata from a single file
+    - build_croissant: turn that metadata into Croissant FileSets + RecordSets
 
-    This design allows easy extension to new file formats (Parquet, JSON, etc.)
-    without modifying existing code.
+    All three are required. The generator owns FileObject creation and ID
+    assignment; build_croissant returns only FileSets and RecordSets.
+
+    Adding a new format: subclass this, implement all three methods,
+    register the instance in registry.py — no other files need to change.
     """
 
     @abstractmethod
@@ -51,5 +55,23 @@ class FileTypeHandler(ABC):
 
         Raises:
             Exception: If the file cannot be processed
+        """
+        pass
+
+    @abstractmethod
+    def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
+        """Build Croissant FileSets and RecordSets for all files this handler processed.
+
+        Called once per handler after the FileObject loop. Receives all metadata
+        dicts this handler produced for the dataset, with pre-assigned FileObject
+        IDs aligned by position.
+
+        Args:
+            file_metas: metadata dicts from extract_metadata, one per file
+            file_ids: FileObject IDs assigned by the generator, aligned with file_metas
+
+        Returns:
+            (additional_distributions, record_sets) — additional_distributions
+            contains FileSets only. FileObjects are always owned by the generator.
         """
         pass

--- a/src/croissant_baker/handlers/csv_handler.py
+++ b/src/croissant_baker/handlers/csv_handler.py
@@ -4,13 +4,16 @@ import logging
 import re
 from pathlib import Path
 
+import mlcroissant as mlc
 import pyarrow as pa
 import pyarrow.csv as pa_csv
 
 from croissant_baker.handlers.base_handler import FileTypeHandler
 from croissant_baker.handlers.utils import (
     compute_file_hash,
+    get_clean_record_name,
     infer_column_types_from_arrow_schema,
+    sanitize_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -248,3 +251,38 @@ class CSVHandler(FileTypeHandler):
             "num_columns": len(columns),
             "columns": columns,
         }
+
+    def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
+        record_sets = []
+        for file_id, file_meta in zip(file_ids, file_metas):
+            rs_name = get_clean_record_name(file_meta["file_name"])
+            rs_id = sanitize_id(rs_name)
+
+            fields = []
+            for col_name, col_type in file_meta["column_types"].items():
+                safe_name = sanitize_id(col_name)
+                field_id = f"{rs_id}/{safe_name}"
+                field = mlc.Field(
+                    id=field_id,
+                    name=col_name,
+                    description=f"Column '{col_name}' from {file_meta['file_name']}",
+                    data_types=[col_type],
+                    source=mlc.Source(
+                        file_object=file_id,
+                        extract=mlc.Extract(column=col_name),
+                    ),
+                )
+                fields.append(field)
+
+            num_rows = file_meta.get("num_rows")
+            row_desc = f" ({num_rows} rows)" if num_rows is not None else ""
+            record_sets.append(
+                mlc.RecordSet(
+                    id=rs_id,
+                    name=rs_name,
+                    description=f"Records from {file_meta['file_name']}{row_desc}",
+                    fields=fields,
+                )
+            )
+
+        return [], record_sets

--- a/src/croissant_baker/handlers/image_handler.py
+++ b/src/croissant_baker/handlers/image_handler.py
@@ -4,6 +4,8 @@ import logging
 from pathlib import Path
 from typing import Dict, List
 
+import mlcroissant as mlc
+
 from croissant_baker.handlers.base_handler import FileTypeHandler
 from croissant_baker.handlers.utils import compute_file_hash
 
@@ -140,6 +142,62 @@ class ImageHandler(FileTypeHandler):
                 "image_format": img_meta["image_format"],
             },
         }
+
+    def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
+        summary = collect_image_summary(file_metas)
+        w_lo, w_hi = summary["width_range"]
+        h_lo, h_hi = summary["height_range"]
+        b_lo, b_hi = summary["num_bands_range"]
+        formats_str = ", ".join(
+            f"{fmt} ({cnt})" for fmt, cnt in summary["format_counts"].items()
+        )
+
+        if w_lo == w_hi and h_lo == h_hi:
+            dims = f"{w_lo}x{h_lo}"
+        else:
+            dims = f"{w_lo}-{w_hi}x{h_lo}-{h_hi}"
+
+        bands_note = f", {b_lo}-{b_hi} bands" if b_hi > 4 else ""
+
+        extensions = set()
+        mime_types = set()
+        for meta in file_metas:
+            ext = Path(meta["file_name"]).suffix.lower()
+            extensions.add(ext)
+            mime_types.add(meta["encoding_format"])
+
+        includes = [f"**/*{ext}" for ext in sorted(extensions)]
+
+        fileset_id = "image-files"
+        image_fileset = mlc.FileSet(
+            id=fileset_id,
+            name="Image files",
+            description=f"{summary['num_images']} image files ({formats_str})",
+            encoding_formats=sorted(mime_types),
+            includes=includes,
+        )
+
+        image_fields = [
+            mlc.Field(
+                id="images/image_content",
+                name="image",
+                description=f"Image content ({summary['num_images']} files, {formats_str})",
+                data_types=["sc:ImageObject"],
+                source=mlc.Source(
+                    file_set=fileset_id,
+                    extract=mlc.Extract(file_property="content"),
+                ),
+            ),
+        ]
+
+        image_record_set = mlc.RecordSet(
+            id="images",
+            name="images",
+            description=f"{summary['num_images']} images ({dims}{bands_note}): {formats_str}",
+            fields=image_fields,
+        )
+
+        return [image_fileset], [image_record_set]
 
 
 def collect_image_summary(image_metadata_list: List[Dict]) -> Dict:

--- a/src/croissant_baker/handlers/parquet_handler.py
+++ b/src/croissant_baker/handlers/parquet_handler.py
@@ -1,13 +1,18 @@
 """Parquet file handler for tabular event streams (e.g., MEDS)."""
 
+from collections import defaultdict
 from pathlib import Path
 
+import mlcroissant as mlc
 from pyarrow.parquet import ParquetFile
 
 from croissant_baker.handlers.base_handler import FileTypeHandler
 from croissant_baker.handlers.utils import (
+    _build_fields,
     compute_file_hash,
+    get_clean_record_name,
     infer_column_types_from_arrow_schema,
+    sanitize_id,
 )
 
 
@@ -55,3 +60,121 @@ class ParquetHandler(FileTypeHandler):
             }
         except Exception as e:
             raise ValueError(f"Failed to process Parquet file {file_path}: {e}") from e
+
+    def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
+        """Build FileSets and RecordSets for all Parquet files in this dataset.
+
+        Groups files by parent directory. Directories with >=2 files become
+        partitioned tables (one FileSet + one RecordSet). All other files get
+        per-file RecordSets. Root-level files (parent == ".") are never grouped.
+        """
+        additional_distributions = []
+        record_sets = []
+
+        # Group by parent directory to detect partitioned tables.
+        # A non-root directory with >=2 .parquet files is treated as one logical
+        # table: one FileSet + one RecordSet (schema taken from first partition).
+        # Root-level files (parent == ".") and single-file directories are
+        # always standalone — one RecordSet per file.
+        dir_groups: dict = defaultdict(list)
+        for file_id, file_meta in zip(file_ids, file_metas):
+            parent = str(Path(file_meta["relative_path"]).parent)
+            dir_groups[parent].append((file_id, file_meta))
+
+        for dir_path, pairs in dir_groups.items():
+            is_partitioned = len(pairs) >= 2 and dir_path != "."
+
+            if is_partitioned:
+                _, first_meta = pairs[0]
+                table_name = Path(dir_path).name
+                dir_id = sanitize_id(dir_path)
+                fileset_id = f"{dir_id}-fileset"
+
+                _suffix = "".join(Path(pairs[0][1]["file_name"]).suffixes)
+                additional_distributions.append(
+                    mlc.FileSet(
+                        id=fileset_id,
+                        name=f"{table_name} partition files",
+                        description=f"{len(pairs)} Parquet partition files for table '{table_name}'",
+                        encoding_formats=["application/vnd.apache.parquet"],
+                        includes=[f"{dir_path}/*{_suffix}"],
+                    )
+                )
+
+                if "arrow_schema" in first_meta:
+                    fields = _build_fields(
+                        first_meta["arrow_schema"],
+                        sanitize_id(table_name),
+                        {"file_set": fileset_id},
+                    )
+                else:
+                    fields = []
+                    for col_name, col_type in first_meta["column_types"].items():
+                        safe_name = sanitize_id(col_name)
+                        fields.append(
+                            mlc.Field(
+                                id=f"{dir_id}/{safe_name}",
+                                name=col_name,
+                                description=f"Column '{col_name}' from table '{table_name}'",
+                                data_types=[col_type],
+                                source=mlc.Source(
+                                    file_set=fileset_id,
+                                    extract=mlc.Extract(column=col_name),
+                                ),
+                            )
+                        )
+
+                num_rows = sum(m.get("num_rows", 0) for _, m in pairs)
+                record_sets.append(
+                    mlc.RecordSet(
+                        id=sanitize_id(table_name),
+                        name=table_name,
+                        description=f"Partitioned table '{table_name}' ({len(pairs)} Parquet files, {num_rows} total rows)",
+                        fields=fields,
+                    )
+                )
+            else:
+                # Standalone: one RecordSet per file
+                for file_id, file_meta in pairs:
+                    rel_dir = str(Path(file_meta["relative_path"]).parent)
+                    if rel_dir != ".":
+                        rs_name = Path(rel_dir).name
+                    else:
+                        rs_name = get_clean_record_name(file_meta["file_name"])
+                    rs_id = sanitize_id(rs_name)
+
+                    if "arrow_schema" in file_meta:
+                        fields = _build_fields(
+                            file_meta["arrow_schema"],
+                            rs_id,
+                            {"file_object": file_id},
+                        )
+                    else:
+                        fields = []
+                        for col_name, col_type in file_meta["column_types"].items():
+                            safe_name = sanitize_id(col_name)
+                            fields.append(
+                                mlc.Field(
+                                    id=f"{rs_id}/{safe_name}",
+                                    name=col_name,
+                                    description=f"Column '{col_name}' from {file_meta['file_name']}",
+                                    data_types=[col_type],
+                                    source=mlc.Source(
+                                        file_object=file_id,
+                                        extract=mlc.Extract(column=col_name),
+                                    ),
+                                )
+                            )
+
+                    num_rows = file_meta.get("num_rows")
+                    row_desc = f" ({num_rows} rows)" if num_rows is not None else ""
+                    record_sets.append(
+                        mlc.RecordSet(
+                            id=rs_id,
+                            name=rs_name,
+                            description=f"Records from {file_meta['file_name']}{row_desc}",
+                            fields=fields,
+                        )
+                    )
+
+        return additional_distributions, record_sets

--- a/src/croissant_baker/handlers/utils.py
+++ b/src/croissant_baker/handlers/utils.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 from typing import Dict, Union
 
+import mlcroissant as mlc
 import pyarrow as pa
 import pyarrow.types as patypes
 
@@ -164,6 +165,59 @@ def compute_file_hash(file_path: Union[str, Path]) -> str:
 
     except (IOError, OSError) as e:
         raise PermissionError(f"Cannot read file {file_path}: {e}")
+
+
+def _build_fields(
+    arrow_schema,
+    parent_id: str,
+    source_ref: dict,
+    col_path_prefix: str = "",
+) -> list:
+    """Recursively build mlc.Field objects from a PyArrow schema or struct type.
+
+    Handles three cases:
+    - Scalar column: maps to a Croissant type via map_arrow_type().
+    - List column: sets is_array=True; recurses on the element type.
+    - Struct column: recurses to produce sub_fields.
+    """
+    fields = []
+    for arrow_field in arrow_schema:
+        col_name = arrow_field.name
+        arrow_type = arrow_field.type
+        safe_name = sanitize_id(col_name)
+        field_id = f"{parent_id}/{safe_name}"
+        col_path = f"{col_path_prefix}/{col_name}" if col_path_prefix else col_name
+
+        is_array = is_arrow_list(arrow_type)
+        inner_type = arrow_type.value_type if is_array else arrow_type
+
+        source = mlc.Source(
+            extract=mlc.Extract(column=col_path),
+            **source_ref,
+        )
+
+        if patypes.is_struct(inner_type):
+            sub_fields = _build_fields(inner_type, field_id, source_ref, col_path)
+            field = mlc.Field(
+                id=field_id,
+                name=col_name,
+                description=f"Column '{col_name}'",
+                is_array=True if is_array else None,
+                source=source,
+                sub_fields=sub_fields,
+            )
+        else:
+            col_type = map_arrow_type(inner_type)
+            field = mlc.Field(
+                id=field_id,
+                name=col_name,
+                description=f"Column '{col_name}'",
+                data_types=[col_type],
+                is_array=True if is_array else None,
+                source=source,
+            )
+        fields.append(field)
+    return fields
 
 
 def get_clean_record_name(file_name: str) -> str:

--- a/src/croissant_baker/handlers/wfdb_handler.py
+++ b/src/croissant_baker/handlers/wfdb_handler.py
@@ -3,8 +3,10 @@
 from pathlib import Path
 import wfdb
 
+import mlcroissant as mlc
+
 from croissant_baker.handlers.base_handler import FileTypeHandler
-from croissant_baker.handlers.utils import compute_file_hash
+from croissant_baker.handlers.utils import compute_file_hash, sanitize_id
 
 
 class WFDBHandler(FileTypeHandler):
@@ -102,3 +104,40 @@ class WFDBHandler(FileTypeHandler):
             metadata["fmt"] = record.fmt
 
         return metadata
+
+    def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
+        record_sets = []
+        for file_id, file_meta in zip(file_ids, file_metas):
+            fields = []
+            for signal_name, signal_type in file_meta["signal_types"].items():
+                safe_name = sanitize_id(signal_name)
+                fields.append(
+                    mlc.Field(
+                        id=f"{file_id}_{safe_name}",
+                        name=signal_name,
+                        description=f"Signal '{signal_name}' from {file_meta['record_name']}",
+                        data_types=[signal_type],
+                        source=mlc.Source(
+                            file_object=file_id,
+                        ),
+                    )
+                )
+
+            duration = file_meta.get("duration_seconds", 0)
+            num_samples = file_meta.get("num_samples", 0)
+            sampling_freq = file_meta.get("sampling_frequency", 0)
+
+            record_sets.append(
+                mlc.RecordSet(
+                    id=sanitize_id(file_meta["record_name"]),
+                    name=file_meta["record_name"],
+                    description=(
+                        f"WFDB record {file_meta['record_name']}: "
+                        f"{file_meta.get('num_signals', 0)} signals at {sampling_freq} Hz, "
+                        f"{num_samples} samples ({duration:.2f} seconds)"
+                    ),
+                    fields=fields,
+                )
+            )
+
+        return [], record_sets

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -45,6 +45,28 @@ class MetadataGenerator:
         includes: Optional[List[str]] = None,
         excludes: Optional[List[str]] = None,
     ):
+        """
+        Initialize the metadata generator for a dataset.
+
+        Args:
+            dataset_path: Path to the directory containing dataset files.
+            name: Dataset name (defaults to directory name).
+            description: Dataset description.
+            url: Dataset URL.
+            license: License URL or SPDX identifier (e.g. "CC-BY-4.0").
+            citation: Citation text, preferably BibTeX format.
+            version: Dataset version string.
+            date_published: Publication date in ISO format ("2023-12-15" or
+                "2023-12-15T10:30:00").
+            creators: List of dicts with "name", "email", and/or "url" keys.
+            count_csv_rows: If True, scan each CSV fully for exact row counts.
+                Defaults to False for performance.
+            includes: Glob patterns to include. Applied before excludes.
+            excludes: Glob patterns to exclude. Applied after includes.
+
+        Raises:
+            ValueError: If dataset_path is not a directory.
+        """
         self.dataset_path = Path(dataset_path).resolve()
         if not self.dataset_path.is_dir():
             raise ValueError(f"Dataset path {dataset_path} is not a directory")
@@ -74,9 +96,9 @@ class MetadataGenerator:
             exclude_patterns=self.excludes,
         )
 
-        # Extract metadata, tracking which handler produced each entry.
-        file_metadata = []
-        meta_handler_map = {}
+        # Extract metadata as (handler, meta) pairs so handler identity is
+        # stored by reference, not by id() — no fragility if dicts are copied.
+        file_metadata: list[tuple] = []
         for file_path in files:
             full_path = self.dataset_path / file_path
             handler = find_handler(full_path)
@@ -84,8 +106,7 @@ class MetadataGenerator:
                 try:
                     meta = handler.extract_metadata(full_path, **self._handler_kwargs)
                     meta["relative_path"] = str(file_path)
-                    file_metadata.append(meta)
-                    meta_handler_map[id(meta)] = handler
+                    file_metadata.append((handler, meta))
                 except Exception as e:
                     print(f"Warning: Failed to process {file_path}: {e}")
 
@@ -113,7 +134,7 @@ class MetadataGenerator:
         file_counter = 0
         _batch_handlers: dict = defaultdict(list)
 
-        for file_meta in file_metadata:
+        for handler, file_meta in file_metadata:
             file_id = f"file_{file_counter}"
             file_counter += 1
 
@@ -147,9 +168,7 @@ class MetadataGenerator:
                         )
                     )
 
-            _h = meta_handler_map.get(id(file_meta))
-            if _h is not None:
-                _batch_handlers[_h].append((file_id, file_meta))
+            _batch_handlers[handler].append((file_id, file_meta))
 
         # Each handler builds its FileSets + RecordSets and returns them.
         # Handlers never return FileObjects — those are owned by the generator.
@@ -159,12 +178,15 @@ class MetadataGenerator:
         #   - enumerations: for low-cardinality categorical columns, emit
         #     sc:Enumeration RecordSets.
         for _h, pairs in _batch_handlers.items():
-            filesets, rs = _h.build_croissant(
-                [m for _, m in pairs],
-                [fid for fid, _ in pairs],
-            )
-            distributions.extend(filesets)
-            record_sets.extend(rs)
+            try:
+                filesets, rs = _h.build_croissant(
+                    [m for _, m in pairs],
+                    [fid for fid, _ in pairs],
+                )
+                distributions.extend(filesets)
+                record_sets.extend(rs)
+            except Exception as e:
+                print(f"Warning: {type(_h).__name__}.build_croissant failed: {e}")
 
         metadata.distribution = distributions
         metadata.record_sets = record_sets
@@ -178,7 +200,7 @@ class MetadataGenerator:
     def _build_description(self, file_metadata: list) -> str:
         if self.description:
             return self.description
-        file_types = {m.get("encoding_format", "unknown") for m in file_metadata}
+        file_types = {m.get("encoding_format", "unknown") for _, m in file_metadata}
         return (
             f"Dataset containing {len(file_metadata)} files "
             f"({', '.join(sorted(file_types))}) with automatically inferred types and structure"
@@ -229,7 +251,15 @@ class MetadataGenerator:
             )
 
     def save_metadata(self, output_path: str, validate: bool = True) -> None:
-        """Generate and save Croissant metadata to a file."""
+        """Generate and save Croissant metadata to a file.
+
+        Args:
+            output_path: Path where the JSON-LD metadata file will be written.
+            validate: If True (default), validates with mlcroissant before saving.
+
+        Raises:
+            ValueError: If validation fails or the file cannot be saved.
+        """
         metadata_dict = self.generate_metadata()
         output_file = Path(output_path)
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -10,12 +10,6 @@ import mlcroissant as mlc
 
 from croissant_baker.files import discover_files
 from croissant_baker.handlers.registry import find_handler, register_all_handlers
-from croissant_baker.handlers.utils import (
-    get_clean_record_name,
-    is_arrow_list,
-    map_arrow_type,
-    sanitize_id,
-)
 
 # Register all handlers
 register_all_handlers()
@@ -28,68 +22,12 @@ def serialize_datetime(obj):
     raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
-def _build_fields(
-    arrow_schema,
-    parent_id: str,
-    source_ref: dict,
-    col_path_prefix: str = "",
-) -> list:
-    """Recursively build mlc.Field objects from a PyArrow schema or struct type.
-
-    Handles three cases:
-    - Scalar column: maps to a Croissant type via map_arrow_type().
-    - List column: sets is_array=True; recurses on the element type.
-    - Struct column: recurses to produce sub_fields.
-    """
-    import pyarrow.types as patypes
-
-    fields = []
-    for arrow_field in arrow_schema:
-        col_name = arrow_field.name
-        arrow_type = arrow_field.type
-        safe_name = sanitize_id(col_name)
-        field_id = f"{parent_id}/{safe_name}"
-        col_path = f"{col_path_prefix}/{col_name}" if col_path_prefix else col_name
-
-        is_array = is_arrow_list(arrow_type)
-        inner_type = arrow_type.value_type if is_array else arrow_type
-
-        source = mlc.Source(
-            extract=mlc.Extract(column=col_path),
-            **source_ref,
-        )
-
-        if patypes.is_struct(inner_type):
-            sub_fields = _build_fields(inner_type, field_id, source_ref, col_path)
-            field = mlc.Field(
-                id=field_id,
-                name=col_name,
-                description=f"Column '{col_name}'",
-                is_array=True if is_array else None,
-                source=source,
-                sub_fields=sub_fields,
-            )
-        else:
-            col_type = map_arrow_type(inner_type)
-            field = mlc.Field(
-                id=field_id,
-                name=col_name,
-                description=f"Column '{col_name}'",
-                data_types=[col_type],
-                is_array=True if is_array else None,
-                source=source,
-            )
-        fields.append(field)
-    return fields
-
-
 class MetadataGenerator:
     """
     Generates Croissant metadata for datasets with automatic type inference.
 
-    This class discovers files in a dataset directory, processes them using
-    registered file handlers, and generates rich Croissant JSON-LD metadata
-    that describes the dataset structure and types.
+    Discovers files, delegates format-specific logic to registered handlers
+    via the build_croissant protocol, and assembles the final JSON-LD.
     """
 
     def __init__(
@@ -107,31 +45,10 @@ class MetadataGenerator:
         includes: Optional[List[str]] = None,
         excludes: Optional[List[str]] = None,
     ):
-        """
-        Initialize the metadata generator for a dataset.
-
-        Args:
-            dataset_path: Path to the directory containing dataset files
-            name: Dataset name (defaults to directory name)
-            description: Dataset description
-            url: Dataset URL
-            license: License URL or SPDX identifier
-            citation: Citation text (preferably BibTeX format)
-            version: Dataset version
-            date_published: Publication date (e.g., "2023-12-15" or "2023-12-15T10:30:00")
-            creators: List of creator dictionaries with name, email, url fields
-            count_csv_rows: Whether to count exact row numbers for CSV files
-            includes: Optional list of glob patterns to include. Applies before excludes.
-            excludes: Optional list of glob patterns to exclude. Applies after includes.
-
-        Raises:
-            ValueError: If the dataset path is not a directory
-        """
         self.dataset_path = Path(dataset_path).resolve()
         if not self.dataset_path.is_dir():
             raise ValueError(f"Dataset path {dataset_path} is not a directory")
 
-        # Store metadata overrides
         self.name = name
         self.description = description
         self.url = url
@@ -142,7 +59,7 @@ class MetadataGenerator:
         self.creators = creators
         self.includes = includes
         self.excludes = excludes
-        # Generic options dict passed to every handler via **kwargs.
+        # Generic options forwarded to every handler via **kwargs.
         # Handlers declare what they use; others ignore the rest.
         # To add a new handler-specific flag: add one key here — the call site never changes.
         self._handler_kwargs = {
@@ -150,458 +67,174 @@ class MetadataGenerator:
         }
 
     def generate_metadata(self) -> dict:
-        """
-        Generate complete Croissant metadata for the dataset.
-
-        Discovers all files in the dataset, processes them with appropriate
-        handlers, and creates a comprehensive metadata structure following
-        the Croissant specification.
-
-        Returns:
-            Dictionary containing the generated Croissant metadata
-
-        Raises:
-            ValueError: If no supported files are found in the dataset
-        """
-        # Discover and process files
+        """Generate complete Croissant metadata for the dataset."""
         files = discover_files(
             str(self.dataset_path),
             include_patterns=self.includes,
             exclude_patterns=self.excludes,
         )
-        file_metadata = []
 
+        # Extract metadata, tracking which handler produced each entry.
+        file_metadata = []
+        meta_handler_map = {}
         for file_path in files:
             full_path = self.dataset_path / file_path
             handler = find_handler(full_path)
             if handler:
                 try:
-                    metadata = handler.extract_metadata(
-                        full_path, **self._handler_kwargs
-                    )
-                    metadata["relative_path"] = str(file_path)
-                    file_metadata.append(metadata)
+                    meta = handler.extract_metadata(full_path, **self._handler_kwargs)
+                    meta["relative_path"] = str(file_path)
+                    file_metadata.append(meta)
+                    meta_handler_map[id(meta)] = handler
                 except Exception as e:
                     print(f"Warning: Failed to process {file_path}: {e}")
 
         if not file_metadata:
             raise ValueError("No supported files found in the dataset")
 
-        # Create Croissant metadata structure with user overrides or defaults
-        dataset_name = self.name or self.dataset_path.name
-
-        # Generate dataset description - prioritize user override, then try to be descriptive
-        if self.description:
-            description = self.description
-        else:
-            file_types = set(
-                meta.get("encoding_format", "unknown") for meta in file_metadata
-            )
-            file_types_str = ", ".join(sorted(file_types))
-            description = f"Dataset containing {len(file_metadata)} files ({file_types_str}) with automatically inferred types and structure"
-
-        # Generate dataset URL - prioritize user override, then use file path as fallback
-        dataset_url = self.url or f"file://{self.dataset_path}"
-
-        # Handle license - support both SPDX identifiers and URLs following Croissant spec
-        # See: https://github.com/mlcommons/croissant/blob/main/docs/croissant-spec.md#license
-        # Croissant license should be a single string (URL)
-        if self.license:
-            if self.license.startswith(("http://", "https://")):
-                license_value = self.license  # Already a URL
-            else:
-                # Convert SPDX identifier to URL (common licenses)
-                # Based on official Croissant examples from HuggingFace and Kaggle
-                spdx_to_url = {
-                    "CC-BY-4.0": "https://creativecommons.org/licenses/by/4.0/",
-                    "CC-BY-SA-4.0": "https://creativecommons.org/licenses/by-sa/4.0/",
-                    "CC-BY-NC-4.0": "https://creativecommons.org/licenses/by-nc/4.0/",
-                    "CC-BY-ND-4.0": "https://creativecommons.org/licenses/by-nd/4.0/",
-                    "CC0-1.0": "https://creativecommons.org/publicdomain/zero/1.0/",
-                    "MIT": "https://opensource.org/licenses/MIT",
-                    "Apache-2.0": "https://www.apache.org/licenses/LICENSE-2.0",
-                    "GPL-3.0": "https://www.gnu.org/licenses/gpl-3.0.html",
-                    "BSD-3-Clause": "https://opensource.org/licenses/BSD-3-Clause",
-                }
-                license_value = spdx_to_url.get(self.license, self.license)
-        else:
-            license_value = (
-                "https://creativecommons.org/licenses/by/4.0/"  # Default to CC-BY-4.0
-            )
-
-        # Handle creators - convert to schema.org Person/Organization objects following Croissant spec
-        # Croissant spec: creator is REQUIRED with cardinality MANY (supports multiple creators)
-        # See: https://docs.mlcommons.org/croissant/docs/croissant-spec.html#required
-        # Real examples: https://huggingface.co/api/datasets/ibm/duorc/croissant
-        if self.creators:
-            creator_objects = []
-            for creator_dict in self.creators:
-                person_kwargs = {}
-                # Add available properties - Croissant/schema.org Person supports name, email, url
-                if "name" in creator_dict:
-                    person_kwargs["name"] = creator_dict["name"]
-                if "email" in creator_dict:
-                    person_kwargs["email"] = creator_dict["email"]
-                if "url" in creator_dict:
-                    person_kwargs["url"] = creator_dict["url"]
-
-                # Create Person object with available properties
-                creator_objects.append(mlc.Person(**person_kwargs))
-        else:
-            # Default creator - could be improved by parsing CITATION or README files
-            creator_objects = [
-                mlc.Person(name="Dataset Creator", email="creator@example.com")
-            ]
-
-        # Handle citation - prioritize user override, then generate basic citation
-        if self.citation:
-            cite_as = self.citation
-        else:
-            current_year = datetime.now().year
-            cite_as = f"Dataset Creator. ({current_year}). {dataset_name} Dataset. Generated with automated type inference."
-
-        # Handle date_published - prioritize user override, then default to current time
-        if self.date_published:
-            try:
-                # Parse user-provided date - supports ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS
-                publication_date = datetime.fromisoformat(self.date_published)
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid date format for --date-published: '{self.date_published}'. "
-                    f"Expected ISO format like '2023-12-15' or '2023-12-15T10:30:00'. Error: {e}"
-                )
-        else:
-            publication_date = datetime.now()
-
-        # Handle version
-        dataset_version = self.version or "1.0.0"
-
         metadata = mlc.Metadata(
-            name=dataset_name,
-            description=description,
-            url=dataset_url,
-            license=license_value,
-            creators=creator_objects,
-            date_published=publication_date,
-            version=dataset_version,
-            cite_as=cite_as,
+            name=self.name or self.dataset_path.name,
+            description=self._build_description(file_metadata),
+            url=self.url or f"file://{self.dataset_path}",
+            license=self._resolve_license(),
+            creators=self._build_creators(),
+            date_published=self._resolve_date(),
+            version=self.version or "1.0.0",
+            cite_as=self._build_citation(),
         )
 
-        file_objects = []
+        # distributions holds both FileObjects and FileSets — the full contents
+        # of the Croissant `distribution` array per the spec.
+        distributions = []
         record_sets = []
-        # Use a counter instead of enumerate(i) to ensure unique FileObject IDs.
-        # Some formats (e.g., WFDB) create multiple FileObjects per iteration via
-        # related_files, so enumerate(i) would cause ID conflicts. The counter
-        # increments for every FileObject created, not just per iteration.
+        # Use a counter (not enumerate) for unique FileObject IDs: some formats
+        # (e.g. WFDB) create multiple FileObjects per meta via related_files,
+        # so enumerate would produce ID collisions.
         file_counter = 0
-
-        # Collect image file IDs so we can build one FileSet + summary
-        # RecordSet after the per-file loop (images are grouped, not per-file).
-        image_file_ids = []
-        image_metas = []
-
-        # Pre-group parquet files by parent directory to detect partitioned tables.
-        # A directory with >=2 .parquet files is treated as one logical table:
-        # one FileSet + one RecordSet (schema from first partition). Individual
-        # FileObjects are still emitted for each partition to preserve checksums.
-        # Root-level parquet files (parent == ".") are never grouped.
-        _parquet_by_dir: dict[str, list] = defaultdict(list)
-        for _fm in file_metadata:
-            if _fm.get("encoding_format") == "application/vnd.apache.parquet":
-                _parent = str(Path(_fm["relative_path"]).parent)
-                if _parent != ".":
-                    _parquet_by_dir[_parent].append(_fm)
-        _partitioned_dirs: set[str] = {
-            d for d, metas in _parquet_by_dir.items() if len(metas) >= 2
-        }
-        # Accumulates (file_id, file_meta) per partitioned directory during the loop.
-        _parquet_groups: dict[str, list] = defaultdict(list)
+        _batch_handlers: dict = defaultdict(list)
 
         for file_meta in file_metadata:
             file_id = f"file_{file_counter}"
             file_counter += 1
 
-            # Create FileObject for each file.
-            # Correctly creates a cr:FileObject per discovered file with
-            # relative contentUrl, SHA256 checksum, size, and encoding format.
-            file_obj = mlc.FileObject(
-                id=file_id,
-                name=file_meta["file_name"],
-                content_url=file_meta["relative_path"],
-                encoding_formats=[file_meta["encoding_format"]],
-                content_size=str(file_meta["file_size"]),
-                sha256=file_meta["sha256"],
+            distributions.append(
+                mlc.FileObject(
+                    id=file_id,
+                    name=file_meta["file_name"],
+                    content_url=file_meta["relative_path"],
+                    encoding_formats=[file_meta["encoding_format"]],
+                    content_size=str(file_meta["file_size"]),
+                    sha256=file_meta["sha256"],
+                )
             )
-            file_objects.append(file_obj)
 
-            # Handle multi-file records (e.g., WFDB: .hea + .dat + .atr)
-            # Some formats like WFDB have multiple physical files per logical record
-            related_file_ids = []
+            # Multi-file records (e.g. WFDB: .hea + .dat + .atr): the generator
+            # owns FileObject creation for every physical file. RecordSet
+            # construction is delegated to the handler via build_croissant.
             if "related_files" in file_meta:
                 for related in file_meta["related_files"]:
                     related_id = f"file_{file_counter}"
                     file_counter += 1
-                    related_file_ids.append(related_id)
-
                     rel_path = Path(related["path"])
-                    relative_path = str(rel_path.relative_to(self.dataset_path))
-
-                    related_obj = mlc.FileObject(
-                        id=related_id,
-                        name=related["name"],
-                        content_url=relative_path,
-                        encoding_formats=[related["encoding"]],
-                        content_size=str(related["size"]),
-                        sha256=related["sha256"],
-                    )
-                    file_objects.append(related_obj)
-
-            # --- RecordSet creation per file type ---
-
-            # Tabular data (CSV, Parquet): one RecordSet per file with column fields.
-            # Partitioned parquet tables (>=2 files in the same directory) are deferred:
-            # their FileObjects are still created above, but RecordSet emission is
-            # handled after the loop via FileSets (one per directory).
-            #
-            # TODO: Add support for more advanced Croissant features.
-            # - references: Detect and add `references` for foreign key relationships
-            #   (e.g., subject_id, hadm_id). This is high-impact.
-            # - enumerations: For categorical columns, generate sc:Enumeration RecordSets.
-            if "column_types" in file_meta:
-                _rel_dir = str(Path(file_meta["relative_path"]).parent)
-                _is_partitioned = (
-                    file_meta.get("encoding_format") == "application/vnd.apache.parquet"
-                    and _rel_dir in _partitioned_dirs
-                )
-                if _is_partitioned:
-                    _parquet_groups[_rel_dir].append((file_id, file_meta))
-                else:
-                    # For parquet files in a subdirectory, prefer the directory name
-                    # over the partition file name (e.g. "drug_molecule" over "part-00000").
-                    if (
-                        file_meta.get("encoding_format")
-                        == "application/vnd.apache.parquet"
-                        and _rel_dir != "."
-                    ):
-                        rs_name = Path(_rel_dir).name
-                    else:
-                        rs_name = get_clean_record_name(file_meta["file_name"])
-                    rs_id = sanitize_id(rs_name)
-                    if "arrow_schema" in file_meta:
-                        fields = _build_fields(
-                            file_meta["arrow_schema"],
-                            rs_id,
-                            {"file_object": file_id},
-                        )
-                    else:
-                        fields = []
-                        for col_name, col_type in file_meta["column_types"].items():
-                            safe_name = sanitize_id(col_name)
-                            field_id = f"{rs_id}/{safe_name}"
-                            field = mlc.Field(
-                                id=field_id,
-                                name=col_name,
-                                description=f"Column '{col_name}' from {file_meta['file_name']}",
-                                data_types=[col_type],
-                                source=mlc.Source(
-                                    file_object=file_id,
-                                    extract=mlc.Extract(column=col_name),
-                                ),
-                            )
-                            fields.append(field)
-
-                    num_rows = file_meta.get("num_rows")
-                    row_desc = f" ({num_rows} rows)" if num_rows is not None else ""
-                    record_set = mlc.RecordSet(
-                        id=rs_id,
-                        name=rs_name,
-                        description=f"Records from {file_meta['file_name']}{row_desc}",
-                        fields=fields,
-                    )
-                    record_sets.append(record_set)
-
-            # Signal data (e.g., WFDB physiological waveforms)
-            elif "signal_types" in file_meta:
-                fields = []
-                for signal_name, signal_type in file_meta["signal_types"].items():
-                    safe_name = sanitize_id(signal_name)
-                    field = mlc.Field(
-                        id=f"{file_id}_{safe_name}",
-                        name=signal_name,
-                        description=f"Signal '{signal_name}' from {file_meta['record_name']}",
-                        data_types=[signal_type],
-                        source=mlc.Source(
-                            file_object=file_id,
-                        ),
-                    )
-                    fields.append(field)
-
-                duration = file_meta.get("duration_seconds", 0)
-                num_samples = file_meta.get("num_samples", 0)
-                sampling_freq = file_meta.get("sampling_frequency", 0)
-
-                record_set = mlc.RecordSet(
-                    id=sanitize_id(file_meta["record_name"]),
-                    name=file_meta["record_name"],
-                    description=f"WFDB record {file_meta['record_name']}: {file_meta.get('num_signals', 0)} signals at {sampling_freq} Hz, {num_samples} samples ({duration:.2f} seconds)",
-                    fields=fields,
-                )
-                record_sets.append(record_set)
-
-            # Image data: defer to summary RecordSet after the loop
-            elif "image_properties" in file_meta:
-                image_file_ids.append(file_id)
-                image_metas.append(file_meta)
-
-        # Build a FileSet + summary RecordSet for all images in the dataset.
-        # Each image already has its own cr:FileObject (with SHA256 and size).
-        # The FileSet groups them by glob pattern so the RecordSet source can
-        # reference all images at once, following the Croissant spec PASS example.
-        if image_file_ids:
-            from croissant_baker.handlers.image_handler import collect_image_summary
-
-            summary = collect_image_summary(image_metas)
-            w_lo, w_hi = summary["width_range"]
-            h_lo, h_hi = summary["height_range"]
-            b_lo, b_hi = summary["num_bands_range"]
-            formats_str = ", ".join(
-                f"{fmt} ({cnt})" for fmt, cnt in summary["format_counts"].items()
-            )
-
-            # Human-readable dimension string for the RecordSet description.
-            # Uniform size → "1920x1080", mixed → "640-1920x480-1080".
-            if w_lo == w_hi and h_lo == h_hi:
-                dims = f"{w_lo}x{h_lo}"
-            else:
-                dims = f"{w_lo}-{w_hi}x{h_lo}-{h_hi}"
-
-            # Only mention band count when images are multi-band (>4),
-            # i.e. scientific imagery like Sentinel-2. Standard RGB/RGBA
-            # images (1-4 bands) don't need the note.
-            bands_note = f", {b_lo}-{b_hi} bands" if b_hi > 4 else ""
-
-            # Determine unique extensions and MIME types across all images.
-            extensions = set()
-            mime_types = set()
-            for meta in image_metas:
-                ext = Path(meta["file_name"]).suffix.lower()
-                extensions.add(ext)
-                mime_types.add(meta["encoding_format"])
-
-            # Build glob patterns -- use **/ prefix to match subdirectories.
-            includes = [f"**/*{ext}" for ext in sorted(extensions)]
-
-            fileset_id = "image-files"
-            image_fileset = mlc.FileSet(
-                id=fileset_id,
-                name="Image files",
-                description=f"{summary['num_images']} image files ({formats_str})",
-                encoding_formats=sorted(mime_types),
-                includes=includes,
-            )
-            file_objects.append(image_fileset)
-
-            image_fields = [
-                mlc.Field(
-                    id="images/image_content",
-                    name="image",
-                    description=f"Image content ({summary['num_images']} files, {formats_str})",
-                    data_types=["sc:ImageObject"],
-                    source=mlc.Source(
-                        file_set=fileset_id,
-                        extract=mlc.Extract(file_property="content"),
-                    ),
-                ),
-            ]
-
-            image_record_set = mlc.RecordSet(
-                id="images",
-                name="images",
-                description=f"{summary['num_images']} images ({dims}{bands_note}): {formats_str}",
-                fields=image_fields,
-            )
-            record_sets.append(image_record_set)
-
-        # Emit one FileSet + one RecordSet per partitioned parquet directory.
-        # Schema is taken from the first partition; all partitions must share the
-        # same schema (standard for Spark/OT-style partitioned datasets).
-        # Individual FileObjects (with checksums) were already appended in the loop.
-        for dir_path, id_meta_pairs in _parquet_groups.items():
-            _, first_meta = id_meta_pairs[0]
-            table_name = Path(dir_path).name
-            dir_id = sanitize_id(dir_path)
-            fileset_id = f"{dir_id}-fileset"
-
-            # Derive the glob suffix from actual filenames so double-extension
-            # files like "part-00000.snappy.parquet" are correctly matched.
-            _sample_name = id_meta_pairs[0][1]["file_name"]
-            _suffix = "".join(Path(_sample_name).suffixes)
-            file_objects.append(
-                mlc.FileSet(
-                    id=fileset_id,
-                    name=f"{table_name} partition files",
-                    description=f"{len(id_meta_pairs)} Parquet partition files for table '{table_name}'",
-                    encoding_formats=["application/vnd.apache.parquet"],
-                    includes=[f"{dir_path}/*{_suffix}"],
-                )
-            )
-
-            if "arrow_schema" in first_meta:
-                fields = _build_fields(
-                    first_meta["arrow_schema"],
-                    sanitize_id(table_name),
-                    {"file_set": fileset_id},
-                )
-            else:
-                fields = []
-                for col_name, col_type in first_meta["column_types"].items():
-                    safe_name = sanitize_id(col_name)
-                    field_id = f"{dir_id}/{safe_name}"
-                    fields.append(
-                        mlc.Field(
-                            id=field_id,
-                            name=col_name,
-                            description=f"Column '{col_name}' from table '{table_name}'",
-                            data_types=[col_type],
-                            source=mlc.Source(
-                                file_set=fileset_id,
-                                extract=mlc.Extract(column=col_name),
-                            ),
+                    distributions.append(
+                        mlc.FileObject(
+                            id=related_id,
+                            name=related["name"],
+                            content_url=str(rel_path.relative_to(self.dataset_path)),
+                            encoding_formats=[related["encoding"]],
+                            content_size=str(related["size"]),
+                            sha256=related["sha256"],
                         )
                     )
 
-            num_rows = sum(m.get("num_rows", 0) for _, m in id_meta_pairs)
-            record_sets.append(
-                mlc.RecordSet(
-                    id=sanitize_id(table_name),
-                    name=table_name,
-                    description=f"Partitioned table '{table_name}' ({len(id_meta_pairs)} Parquet files, {num_rows} total rows)",
-                    fields=fields,
-                )
-            )
+            _h = meta_handler_map.get(id(file_meta))
+            if _h is not None:
+                _batch_handlers[_h].append((file_id, file_meta))
 
-        metadata.distribution = file_objects
+        # Each handler builds its FileSets + RecordSets and returns them.
+        # Handlers never return FileObjects — those are owned by the generator.
+        # TODO: future improvements per handler:
+        #   - references: detect foreign-key columns (e.g. subject_id) and emit
+        #     cr:references links between RecordSets — high-impact for EHR data.
+        #   - enumerations: for low-cardinality categorical columns, emit
+        #     sc:Enumeration RecordSets.
+        for _h, pairs in _batch_handlers.items():
+            filesets, rs = _h.build_croissant(
+                [m for _, m in pairs],
+                [fid for fid, _ in pairs],
+            )
+            distributions.extend(filesets)
+            record_sets.extend(rs)
+
+        metadata.distribution = distributions
         metadata.record_sets = record_sets
 
         return metadata.to_json()
 
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_description(self, file_metadata: list) -> str:
+        if self.description:
+            return self.description
+        file_types = {m.get("encoding_format", "unknown") for m in file_metadata}
+        return (
+            f"Dataset containing {len(file_metadata)} files "
+            f"({', '.join(sorted(file_types))}) with automatically inferred types and structure"
+        )
+
+    def _resolve_license(self) -> str:
+        if not self.license:
+            return "https://creativecommons.org/licenses/by/4.0/"
+        if self.license.startswith(("http://", "https://")):
+            return self.license
+        spdx_to_url = {
+            "CC-BY-4.0": "https://creativecommons.org/licenses/by/4.0/",
+            "CC-BY-SA-4.0": "https://creativecommons.org/licenses/by-sa/4.0/",
+            "CC-BY-NC-4.0": "https://creativecommons.org/licenses/by-nc/4.0/",
+            "CC-BY-ND-4.0": "https://creativecommons.org/licenses/by-nd/4.0/",
+            "CC0-1.0": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "MIT": "https://opensource.org/licenses/MIT",
+            "Apache-2.0": "https://www.apache.org/licenses/LICENSE-2.0",
+            "GPL-3.0": "https://www.gnu.org/licenses/gpl-3.0.html",
+            "BSD-3-Clause": "https://opensource.org/licenses/BSD-3-Clause",
+        }
+        return spdx_to_url.get(self.license, self.license)
+
+    def _build_creators(self) -> list:
+        if not self.creators:
+            return [mlc.Person(name="Dataset Creator", email="creator@example.com")]
+        return [
+            mlc.Person(**{k: v for k, v in c.items() if k in ("name", "email", "url")})
+            for c in self.creators
+        ]
+
+    def _build_citation(self) -> str:
+        if self.citation:
+            return self.citation
+        year = datetime.now().year
+        name = self.name or self.dataset_path.name
+        return f"Dataset Creator. ({year}). {name} Dataset. Generated with automated type inference."
+
+    def _resolve_date(self) -> datetime:
+        if not self.date_published:
+            return datetime.now()
+        try:
+            return datetime.fromisoformat(self.date_published)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid date format for --date-published: '{self.date_published}'. "
+                f"Expected ISO format like '2023-12-15' or '2023-12-15T10:30:00'. Error: {e}"
+            )
+
     def save_metadata(self, output_path: str, validate: bool = True) -> None:
-        """
-        Generate and save Croissant metadata to a file.
-
-        Args:
-            output_path: Path where the metadata file should be saved
-            validate: Whether to validate the metadata before saving
-
-        Raises:
-            ValueError: If validation fails or file cannot be saved
-        """
+        """Generate and save Croissant metadata to a file."""
         metadata_dict = self.generate_metadata()
         output_file = Path(output_path)
         output_file.parent.mkdir(parents=True, exist_ok=True)
 
         if validate:
-            # Validate using temporary file before saving to final location
             with tempfile.NamedTemporaryFile(
                 mode="w", suffix=".jsonld", delete=False
             ) as tmp_file:
@@ -613,27 +246,17 @@ class MetadataGenerator:
                     default=serialize_datetime,
                 )
                 tmp_path = tmp_file.name
-
             try:
-                # Validate by attempting to load with mlcroissant
                 mlc.Dataset(tmp_path)
                 self._save_to_file(metadata_dict, output_file)
             except Exception as e:
                 raise ValueError(f"Validation failed: {e}")
             finally:
-                # Clean up the temporary file
                 Path(tmp_path).unlink(missing_ok=True)
         else:
             self._save_to_file(metadata_dict, output_file)
 
     def _save_to_file(self, metadata_dict: dict, output_file: Path) -> None:
-        """
-        Save metadata dictionary to a JSON-LD file.
-
-        Args:
-            metadata_dict: The metadata to save
-            output_file: Path where the file should be saved
-        """
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(
                 metadata_dict,
@@ -642,5 +265,4 @@ class MetadataGenerator:
                 ensure_ascii=False,
                 default=serialize_datetime,
             )
-            # Ensure newline at end of file to avoid pre-commit edits
             f.write("\n")

--- a/tests/data/output/open_targets_like_croissant.jsonld
+++ b/tests/data/output/open_targets_like_croissant.jsonld
@@ -178,89 +178,6 @@
   "recordSet": [
     {
       "@type": "cr:RecordSet",
-      "@id": "drug_molecule",
-      "name": "drug_molecule",
-      "description": "Records from part-00000.parquet (5 rows)",
-      "field": [
-        {
-          "@type": "cr:Field",
-          "@id": "drug_molecule/id",
-          "name": "id",
-          "description": "Column 'id'",
-          "dataType": "sc:Text",
-          "source": {
-            "fileObject": {
-              "@id": "file_8"
-            },
-            "extract": {
-              "column": "id"
-            }
-          }
-        },
-        {
-          "@type": "cr:Field",
-          "@id": "drug_molecule/name",
-          "name": "name",
-          "description": "Column 'name'",
-          "dataType": "sc:Text",
-          "source": {
-            "fileObject": {
-              "@id": "file_8"
-            },
-            "extract": {
-              "column": "name"
-            }
-          }
-        },
-        {
-          "@type": "cr:Field",
-          "@id": "drug_molecule/maxClinicalTrialPhase",
-          "name": "maxClinicalTrialPhase",
-          "description": "Column 'maxClinicalTrialPhase'",
-          "dataType": "cr:Float32",
-          "source": {
-            "fileObject": {
-              "@id": "file_8"
-            },
-            "extract": {
-              "column": "maxClinicalTrialPhase"
-            }
-          }
-        },
-        {
-          "@type": "cr:Field",
-          "@id": "drug_molecule/yearOfFirstApproval",
-          "name": "yearOfFirstApproval",
-          "description": "Column 'yearOfFirstApproval'",
-          "dataType": "cr:Int16",
-          "source": {
-            "fileObject": {
-              "@id": "file_8"
-            },
-            "extract": {
-              "column": "yearOfFirstApproval"
-            }
-          }
-        },
-        {
-          "@type": "cr:Field",
-          "@id": "drug_molecule/hasBeenWithdrawn",
-          "name": "hasBeenWithdrawn",
-          "description": "Column 'hasBeenWithdrawn'",
-          "dataType": "sc:Boolean",
-          "source": {
-            "fileObject": {
-              "@id": "file_8"
-            },
-            "extract": {
-              "column": "hasBeenWithdrawn"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "@type": "cr:RecordSet",
       "@id": "targets",
       "name": "targets",
       "description": "Partitioned table 'targets' (2 Parquet files, 10 total rows)",
@@ -635,6 +552,89 @@
             },
             "extract": {
               "column": "isTherapeuticArea"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@type": "cr:RecordSet",
+      "@id": "drug_molecule",
+      "name": "drug_molecule",
+      "description": "Records from part-00000.parquet (5 rows)",
+      "field": [
+        {
+          "@type": "cr:Field",
+          "@id": "drug_molecule/id",
+          "name": "id",
+          "description": "Column 'id'",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "id"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drug_molecule/name",
+          "name": "name",
+          "description": "Column 'name'",
+          "dataType": "sc:Text",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "name"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drug_molecule/maxClinicalTrialPhase",
+          "name": "maxClinicalTrialPhase",
+          "description": "Column 'maxClinicalTrialPhase'",
+          "dataType": "cr:Float32",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "maxClinicalTrialPhase"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drug_molecule/yearOfFirstApproval",
+          "name": "yearOfFirstApproval",
+          "description": "Column 'yearOfFirstApproval'",
+          "dataType": "cr:Int16",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "yearOfFirstApproval"
+            }
+          }
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "drug_molecule/hasBeenWithdrawn",
+          "name": "hasBeenWithdrawn",
+          "description": "Column 'hasBeenWithdrawn'",
+          "dataType": "sc:Boolean",
+          "source": {
+            "fileObject": {
+              "@id": "file_8"
+            },
+            "extract": {
+              "column": "hasBeenWithdrawn"
             }
           }
         }

--- a/tests/data/output/reserved_names_croissant.jsonld
+++ b/tests/data/output/reserved_names_croissant.jsonld
@@ -54,9 +54,9 @@
     "@type": "sc:Person",
     "name": "Test Author"
   },
-  "datePublished": "2026-04-08T09:34:16.957326",
+  "datePublished": "2026-04-11T11:12:48.290147",
   "license": "https://creativecommons.org/licenses/by/4.0/",
-  "url": "file:///private/var/folders/cc/x4wmyd75077d6w05q421t82r0000gn/T/pytest-of-rajnu/pytest-23/test_reserved_name_struct_fiel0/reserved_names",
+  "url": "file:///private/var/folders/t2/64zmxnp511vdl4pwg5frfck40000gn/T/pytest-of-rafraf/pytest-14/test_reserved_name_struct_fiel0/reserved_names",
   "version": "1.0.0",
   "distribution": [
     {

--- a/tests/test_csv_handler.py
+++ b/tests/test_csv_handler.py
@@ -71,3 +71,47 @@ def test_csv_handler_data_types(tmp_path: Path) -> None:
     assert column_types["bool_col"] == "sc:Boolean"
     assert column_types["float_col"] == "cr:Float64"
     assert column_types["text_col"] == "sc:Text"
+
+
+# ---------------------------------------------------------------------------
+# build_croissant
+# ---------------------------------------------------------------------------
+
+
+def test_csv_build_croissant_single_file() -> None:
+    handler = CSVHandler()
+    meta = {
+        "file_name": "patients.csv",
+        "relative_path": "patients.csv",
+        "column_types": {"id": "sc:Text", "age": "cr:Int64", "dob": "sc:Date"},
+        "num_rows": 100,
+    }
+    filesets, record_sets = handler.build_croissant([meta], ["file_0"])
+
+    assert filesets == []
+    assert len(record_sets) == 1
+    assert record_sets[0].name == "patients"
+    assert len(record_sets[0].fields) == 3
+
+
+def test_csv_build_croissant_multiple_files() -> None:
+    handler = CSVHandler()
+    metas = [
+        {
+            "file_name": "a.csv",
+            "relative_path": "a.csv",
+            "column_types": {"x": "sc:Text"},
+            "num_rows": None,
+        },
+        {
+            "file_name": "b.csv",
+            "relative_path": "b.csv",
+            "column_types": {"y": "cr:Float64"},
+            "num_rows": 50,
+        },
+    ]
+    filesets, record_sets = handler.build_croissant(metas, ["file_0", "file_1"])
+
+    assert filesets == []
+    assert len(record_sets) == 2
+    assert {rs.name for rs in record_sets} == {"a", "b"}

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -222,3 +222,41 @@ def test_image_handler_registered() -> None:
     assert find_handler(Path("photo.jpg")) is not None
     assert find_handler(Path("scan.png")) is not None
     assert find_handler(Path("satellite.tiff")) is not None
+
+
+# ---------------------------------------------------------------------------
+# build_croissant
+# ---------------------------------------------------------------------------
+
+
+def _img_meta(name, fmt="JPEG", mime="image/jpeg", w=100, h=100, bands=3):
+    return {
+        "file_name": name,
+        "encoding_format": mime,
+        "image_properties": {
+            "width": w,
+            "height": h,
+            "num_bands": bands,
+            "image_format": fmt,
+        },
+    }
+
+
+def test_image_build_croissant(handler: ImageHandler) -> None:
+    metas = [_img_meta("a.jpg"), _img_meta("b.jpg")]
+    filesets, record_sets = handler.build_croissant(metas, ["file_0", "file_1"])
+
+    assert len(filesets) == 1
+    assert len(record_sets) == 1
+    assert record_sets[0].name == "images"
+    assert "**/*.jpg" in filesets[0].includes
+
+
+def test_image_build_croissant_multiband(handler: ImageHandler) -> None:
+    metas = [
+        _img_meta(f"tile_{i}.tif", fmt="TIFF", mime="image/tiff", bands=12)
+        for i in range(3)
+    ]
+    _, record_sets = handler.build_croissant(metas, [f"file_{i}" for i in range(3)])
+
+    assert "band" in record_sets[0].description

--- a/tests/test_parquet_handler.py
+++ b/tests/test_parquet_handler.py
@@ -107,3 +107,46 @@ def test_extract_metadata_not_found(handler: ParquetHandler) -> None:
     """Test that missing file raises FileNotFoundError."""
     with pytest.raises(FileNotFoundError):
         handler.extract_metadata(Path("/nonexistent/data.parquet"))
+
+
+# ---------------------------------------------------------------------------
+# build_croissant
+# ---------------------------------------------------------------------------
+
+
+def _pq_meta(name, rel_path, cols=None):
+    return {
+        "file_name": name,
+        "relative_path": rel_path,
+        "column_types": cols or {"id": "sc:Text", "value": "cr:Float64"},
+        "num_rows": 10,
+        "encoding_format": "application/vnd.apache.parquet",
+    }
+
+
+def test_parquet_build_croissant_standalone(handler: ParquetHandler) -> None:
+    filesets, record_sets = handler.build_croissant(
+        [_pq_meta("data.parquet", "data.parquet")], ["file_0"]
+    )
+    assert filesets == []
+    assert record_sets[0].name == "data"
+
+
+def test_parquet_build_croissant_single_file_in_subdir(handler: ParquetHandler) -> None:
+    filesets, record_sets = handler.build_croissant(
+        [_pq_meta("part-00000.parquet", "events/part-00000.parquet")], ["file_0"]
+    )
+    assert filesets == []
+    assert record_sets[0].name == "events"
+
+
+def test_parquet_build_croissant_partitioned(handler: ParquetHandler) -> None:
+    metas = [
+        _pq_meta("part-00000.parquet", "events/part-00000.parquet"),
+        _pq_meta("part-00001.parquet", "events/part-00001.parquet"),
+    ]
+    filesets, record_sets = handler.build_croissant(metas, ["file_0", "file_1"])
+    assert len(filesets) == 1
+    assert len(record_sets) == 1
+    assert record_sets[0].name == "events"
+    assert "events/*.parquet" in filesets[0].includes

--- a/tests/test_wfdb_handler.py
+++ b/tests/test_wfdb_handler.py
@@ -61,3 +61,26 @@ def test_missing_dat_file_raises_error(tmp_path):
 
     with pytest.raises(ValueError, match="WFDB data file missing"):
         handler.extract_metadata(hea_file)
+
+
+# ---------------------------------------------------------------------------
+# build_croissant
+# ---------------------------------------------------------------------------
+
+
+def test_wfdb_build_croissant() -> None:
+    handler = WFDBHandler()
+    meta = {
+        "record_name": "100",
+        "signal_types": {"MLII": "sc:Float", "V5": "sc:Float"},
+        "num_signals": 2,
+        "sampling_frequency": 360,
+        "num_samples": 650000,
+        "duration_seconds": 1805.56,
+    }
+    filesets, record_sets = handler.build_croissant([meta], ["file_0"])
+
+    assert filesets == []
+    assert len(record_sets) == 1
+    assert record_sets[0].name == "100"
+    assert {f.name for f in record_sets[0].fields} == {"MLII", "V5"}


### PR DESCRIPTION
## Why

`MetadataGenerator.generate_metadata()` had grown to 647 lines with format-specific dispatch — `if "column_types" ... elif "signal_types" ... elif "image_properties"` — baked directly into the generator. Every new handler required editing the generator. This doesn't scale.

## What changed

Added `build_croissant(file_metas, file_ids) -> (FileSets, RecordSets)` as an `@abstractmethod` on `FileTypeHandler`. The generator now does exactly two things:

1. Creates all `FileObject`s (owns ID assignment and the global counter)
2. Calls `handler.build_croissant()` per handler — handlers return FileSets + RecordSets, never FileObjects

Format knowledge — column types, signal fields, image glob patterns, partitioned Parquet grouping — lives entirely inside each handler.

## Design

Three required methods per handler: `can_handle`, `extract_metadata`, `build_croissant`. The registry pattern + Strategy pattern means adding a new format is: subclass, implement three methods, register — zero other files change.

`_build_fields` (Arrow schema → `mlc.Field`, handles nested lists/structs recursively) moved to `handlers/utils.py`. Renamed `file_objects` → `distributions` in the generator to match Croissant spec terminology (`distribution` holds both FileObjects and FileSets).

## Why `open_targets_like_croissant.jsonld` changed

Previously standalone Parquet RecordSets were emitted inline during the main loop while partitioned ones were deferred post-loop. Now all Parquet output is emitted together in the post-loop batch phase. The JSON-LD is semantically identical — the Croissant spec does not require ordering, and all structural test assertions pass unchanged.

## Result

- `metadata_generator.py`: 647 → 249 lines, zero format-specific key checks
- 72/72 tests pass
- Adding a new format: subclass `FileTypeHandler`, implement 3 methods, register in `registry.py`