### PR TITLE
fix(wfdb): handle header parse failures

### DIFF
--- a/src/croissant_baker/handlers/wfdb_handler.py
+++ b/src/croissant_baker/handlers/wfdb_handler.py
@@ -33,7 +33,10 @@ class WFDBHandler(FileTypeHandler):
             raise FileNotFoundError(f"WFDB header file not found: {file_path}")
 
         record_path = file_path.with_suffix("")
-        record = wfdb.rdheader(str(record_path))
+        try:
+            record = wfdb.rdheader(str(record_path))
+        except Exception as e:
+            raise ValueError(f"Failed to read WFDB header {file_path}: {e}") from e
 
         dat_file = file_path.with_suffix(".dat")
         if not dat_file.exists():

--- a/tests/test_wfdb_handler.py
+++ b/tests/test_wfdb_handler.py
@@ -1,6 +1,8 @@
 """Tests for WFDB handler."""
 
 from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from croissant_baker.handlers.wfdb_handler import WFDBHandler
@@ -61,6 +63,19 @@ def test_missing_dat_file_raises_error(tmp_path):
 
     with pytest.raises(ValueError, match="WFDB data file missing"):
         handler.extract_metadata(hea_file)
+
+
+def test_rdheader_failure_is_wrapped(tmp_path):
+    handler = WFDBHandler()
+    hea_file = tmp_path / "test.hea"
+    hea_file.write_text("test 1 360 1000")
+
+    with patch(
+        "croissant_baker.handlers.wfdb_handler.wfdb.rdheader",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(ValueError, match="Failed to read WFDB header"):
+            handler.extract_metadata(hea_file)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wrap `wfdb.rdheader()` failures in `WFDBHandler` with a contextual `ValueError`
- Add a regression test to verify malformed or failing WFDB headers are handled cleanly

## Validation
- `uv run pytest -q`

Closes #50