### PR TITLE
fix(image): read TIFF dimensions from tags to avoid swapped metadata

### DIFF
--- a/src/croissant_baker/handlers/image_handler.py
+++ b/src/croissant_baker/handlers/image_handler.py
@@ -64,16 +64,35 @@ def _read_with_tifffile(file_path: Path) -> Dict:
 
     with tifffile.TiffFile(str(file_path)) as tif:
         page = tif.pages[0]
-        shape = page.shape  # (height, width) or (height, width, bands)
+        # Prefer the TIFF tags, which describe the logical image dimensions
+        # directly and are not affected by planar storage order.
+        width = getattr(page, "imagewidth", None)
+        height = getattr(page, "imagelength", None)
+        num_bands = getattr(page, "samplesperpixel", None)
 
-        height = shape[0]
-        width = shape[1]
-        num_bands = shape[2] if len(shape) > 2 else 1
+        if width is None or height is None or num_bands is None:
+            # Some TIFF variants expose dimensions more reliably through axes.
+            shape = getattr(page, "shape", ())
+            axes = getattr(page, "axes", "") or ""
+            shape_map = dict(zip(axes, shape)) if axes else {}
+
+            if width is None:
+                width = shape_map.get("X")
+            if height is None:
+                height = shape_map.get("Y")
+            if num_bands is None:
+                num_bands = shape_map.get("S")
+
+        if width is None or height is None:
+            raise ValueError(f"Unable to determine TIFF dimensions for {file_path}")
+
+        if num_bands is None:
+            num_bands = 1
 
         return {
-            "width": width,
-            "height": height,
-            "num_bands": num_bands,
+            "width": int(width),
+            "height": int(height),
+            "num_bands": int(num_bands),
             "image_format": "TIFF",
         }
 

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -2,8 +2,11 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
+import tifffile
 
+import croissant_baker.handlers.image_handler as image_handler_module
 from croissant_baker.handlers.image_handler import (
     ImageHandler,
     collect_image_summary,
@@ -116,6 +119,50 @@ def test_extract_metadata_tiff(
     assert props["width"] > 0
     assert props["height"] > 0
     # Sentinel-2 images have 12 bands
+    assert props["num_bands"] == 12
+    assert props["image_format"] == "TIFF"
+
+
+@pytest.fixture
+def separate_planar_tiff_path(tmp_path: Path) -> Path:
+    """Create a multi-band TIFF that forces the tifffile fallback path."""
+    path = tmp_path / "separate_planar.tiff"
+    data = np.zeros((12, 5, 7), dtype=np.uint8)
+    tifffile.imwrite(
+        str(path),
+        data,
+        photometric="minisblack",
+        planarconfig="separate",
+    )
+    return path
+
+
+def test_extract_metadata_separate_planar_tiff(
+    handler: ImageHandler,
+    separate_planar_tiff_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for TIFFs whose band axis is stored first."""
+
+    def _force_tifffile_fallback(_path: Path) -> None:
+        raise RuntimeError("force tifffile fallback")
+
+    monkeypatch.setattr(
+        image_handler_module,
+        "_read_with_pillow",
+        _force_tifffile_fallback,
+    )
+
+    meta = handler.extract_metadata(separate_planar_tiff_path)
+
+    assert meta["file_name"] == "separate_planar.tiff"
+    assert meta["encoding_format"] == "image/tiff"
+    assert meta["file_size"] > 0
+    assert len(meta["sha256"]) == 64
+
+    props = meta["image_properties"]
+    assert props["width"] == 7
+    assert props["height"] == 5
     assert props["num_bands"] == 12
     assert props["image_format"] == "TIFF"
 


### PR DESCRIPTION
## Summary

This PR fixes TIFF metadata extraction for files that store bands separately.

Previously, the code read TIFF dimensions from `page.shape`, which can put the band count first for some TIFF layouts. That caused width and height to be swapped in generated metadata.

The new logic:
- reads `ImageWidth`, `ImageLength`, and `SamplesPerPixel` first
- falls back to `page.shape` plus `page.axes` if needed (use labeled axes like X, Y, and S)
- raises a clear error if width/height still cannot be determined

A regression test was added that forces the tifffile fallback path and verifies that a separate-planar TIFF reports the correct width, height, and band count.

## Why this matters

Some TIFF files, especially scientific or multi-band ones, store dimensions differently from standard images. This fix prevents incorrect metadata from being generated for those files.

## Validation

- `uv run pytest -q`
- `uv run ruff check src/croissant_baker/handlers/image_handler.py tests/test_image_handler.py`

## Related Issue

Fixes #55