### PR TITLE
fix: validate magic bytes in image and parquet can_handle (#93)

### DIFF
--- a/src/croissant_baker/handlers/image_handler.py
+++ b/src/croissant_baker/handlers/image_handler.py
@@ -41,6 +41,68 @@ _MIME_TYPES: Dict[str, str] = {
     ".tif": "image/tiff",
 }
 
+# Magic-byte signatures for every supported image extension. These are
+# stable, format-spec-defined headers — they don't change across versions:
+#
+#   PNG     : ISO/IEC 15948 §5.2 — 8-byte signature
+#   JPEG    : ITU-T T.81 / JFIF  — SOI marker 0xFFD8 followed by another marker (0xFF**)
+#   GIF     : GIF89a spec        — ASCII "GIF87a" or "GIF89a"
+#   TIFF    : TIFF 6.0 §2        — "II\x2a\x00" (LE) or "MM\x00\x2a" (BE);
+#                                  BigTIFF (Adobe ext, 2007) uses version byte
+#                                  0x2b instead of 0x2a — read by Pillow and tifffile
+#   BMP     : BITMAPFILEHEADER   — bfType "BM"
+#   WebP    : RFC 6386           — "RIFF" + 4-byte size + "WEBP"
+#   ICO     : Microsoft ICONDIR  — reserved 0x0000, type 0x0001 (icon) or 0x0002 (cursor)
+#
+# Each entry maps an extension to a predicate over the file's leading bytes.
+# We read just enough bytes to satisfy the longest signature (WebP, 12 bytes).
+_IMAGE_MAGIC_PREFIX_BYTES = 12
+
+# Standard TIFF (version 0x2a) and BigTIFF (version 0x2b), little- and big-endian.
+_TIFF_MAGICS = (b"II*\x00", b"MM\x00*", b"II+\x00", b"MM\x00+")
+
+_IMAGE_MAGIC_CHECKS = {
+    ".png": lambda h: h.startswith(b"\x89PNG\r\n\x1a\n"),
+    ".jpg": lambda h: h.startswith(b"\xff\xd8\xff"),
+    ".jpeg": lambda h: h.startswith(b"\xff\xd8\xff"),
+    ".gif": lambda h: h.startswith((b"GIF87a", b"GIF89a")),
+    ".tiff": lambda h: h.startswith(_TIFF_MAGICS),
+    ".tif": lambda h: h.startswith(_TIFF_MAGICS),
+    ".bmp": lambda h: h.startswith(b"BM"),
+    ".webp": lambda h: h[:4] == b"RIFF" and h[8:12] == b"WEBP",
+    ".ico": lambda h: h[:4] in (b"\x00\x00\x01\x00", b"\x00\x00\x02\x00"),
+}
+
+
+def _has_image_magic(file_path: Path) -> bool:
+    """Return True iff ``file_path``'s leading bytes match the magic for its extension.
+
+    Used by :meth:`ImageHandler.can_handle` to enforce the registry contract:
+    if a handler claims a file, ``extract_metadata`` must be able to read it.
+    A file with an image extension but non-image content (e.g. a renamed HTML
+    page saved as ``.png``) is rejected and a WARNING is logged so the user
+    can see which files were skipped and why. Missing or unreadable files
+    return False without logging (those are caller errors, not impostors).
+    """
+    suffix = file_path.suffix.lower()
+    check = _IMAGE_MAGIC_CHECKS.get(suffix)
+    if check is None:
+        return False
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(_IMAGE_MAGIC_PREFIX_BYTES)
+    except OSError:
+        return False
+    if check(head):
+        return True
+    logger.warning(
+        "Skipping %s: extension is %s but file content does not match the "
+        "expected image magic bytes",
+        file_path,
+        suffix,
+    )
+    return False
+
 
 def _read_with_pillow(file_path: Path) -> Dict:
     """Read image metadata using Pillow (standard RGB/grayscale images)."""
@@ -145,7 +207,9 @@ class ImageHandler(FileTypeHandler):
     FORMAT_DESCRIPTION = "Dimensions, color mode, encoding format"
 
     def can_handle(self, file_path: Path) -> bool:
-        return file_path.suffix.lower() in SUPPORTED_EXTENSIONS
+        if file_path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            return False
+        return _has_image_magic(file_path)
 
     def extract_metadata(self, file_path: Path, **kwargs) -> dict:
         if not file_path.exists():

--- a/src/croissant_baker/handlers/parquet_handler.py
+++ b/src/croissant_baker/handlers/parquet_handler.py
@@ -1,5 +1,6 @@
 """Parquet file handler for tabular event streams (e.g., MEDS)."""
 
+import logging
 from collections import defaultdict
 from pathlib import Path
 
@@ -14,6 +15,55 @@ from croissant_baker.handlers.utils import (
     infer_column_types_from_arrow_schema,
     sanitize_id,
 )
+
+logger = logging.getLogger(__name__)
+
+# Apache Parquet file format spec: every Parquet file begins AND ends with
+# the 4-byte ASCII magic "PAR1" — the trailing copy is the footer marker.
+# A valid file is therefore at least 8 bytes long.
+# Reference: https://parquet.apache.org/docs/file-format/
+_PARQUET_MAGIC = b"PAR1"
+_PARQUET_MAGIC_LEN = len(_PARQUET_MAGIC)
+
+
+def _has_parquet_magic(file_path: Path) -> bool:
+    """Return True iff ``file_path`` has the Parquet magic at start and end.
+
+    Files that fail any check (too small, missing PAR1 header, missing PAR1
+    footer) are rejected and a WARNING is logged with the specific reason so
+    the user can see which files were skipped and why. Missing or unreadable
+    files return False without logging (caller errors, not impostors).
+    """
+    try:
+        size = file_path.stat().st_size
+    except OSError:
+        return False
+    if size < _PARQUET_MAGIC_LEN * 2:
+        logger.warning(
+            "Skipping %s: file is too small (%d bytes) to be a valid Parquet file",
+            file_path,
+            size,
+        )
+        return False
+    try:
+        with open(file_path, "rb") as f:
+            if f.read(_PARQUET_MAGIC_LEN) != _PARQUET_MAGIC:
+                logger.warning(
+                    "Skipping %s: missing Parquet PAR1 header magic",
+                    file_path,
+                )
+                return False
+            f.seek(-_PARQUET_MAGIC_LEN, 2)
+            if f.read(_PARQUET_MAGIC_LEN) != _PARQUET_MAGIC:
+                logger.warning(
+                    "Skipping %s: missing Parquet PAR1 footer magic "
+                    "(file may be truncated)",
+                    file_path,
+                )
+                return False
+            return True
+    except OSError:
+        return False
 
 
 class ParquetHandler(FileTypeHandler):
@@ -31,7 +81,9 @@ class ParquetHandler(FileTypeHandler):
     FORMAT_DESCRIPTION = "Arrow schema, column names and types, row count"
 
     def can_handle(self, file_path: Path) -> bool:
-        return file_path.suffix.lower() == ".parquet"
+        if file_path.suffix.lower() != ".parquet":
+            return False
+        return _has_parquet_magic(file_path)
 
     def extract_metadata(self, file_path: Path, **kwargs) -> dict:
         """Extract metadata from a Parquet file via pyarrow schema inspection."""

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -19,32 +19,135 @@ def handler() -> ImageHandler:
 
 
 # ---------------------------------------------------------------------------
-# can_handle
+# can_handle — extension + magic bytes (issue #93)
+#
+# can_handle enforces the registry contract: True implies extract_metadata
+# can read the file. Tests cover the three failure modes (wrong extension,
+# right extension/wrong content, missing file) plus the happy path per
+# extension. Each accepted-extension case writes a minimal magic-byte stub
+# so we exercise real files, not bare path strings.
 # ---------------------------------------------------------------------------
 
 
+# Minimal magic-byte stubs per supported extension. These are not full
+# images — they only need enough bytes to satisfy can_handle's check.
+_IMAGE_STUBS = {
+    ".png": b"\x89PNG\r\n\x1a\n",
+    ".jpg": b"\xff\xd8\xff\xe0",
+    ".jpeg": b"\xff\xd8\xff\xe0",
+    ".gif": b"GIF89a",
+    ".bmp": b"BM\x00\x00\x00\x00",
+    ".webp": b"RIFF\x00\x00\x00\x00WEBP",
+    ".tiff": b"II*\x00",
+    ".tif": b"MM\x00*",
+    ".ico": b"\x00\x00\x01\x00",
+}
+
+
 @pytest.mark.parametrize(
-    "name,expected",
+    "filename",
     [
-        ("photo.jpg", True),
-        ("photo.jpeg", True),
-        ("photo.JPG", True),
-        ("scan.png", True),
-        ("scan.PNG", True),
-        ("frame.gif", True),
-        ("icon.bmp", True),
-        ("hero.webp", True),
-        ("satellite.tiff", True),
-        ("satellite.tif", True),
-        ("satellite.TIFF", True),
-        ("data.csv", False),
-        ("model.parquet", False),
-        ("readme.txt", False),
-        ("record.hea", False),
+        "photo.jpg",
+        "photo.jpeg",
+        "photo.JPG",  # case-insensitive suffix
+        "scan.png",
+        "scan.PNG",
+        "frame.gif",
+        "icon.bmp",
+        "hero.webp",
+        "satellite.tiff",
+        "satellite.tif",
+        "satellite.TIFF",
+        "image.ico",
     ],
 )
-def test_can_handle(handler: ImageHandler, name: str, expected: bool) -> None:
-    assert handler.can_handle(Path(name)) == expected
+def test_can_handle_accepts_supported_extensions_with_magic(
+    handler: ImageHandler, tmp_path: Path, filename: str
+) -> None:
+    """Files whose extension is supported AND whose content matches the
+    extension's magic bytes are accepted."""
+    p = tmp_path / filename
+    p.write_bytes(_IMAGE_STUBS[p.suffix.lower()])
+    assert handler.can_handle(p) is True
+
+
+@pytest.mark.parametrize(
+    "name", ["data.csv", "model.parquet", "readme.txt", "record.hea"]
+)
+def test_can_handle_rejects_unsupported_extensions(
+    handler: ImageHandler, name: str
+) -> None:
+    """Non-image extensions are rejected before any I/O — bare path is fine."""
+    assert handler.can_handle(Path(name)) is False
+
+
+def test_can_handle_rejects_missing_file(handler: ImageHandler) -> None:
+    """A path with an image extension but no file on disk is rejected.
+
+    Without a file we cannot honor the contract that extract_metadata won't
+    crash, so can_handle must say no.
+    """
+    assert handler.can_handle(Path("/nonexistent/photo.png")) is False
+
+
+def test_can_handle_rejects_wrong_magic(
+    handler: ImageHandler, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Right extension, wrong content (e.g., HTML renamed to .png) is rejected
+    AND a WARNING is logged naming the file so the user knows what was skipped.
+
+    Regression for #93: prevents the registry from dispatching a renamed
+    file to ImageHandler.extract_metadata and crashing inside Pillow, and
+    surfaces the skip so the user is not blindsided by a missing file count.
+    """
+    impostor = tmp_path / "fake.png"
+    impostor.write_bytes(b"<!DOCTYPE html><html></html>")
+    with caplog.at_level("WARNING", logger="croissant_baker.handlers.image_handler"):
+        assert handler.can_handle(impostor) is False
+    assert any(
+        str(impostor) in r.message and "magic bytes" in r.message
+        for r in caplog.records
+    ), f"expected a WARNING naming {impostor} and 'magic bytes', got {caplog.records}"
+
+
+def test_can_handle_missing_file_does_not_warn(
+    handler: ImageHandler, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A missing file is silently rejected (no spurious warnings) since the
+    caller, not the file, is at fault."""
+    with caplog.at_level("WARNING", logger="croissant_baker.handlers.image_handler"):
+        assert handler.can_handle(Path("/nonexistent/photo.png")) is False
+    assert caplog.records == []
+
+
+def test_can_handle_accepts_real_image(handler: ImageHandler, tmp_path: Path) -> None:
+    """A fully-encoded PNG (not just a magic stub) is accepted."""
+    from PIL import Image
+
+    real_png = tmp_path / "real.png"
+    Image.new("RGB", (4, 4), color="red").save(real_png)
+    assert handler.can_handle(real_png) is True
+
+
+def test_can_handle_accepts_bigtiff(handler: ImageHandler, tmp_path: Path) -> None:
+    """BigTIFF (TIFF variant for files >4GB, version byte 0x2b) is accepted.
+
+    Regression for #93: Pillow and tifffile both read BigTIFF, so the
+    contract requires can_handle to claim it.
+    """
+    bigtiff = tmp_path / "huge.tiff"
+    tifffile.imwrite(
+        str(bigtiff),
+        np.zeros((4, 4, 3), dtype=np.uint8),
+        bigtiff=True,
+    )
+    # Verify we wrote a real BigTIFF (version byte 0x2b, not 0x2a).
+    assert bigtiff.read_bytes()[:4] in (b"II+\x00", b"MM\x00+")
+    assert handler.can_handle(bigtiff) is True
+    # And extract_metadata must succeed — the contract.
+    meta = handler.extract_metadata(bigtiff)
+    assert meta["image_properties"]["width"] == 4
+    assert meta["image_properties"]["height"] == 4
 
 
 # ---------------------------------------------------------------------------
@@ -261,14 +364,20 @@ def test_collect_image_summary_missing_properties() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_image_handler_registered() -> None:
-    """ImageHandler should be discoverable via the global registry."""
+def test_image_handler_registered(tmp_path: Path) -> None:
+    """ImageHandler should be discoverable via the global registry for real
+    image files (i.e. extension AND magic bytes match)."""
     from croissant_baker.handlers.registry import find_handler, register_all_handlers
 
     register_all_handlers()
-    assert find_handler(Path("photo.jpg")) is not None
-    assert find_handler(Path("scan.png")) is not None
-    assert find_handler(Path("satellite.tiff")) is not None
+    for name, magic in [
+        ("photo.jpg", _IMAGE_STUBS[".jpg"]),
+        ("scan.png", _IMAGE_STUBS[".png"]),
+        ("satellite.tiff", _IMAGE_STUBS[".tiff"]),
+    ]:
+        p = tmp_path / name
+        p.write_bytes(magic)
+        assert find_handler(p) is not None, f"no handler dispatched for {name}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parquet_handler.py
+++ b/tests/test_parquet_handler.py
@@ -31,16 +31,97 @@ def sample_parquet(tmp_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# can_handle
+# can_handle — extension + magic bytes (issue #93)
+#
+# can_handle enforces the registry contract: True implies extract_metadata
+# can read the file. Tests cover the failure modes (wrong extension, right
+# extension/wrong content, truncated, missing) plus the happy path.
 # ---------------------------------------------------------------------------
 
 
-def test_can_handle_parquet(handler: ParquetHandler) -> None:
-    """Test Parquet handler file type detection."""
-    assert handler.can_handle(Path("data.parquet"))
-    assert handler.can_handle(Path("data.PARQUET"))
-    assert not handler.can_handle(Path("data.csv"))
-    assert not handler.can_handle(Path("data.txt"))
+@pytest.mark.parametrize("name", ["data.csv", "data.txt", "data"])
+def test_can_handle_rejects_unsupported_extensions(
+    handler: ParquetHandler, name: str
+) -> None:
+    """Non-.parquet extensions are rejected before any I/O."""
+    assert handler.can_handle(Path(name)) is False
+
+
+_PARQUET_LOGGER = "croissant_baker.handlers.parquet_handler"
+
+
+def test_can_handle_missing_file_does_not_warn(
+    handler: ParquetHandler, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A missing .parquet path is silently rejected (no spurious warning)
+    since the caller, not the file, is at fault."""
+    with caplog.at_level("WARNING", logger=_PARQUET_LOGGER):
+        assert handler.can_handle(Path("/nonexistent/data.parquet")) is False
+    assert caplog.records == []
+
+
+def test_can_handle_rejects_wrong_magic(
+    handler: ParquetHandler, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A .parquet file without PAR1 magic is rejected AND a WARNING is
+    logged identifying the file and the missing PAR1 header.
+
+    Regression for #93: prevents the registry from dispatching a renamed
+    file to ParquetHandler.extract_metadata and crashing inside pyarrow,
+    while still surfacing the skip so the user knows what was dropped.
+    """
+    impostor = tmp_path / "fake.parquet"
+    impostor.write_bytes(b"not a parquet file at all")
+    with caplog.at_level("WARNING", logger=_PARQUET_LOGGER):
+        assert handler.can_handle(impostor) is False
+    assert any(
+        str(impostor) in r.message and "PAR1 header" in r.message
+        for r in caplog.records
+    ), f"expected a WARNING naming {impostor} and 'PAR1 header', got {caplog.records}"
+
+
+def test_can_handle_rejects_truncated_parquet(
+    handler: ParquetHandler, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A truncated Parquet (start magic only, no footer magic) is rejected
+    AND a WARNING explicitly mentions the missing footer / possible truncation."""
+    truncated = tmp_path / "truncated.parquet"
+    truncated.write_bytes(b"PAR1" + b"\x00" * 32)
+    with caplog.at_level("WARNING", logger=_PARQUET_LOGGER):
+        assert handler.can_handle(truncated) is False
+    assert any(
+        str(truncated) in r.message
+        and ("footer" in r.message or "truncated" in r.message)
+        for r in caplog.records
+    ), (
+        f"expected a WARNING naming {truncated} and footer/truncated, got {caplog.records}"
+    )
+
+
+def test_can_handle_rejects_too_small_parquet(
+    handler: ParquetHandler, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A .parquet file under 8 bytes (cannot fit two PAR1 magics) is rejected
+    with a WARNING that names the file and its size."""
+    tiny = tmp_path / "tiny.parquet"
+    tiny.write_bytes(b"PAR")  # 3 bytes, well under the 8-byte minimum
+    with caplog.at_level("WARNING", logger=_PARQUET_LOGGER):
+        assert handler.can_handle(tiny) is False
+    assert any(
+        str(tiny) in r.message and "too small" in r.message for r in caplog.records
+    ), f"expected a WARNING naming {tiny} and 'too small', got {caplog.records}"
+
+
+def test_can_handle_accepts_real_parquet(
+    handler: ParquetHandler, sample_parquet: Path
+) -> None:
+    """A real Parquet file (PAR1 at start AND end) is accepted, including
+    when the extension is uppercased."""
+    assert handler.can_handle(sample_parquet) is True
+
+    upper = sample_parquet.with_name("test.PARQUET")
+    upper.write_bytes(sample_parquet.read_bytes())
+    assert handler.can_handle(upper) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The handler registry contract was implicit: when can_handle returns True, extract_metadata should not raise on the file's content. Image and parquet handlers dispatched on extension alone, so renamed or truncated files crashed inside Pillow or pyarrow with library tracebacks.

This change adds a magic byte check to can_handle for both handlers. Image covers PNG, JPEG, GIF, TIFF (including BigTIFF), BMP, WebP, ICO, each signature cited from the format spec. Parquet requires PAR1 at start AND end, so truncated files are rejected. Files that fail the check are skipped by the registry and a WARNING is logged that names the file and the specific reason (wrong magic, missing footer, too small) so users see what was dropped instead of being blindsided by a smaller file count.

Verified on MIMIC IV MEDS (369 parquet files), MIMIC IV CSV (31 files), and a mixed impostor fixture where four bad files were dropped with clear stderr warnings naming each one. 189 tests pass.

Closes #93.