### PR TITLE
rai:dataBias -> rai:dataBiases and rai:socialImpact -> rai:dataSocialImpact

### DIFF
--- a/rai-example.yaml
+++ b/rai-example.yaml
@@ -41,11 +41,11 @@ ai_fairness:
     countries, or patient demographics. Not intended for direct clinical
     decision-making.
 
-  # rai:dataBias
+  # rai:dataBiases
   # Detail specific skews, representational gaps, and known biases — including
   # the geographic or demographic background of annotators, institutional norms
   # of the source, and amplified biases in any synthetic data.
-  data_bias: >
+  data_biases: >
     The patient population skews toward English-speaking adults; paediatric
     and non-English-speaking patients are under-represented. Annotator pool
     consisted of clinical experts from a single US institution.
@@ -68,7 +68,7 @@ ai_fairness:
     models. Supporting research into hospital readmission, mortality prediction,
     and clinical decision support. Not intended for direct clinical use.
 
-  # rai:socialImpact
+  # rai:dataSocialImpact
   # Articulate what new capabilities the dataset enables, who benefits, potential
   # harms, affected groups, and concrete mitigation steps (licensing, access
   # controls, usage agreements).

--- a/src/croissant_baker/rai/injector.py
+++ b/src/croissant_baker/rai/injector.py
@@ -33,14 +33,14 @@ def inject_rai(metadata: dict, config: RAIConfig) -> dict:
     af = config.ai_fairness
     if af.data_limitations:
         metadata["rai:dataLimitations"] = af.data_limitations
-    if af.data_bias:
-        metadata["rai:dataBias"] = af.data_bias
+    if af.data_biases:
+        metadata["rai:dataBiases"] = af.data_biases
     if af.personal_sensitive_information:
         metadata["rai:personalSensitiveInformation"] = af.personal_sensitive_information
     if af.data_use_cases:
         metadata["rai:dataUseCases"] = af.data_use_cases
-    if af.social_impact:
-        metadata["rai:socialImpact"] = af.social_impact
+    if af.data_social_impact:
+        metadata["rai:dataSocialImpact"] = af.data_social_impact
     if af.has_synthetic_data is not None:
         metadata["rai:hasSyntheticData"] = af.has_synthetic_data
 

--- a/src/croissant_baker/rai/loader.py
+++ b/src/croissant_baker/rai/loader.py
@@ -35,12 +35,12 @@ def load_rai_config(path: Path) -> RAIConfig:
     af_raw = raw.get("ai_fairness") or {}
     ai_fairness = AIFairnessConfig(
         data_limitations=_str(af_raw.get("data_limitations")),
-        data_bias=_str(af_raw.get("data_bias")),
+        data_biases=_str(af_raw.get("data_biases")),
         personal_sensitive_information=_str(
             af_raw.get("personal_sensitive_information")
         ),
         data_use_cases=_str(af_raw.get("data_use_cases")),
-        social_impact=_str(af_raw.get("social_impact")),
+        data_social_impact=_str(af_raw.get("data_social_impact")),
         has_synthetic_data=bool(af_raw["has_synthetic_data"])
         if "has_synthetic_data" in af_raw
         else None,

--- a/src/croissant_baker/rai/schema.py
+++ b/src/croissant_baker/rai/schema.py
@@ -12,10 +12,10 @@ from typing import Optional
 @dataclass
 class AIFairnessConfig:
     data_limitations: Optional[str] = None
-    data_bias: Optional[str] = None
+    data_biases: Optional[str] = None
     personal_sensitive_information: Optional[str] = None
     data_use_cases: Optional[str] = None
-    social_impact: Optional[str] = None
+    data_social_impact: Optional[str] = None
     has_synthetic_data: Optional[bool] = None
 
 

--- a/tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml
+++ b/tests/data/input/mimiciv_demo/physionet.org/mimiciv_demo-rai-example.yaml
@@ -9,7 +9,7 @@ ai_fairness:
     countries, or patient demographics. Not intended for direct clinical
     decision-making.
 
-  data_bias: >
+  data_biases: >
     The patient population skews toward English-speaking adults; paediatric
     and non-English-speaking patients are under-represented.
 
@@ -24,7 +24,7 @@ ai_fairness:
     prediction, and clinical decision support. Not intended for direct
     clinical decision-making.
 
-  social_impact: >
+  data_social_impact: >
     This dataset enables research that could improve clinical AI tools and
     patient outcomes. However, models trained on biased data risk perpetuating
     health disparities if deployed without careful evaluation.

--- a/tests/data/output/mimiciv_demo_croissant_rai.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant_rai.jsonld
@@ -5785,10 +5785,10 @@
     }
   ],
   "rai:dataLimitations": "Data originates from a single academic medical centre in the northeastern United States. Findings may not generalise to other hospital systems, countries, or patient demographics. Not intended for direct clinical decision-making.",
-  "rai:dataBias": "The patient population skews toward English-speaking adults; paediatric and non-English-speaking patients are under-represented.",
+  "rai:dataBiases": "The patient population skews toward English-speaking adults; paediatric and non-English-speaking patients are under-represented.",
   "rai:personalSensitiveInformation": "The dataset contains de-identified patient health records. Re-identification risk has been minimised via HIPAA Safe Harbor procedures. Access is restricted to credentialed researchers who have signed a data use agreement.",
   "rai:dataUseCases": "Benchmarking clinical natural language processing and machine learning models. Supporting research into hospital readmission, mortality prediction, and clinical decision support. Not intended for direct clinical decision-making.",
-  "rai:socialImpact": "This dataset enables research that could improve clinical AI tools and patient outcomes. However, models trained on biased data risk perpetuating health disparities if deployed without careful evaluation.",
+  "rai:dataSocialImpact": "This dataset enables research that could improve clinical AI tools and patient outcomes. However, models trained on biased data risk perpetuating health disparities if deployed without careful evaluation.",
   "rai:hasSyntheticData": false,
   "prov:wasDerivedFrom": [
     {

--- a/tests/test_rai.py
+++ b/tests/test_rai.py
@@ -28,10 +28,10 @@ MIMICIV_PATH = (
 _RAI_PROV_KEYS = [
     "prov:wasGeneratedBy",
     "rai:dataLimitations",
-    "rai:dataBias",
+    "rai:dataBiases",
     "rai:personalSensitiveInformation",
     "rai:dataUseCases",
-    "rai:socialImpact",
+    "rai:dataSocialImpact",
     "prov:wasDerivedFrom",
 ]
 


### PR DESCRIPTION
The YAML-based RAI workflow uses `rai:dataBias` (singular) as the key for data bias. The `--rai-*` flags introduced in https://github.com/MIT-LCP/croissant-baker/pull/69 uses `rai:dataBiases` (plural).

According to the online spec at https://docs.mlcommons.org/croissant/docs/croissant-rai-spec.html, the plural `rai:dataBiases` is correct. `rai:socialImpact` also appears incorrect (according to the spec, it should be `rai:dataSocialImpact`). 

This pull request updates the YAML workflow to use `rai:dataBiases` and `rai:dataSocialImpact`. @JoanGi, could you confirm that these keys are correct?
