### PR TITLE
fix: count only cr:FileObject entries in CLI summary

### DIFF
--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -118,6 +118,13 @@ _SPEC_REQUIRED_FLAGS = {
 _RAI_CONFORMS_TO = "http://mlcommons.org/croissant/RAI/1.0"
 
 
+def _echo_file_counts(file_count: int, file_set_count: int) -> None:
+    """Print Files and File sets banner lines (File sets only when present)."""
+    typer.echo(f"Files: {file_count}")
+    if file_set_count:
+        typer.echo(f"File sets: {file_set_count}")
+
+
 def _warn_missing_spec_fields(**provided: object) -> None:
     """Warn about spec-required fields that were not explicitly provided."""
     missing = [
@@ -645,13 +652,15 @@ def main(
                 progress.update(save_task, description="Save completed!")
 
         # Show results
-        file_count = len(metadata_dict.get("distribution", []))
+        distribution = metadata_dict.get("distribution", [])
+        file_count = sum(1 for d in distribution if d.get("@type") == "cr:FileObject")
+        file_set_count = sum(1 for d in distribution if d.get("@type") == "cr:FileSet")
         record_count = len(metadata_dict.get("recordSet", []))
 
         typer.echo(
             f"Success! Generated {'validated ' if validate else ''}Croissant metadata"
         )
-        typer.echo(f"Files: {file_count}")
+        _echo_file_counts(file_count, file_set_count)
         typer.echo(f"Record sets: {record_count}")
         typer.echo(f"Saved to: {output}")
 
@@ -742,12 +751,10 @@ def validate(
         typer.echo(f"Description: {dataset.metadata.description}")
 
         if hasattr(dataset.metadata, "distribution"):
-            file_count = (
-                len(dataset.metadata.distribution)
-                if dataset.metadata.distribution
-                else 0
-            )
-            typer.echo(f"Files: {file_count}")
+            distribution = dataset.metadata.distribution or []
+            file_count = sum(1 for d in distribution if isinstance(d, mlc.FileObject))
+            file_set_count = sum(1 for d in distribution if isinstance(d, mlc.FileSet))
+            _echo_file_counts(file_count, file_set_count)
 
         if hasattr(dataset.metadata, "record_sets"):
             record_count = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -362,6 +362,60 @@ def test_dry_run_invalid_input() -> None:
     assert result.exit_code == 1
 
 
+def test_summary_files_count_excludes_filesets(tmp_path: Path) -> None:
+    """Banner Files line counts cr:FileObject entries only."""
+    from PIL import Image
+
+    dataset = tmp_path / "imgs"
+    dataset.mkdir()
+    for i in range(3):
+        Image.new("RGB", (4, 4)).save(dataset / f"img_{i}.png")
+    output = tmp_path / "out.jsonld"
+
+    result = runner.invoke(
+        app,
+        [
+            "-i",
+            str(dataset),
+            "-o",
+            str(output),
+            "--creator",
+            "Tester",
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    assert "Files: 3" in result.stdout
+    assert "Files: 4" not in result.stdout
+    assert "File sets: 1" in result.stdout
+
+    metadata = json.loads(output.read_text())
+    types = [d["@type"] for d in metadata["distribution"]]
+    assert types.count("cr:FileObject") == 3
+    assert types.count("cr:FileSet") == 1
+
+
+def test_validate_command_files_count_excludes_filesets(tmp_path: Path) -> None:
+    """Validate subcommand banner counts FileObject entries only."""
+    from PIL import Image
+
+    dataset = tmp_path / "imgs"
+    dataset.mkdir()
+    for i in range(2):
+        Image.new("RGB", (4, 4)).save(dataset / f"img_{i}.png")
+    jsonld = tmp_path / "out.jsonld"
+
+    gen = runner.invoke(app, ["-i", str(dataset), "-o", str(jsonld), "--creator", "T"])
+    assert gen.exit_code == 0, gen.output
+
+    result = runner.invoke(app, ["validate", str(jsonld)])
+    assert result.exit_code == 0, result.output
+    assert "Files: 2" in result.stdout
+    assert "Files: 3" not in result.stdout
+    assert "File sets: 1" in result.stdout
+
+
 def test_include_filter_limits_generated_files(
     mixed_dataset: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
The Files line used len(distribution), which mixes FileObject and FileSet entries and inflated the count for partitioned Parquet and image datasets. Generate and validate paths now filter on @type, and a File sets line is emitted when FileSets are present.

Closes #92