### PR TITLE
fix: remove file:// url fallback to prevent local path leakage

### DIFF
--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -116,7 +116,7 @@ class MetadataGenerator:
         metadata = mlc.Metadata(
             name=self.name or self.dataset_path.name,
             description=self._build_description(file_metadata),
-            url=self.url or f"file://{self.dataset_path}",
+            url=self.url,
             license=self._resolve_license(),
             creators=self._build_creators(),
             date_published=self._resolve_date(),


### PR DESCRIPTION
When --url is not provided, the dataset url field previously fell back to file:///absolute/path/to/dataset, leaking the local filesystem path. The url should be provided explicitly via the --url flag.