### PR TITLE
fix: update README for PyPI page rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="https://lcp.mit.edu/croissant-baker/"><strong>Documentation</strong></a>
+  <a href="https://lcp.mit.edu/croissant-baker/"><strong>📖 Documentation</strong></a>
 </p>
 
 ---


### PR DESCRIPTION
The 0.1.0 wheel uploaded to PyPI was built before the README updates, so the PyPI page shows no description. This bumps a patch version so the next release includes the current README.