### PR TITLE
fix: use absolute URL for PyPI logo and markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/baker_logo.png" alt="croissant-baker" width="200">
+  <img src="https://raw.githubusercontent.com/MIT-LCP/croissant-baker/main/docs/assets/baker_logo.png" alt="croissant-baker" width="200">
 </p>
 
 <h1 align="center">Croissant Baker</h1>

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ See the [documentation](https://lcp.mit.edu/croissant-baker/) for full CLI refer
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [DEVELOPMENT.md](DEVELOPMENT.md) for setup, testing, releases, and how to add new file handlers.
+See [CONTRIBUTING.md](https://raw.githubusercontent.com/MIT-LCP/croissant-baker/main/CONTRIBUTING.md) for guidelines and [DEVELOPMENT.md](https://raw.githubusercontent.com/MIT-LCP/croissant-baker/main/DEVELOPMENT.md) for setup, testing, releases, and how to add new file handlers.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file.
+MIT License - see [LICENSE](https://raw.githubusercontent.com/MIT-LCP/croissant-baker/main/LICENSE) file.


### PR DESCRIPTION
The README uses a relative path for the logo (docs/assets/baker_logo.png).

PyPI can't resolve this path, resulting in a "Bad url scheme" error: https://pypi.org/project/croissant-baker/0.1.1

(Image path is: https://pypi-camo.freetls.fastly.net/e76485557350d6d7f3a80a6a1fdf7f81e1ba5a34/646f63732f6173736574732f62616b65725f6c6f676f2e706e67)

This pull request replaces the relative path with the absolute path.