### PR TITLE
feat: declare Croissant 1.1 conformance and expose optional spec flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,9 +35,9 @@ $ croissant-baker [OPTIONS] COMMAND [ARGS]...
 * `--alternate-name TEXT`: Short alias for the dataset (e.g., 'MIMIC-IV').
 * `--is-live-dataset`: Mark the dataset as a live, evolving stream (e.g., a continuously-appended log).
 * `--temporal-coverage TEXT`: Time period the data covers. ISO 8601 recommended: '2008/2019' (interval) or '2023-01-15' (point).
-* `--usage-info TEXT`: URL of a usage / consent policy. Examples: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term), or any ODRL Offer URL.
-* `--field-mappings FILE`: YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\n  <col>:\n    equivalent_property: <URI>\n    data_types: [<URI>, ...]'. Use for multi-property overrides; for one URI per column see --field-mapping.
-* `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Repeatable; combine with --field-mappings (flags override YAML).
+* `--usage-info TEXT`: URI pointing to a usage or consent policy. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term).
+* `--field-mappings FILE`: YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\n  <col>:\n    equivalent_property: <URI>\n    data_types: [<URI>, ...]'. Note: column names match across ALL RecordSets, so 'id' applies to every 'id' column in the dataset.
+* `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Matches by bare column name across all RecordSets; a warning prints if a name resolves to multiple fields. Repeatable; combine with --field-mappings (flags override YAML).
 * `--count-csv-rows`: Count exact row numbers for CSV files (slow for large datasets)
 * `--rai-data-collection TEXT`: How and where the data was gathered.
 * `--rai-data-collection-type TEXT`: Collection type, e.g. 'observational'. Can be used multiple times.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,7 +23,21 @@ $ croissant-baker [OPTIONS] COMMAND [ARGS]...
 * `--citation TEXT`: Citation text (preferably BibTeX format)
 * `--dataset-version TEXT`: Dataset version (e.g., 1.0.0)
 * `--date-published TEXT`: Publication date (e.g., 2023-12-15 or 2023-12-15T10:30:00)
+* `--date-created TEXT`: Creation date (e.g., 2023-12-15 or 2023-12-15T10:30:00).
+* `--date-modified TEXT`: Last-modified date (e.g., 2023-12-15 or 2023-12-15T10:30:00).
 * `--creator TEXT`: Creator information. Format: 'Name[,Email[,URL]]'. Use multiple times for multiple creators. Examples: --creator 'John Doe' --creator 'Jane Smith,jane@example.com,https://jane.com'
+* `--publisher TEXT`: Publishing organization name (e.g., 'PhysioNet').
+* `--keywords TEXT`: Topical keywords for dataset discovery. Repeat (--keywords a --keywords b) or comma-delimit (--keywords 'a,b').
+* `--in-language TEXT`: BCP 47 language code (e.g., 'en'). Repeat or comma-delimit for multilingual datasets.
+* `--same-as TEXT`: URL of an equivalent record (e.g. DOI, mirror landing page). Repeat or comma-delimit.
+* `--sd-license TEXT`: License of the metadata description itself (e.g., 'CC0-1.0'), distinct from the data license.
+* `--sd-version TEXT`: Version of the metadata description (e.g., '1.0.0'), distinct from --dataset-version.
+* `--alternate-name TEXT`: Short alias for the dataset (e.g., 'MIMIC-IV').
+* `--is-live-dataset`: Mark the dataset as a live, evolving stream (e.g., a continuously-appended log).
+* `--temporal-coverage TEXT`: Time period the data covers. ISO 8601 recommended: '2008/2019' (interval) or '2023-01-15' (point).
+* `--usage-info TEXT`: URL of a usage / consent policy. Examples: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term), or any ODRL Offer URL.
+* `--field-mappings FILE`: YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\n  <col>:\n    equivalent_property: <URI>\n    data_types: [<URI>, ...]'. Use for multi-property overrides; for one URI per column see --field-mapping.
+* `--field-mapping TEXT`: Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Repeatable; combine with --field-mappings (flags override YAML).
 * `--count-csv-rows`: Count exact row numbers for CSV files (slow for large datasets)
 * `--rai-data-collection TEXT`: How and where the data was gathered.
 * `--rai-data-collection-type TEXT`: Collection type, e.g. 'observational'. Can be used multiple times.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,13 @@ authors = [
 # Note: pandas is not a direct dependency — available transitively via wfdb.
 dependencies = [
     "typer>=0.9.0",
-    "mlcroissant>=1.0.20",
+    # Upper-bound mlcroissant: croissant-baker emits Croissant 1.1 JSON-LD and
+    # is coupled to mlcroissant's 1.1.x behaviour (validator rules, @context
+    # generation, post-hoc field mappings). A 1.2.x release likely tracks a new
+    # spec and warrants a deliberate review of our outputs and conformance
+    # claim. Patches and minors flow automatically.
+    # Latest 1.1.x at pin time: 1.1.0 (released 2026-04-16).
+    "mlcroissant>=1.1.0,<1.2.0",
     "rich>=15.0.0",
     "wfdb>=4.3.1",
     "pyarrow>=23.0.1",

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -17,7 +17,11 @@ from rich.progress import (
     TextColumn,
 )
 
-from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
+from croissant_baker.metadata_generator import (
+    MetadataGenerator,
+    RAI_CONFORMS_TO,
+    serialize_datetime,
+)
 from croissant_baker.files import discover_files
 from croissant_baker.handlers.registry import find_handler
 import mlcroissant as mlc
@@ -115,8 +119,6 @@ _SPEC_REQUIRED_FLAGS = {
     "date_published": "--date-published",
 }
 
-_RAI_CONFORMS_TO = "http://mlcommons.org/croissant/RAI/1.0"
-
 
 def _echo_file_counts(file_count: int, file_set_count: int) -> None:
     """Print Files and File sets banner lines (File sets only when present)."""
@@ -147,12 +149,106 @@ def _normalize_optional_text(value: Optional[str]) -> Optional[str]:
     return value or None
 
 
+def _split_csv_list(values: Optional[List[str]]) -> Optional[List[str]]:
+    """Accept both `--flag a --flag b` and `--flag "a,b"` (and mixed).
+
+    Returns None when the user provided nothing, so optional fields stay
+    absent in the output rather than emitting an empty list. Per
+    schema.org, list properties may be repeated or comma-delimited.
+    """
+    if not values:
+        return None
+    out = [item.strip() for v in values for item in v.split(",")]
+    out = [item for item in out if item]
+    return out or None
+
+
 def _normalize_optional_text_list(values: Optional[List[str]]) -> Optional[List[str]]:
     """Strip repeated text options and drop empty items."""
     if not values:
         return None
     normalized = [value.strip() for value in values if value and value.strip()]
     return normalized or None
+
+
+_FIELD_MAPPING_KEYS = {"equivalent_property", "data_types"}
+
+
+def _load_field_mappings(path: Optional[Path]) -> Optional[dict]:
+    """Load a YAML sidecar mapping column names to vocab URI overrides.
+
+    YAML keys are snake_case (the dominant convention in Python YAML configs).
+    The snake → camel translation to JSON-LD output keys
+    (``equivalentProperty``, ``dataType``) happens at emit time in
+    ``_apply_field_mappings``.
+
+    Expected shape:
+        fields:
+          age:
+            equivalent_property: "wdt:P3629"   # Wikidata: age in years
+            data_types: ["wd:Q11464"]
+          patient_id:
+            equivalent_property: "snomed:399097000"
+    """
+    if path is None:
+        return None
+    import yaml
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(f"{path} must contain a YAML mapping at the top level")
+    fields = raw.get("fields")
+    if fields is None:
+        raise typer.BadParameter(f"{path}: missing top-level 'fields:' key")
+    if not isinstance(fields, dict):
+        raise typer.BadParameter(f"{path}: 'fields' must be a mapping of column names")
+    allowed = sorted(_FIELD_MAPPING_KEYS)
+    for col, override in fields.items():
+        if not isinstance(override, dict):
+            raise typer.BadParameter(
+                f"{path}: column '{col}' must map to an object, got {type(override).__name__}"
+            )
+        unknown = set(override) - _FIELD_MAPPING_KEYS
+        if unknown:
+            raise typer.BadParameter(
+                f"{path}: column '{col}' has unknown keys {sorted(unknown)}. Allowed: {allowed}"
+            )
+    return fields
+
+
+def _merge_field_mapping_flags(
+    yaml_mappings: Optional[dict], cli_mappings: Optional[List[str]]
+) -> Optional[dict]:
+    """Merge YAML field mappings with repeatable ``--field-mapping COL=URI`` flags.
+
+    CLI flags carry the simple ``equivalent_property`` case; users wanting
+    multiple keys (``data_types`` lists) reach for the YAML form. Flags win
+    on conflict — last specified beats earlier specified, and CLI beats YAML.
+    """
+    merged = dict(yaml_mappings or {})
+    for raw in cli_mappings or []:
+        if "=" not in raw:
+            raise typer.BadParameter(
+                f"--field-mapping must be 'COLUMN=URI', got {raw!r}"
+            )
+        col, uri = raw.split("=", 1)
+        col, uri = col.strip(), uri.strip()
+        if not col or not uri:
+            raise typer.BadParameter(
+                f"--field-mapping must be 'COLUMN=URI', got {raw!r}"
+            )
+        merged.setdefault(col, {})["equivalent_property"] = uri
+    return merged or None
+
+
+def _validate_url(option_name: str, value: Optional[str]) -> None:
+    """Reject obviously non-URL strings on a flag advertised as taking a URL."""
+    if value is None:
+        return
+    if not value.startswith(("http://", "https://")):
+        raise typer.BadParameter(
+            f"{option_name} must be an http(s):// URL, got {value!r}"
+        )
 
 
 def _validate_iso_datetimes(option_name: str, values: Optional[List[str]]) -> None:
@@ -255,17 +351,17 @@ def _ensure_rai_conforms_to(metadata_dict: dict, force: bool = False) -> None:
 
     conforms_to = metadata_dict.get("conformsTo")
     if conforms_to is None:
-        metadata_dict["conformsTo"] = [_RAI_CONFORMS_TO]
+        metadata_dict["conformsTo"] = [RAI_CONFORMS_TO]
         return
     if isinstance(conforms_to, str):
         metadata_dict["conformsTo"] = (
             [conforms_to]
-            if conforms_to == _RAI_CONFORMS_TO
-            else [conforms_to, _RAI_CONFORMS_TO]
+            if conforms_to == RAI_CONFORMS_TO
+            else [conforms_to, RAI_CONFORMS_TO]
         )
         return
-    if isinstance(conforms_to, list) and _RAI_CONFORMS_TO not in conforms_to:
-        conforms_to.append(_RAI_CONFORMS_TO)
+    if isinstance(conforms_to, list) and RAI_CONFORMS_TO not in conforms_to:
+        conforms_to.append(RAI_CONFORMS_TO)
 
 
 @app.callback(invoke_without_command=True)
@@ -303,6 +399,16 @@ def main(
         "--date-published",
         help="Publication date (e.g., 2023-12-15 or 2023-12-15T10:30:00)",
     ),
+    date_created: Optional[str] = typer.Option(
+        None,
+        "--date-created",
+        help="Creation date (e.g., 2023-12-15 or 2023-12-15T10:30:00).",
+    ),
+    date_modified: Optional[str] = typer.Option(
+        None,
+        "--date-modified",
+        help="Last-modified date (e.g., 2023-12-15 or 2023-12-15T10:30:00).",
+    ),
     # Creator information following mlcroissant specification
     # Spec: creator is REQUIRED with cardinality MANY (supports multiple creators)
     # ExpectedType: Organization OR Person with flexible properties (name, email, url)
@@ -311,6 +417,68 @@ def main(
         None,
         "--creator",
         help="Creator information. Format: 'Name[,Email[,URL]]'. Use multiple times for multiple creators. Examples: --creator 'John Doe' --creator 'Jane Smith,jane@example.com,https://jane.com'",
+    ),
+    publisher: Optional[str] = typer.Option(
+        None,
+        "--publisher",
+        help="Publishing organization name (e.g., 'PhysioNet').",
+    ),
+    keywords: Optional[List[str]] = typer.Option(
+        None,
+        "--keywords",
+        help="Topical keywords for dataset discovery. Repeat (--keywords a --keywords b) or comma-delimit (--keywords 'a,b').",
+    ),
+    in_language: Optional[List[str]] = typer.Option(
+        None,
+        "--in-language",
+        help="BCP 47 language code (e.g., 'en'). Repeat or comma-delimit for multilingual datasets.",
+    ),
+    same_as: Optional[List[str]] = typer.Option(
+        None,
+        "--same-as",
+        help="URL of an equivalent record (e.g. DOI, mirror landing page). Repeat or comma-delimit.",
+    ),
+    sd_license: Optional[str] = typer.Option(
+        None,
+        "--sd-license",
+        help="License of the metadata description itself (e.g., 'CC0-1.0'), distinct from the data license.",
+    ),
+    sd_version: Optional[str] = typer.Option(
+        None,
+        "--sd-version",
+        help="Version of the metadata description (e.g., '1.0.0'), distinct from --dataset-version.",
+    ),
+    alternate_name: Optional[str] = typer.Option(
+        None,
+        "--alternate-name",
+        help="Short alias for the dataset (e.g., 'MIMIC-IV').",
+    ),
+    is_live_dataset: bool = typer.Option(
+        False,
+        "--is-live-dataset",
+        help="Mark the dataset as a live, evolving stream (e.g., a continuously-appended log).",
+    ),
+    temporal_coverage: Optional[str] = typer.Option(
+        None,
+        "--temporal-coverage",
+        help="Time period the data covers. ISO 8601 recommended: '2008/2019' (interval) or '2023-01-15' (point).",
+    ),
+    usage_info: Optional[str] = typer.Option(
+        None,
+        "--usage-info",
+        help="URL of a usage / consent policy. Examples: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term), or any ODRL Offer URL.",
+    ),
+    field_mappings: Optional[Path] = typer.Option(
+        None,
+        "--field-mappings",
+        help="YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\\n  <col>:\\n    equivalent_property: <URI>\\n    data_types: [<URI>, ...]'. Use for multi-property overrides; for one URI per column see --field-mapping.",
+        exists=True,
+        dir_okay=False,
+    ),
+    field_mapping: Optional[List[str]] = typer.Option(
+        None,
+        "--field-mapping",
+        help="Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Repeatable; combine with --field-mappings (flags override YAML).",
     ),
     count_csv_rows: bool = typer.Option(
         False,
@@ -580,6 +748,11 @@ def main(
                     err=True,
                 )
 
+        _validate_url("--usage-info", usage_info)
+        merged_field_mappings = _merge_field_mapping_flags(
+            _load_field_mappings(field_mappings), field_mapping
+        )
+
         generator = MetadataGenerator(
             dataset_path=input,
             name=name,
@@ -589,7 +762,20 @@ def main(
             citation=citation,
             version=dataset_version,
             date_published=date_published,
+            date_created=date_created,
+            date_modified=date_modified,
             creators=parsed_creators if parsed_creators else None,
+            publisher=publisher,
+            keywords=_split_csv_list(keywords),
+            in_language=_split_csv_list(in_language),
+            same_as=_split_csv_list(same_as),
+            sd_license=sd_license,
+            sd_version=sd_version,
+            alternate_name=alternate_name,
+            is_live_dataset=is_live_dataset or None,
+            temporal_coverage=temporal_coverage,
+            usage_info=usage_info,
+            field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
             includes=include,
             excludes=exclude,

--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -3,6 +3,7 @@
 import csv
 from datetime import datetime
 import json
+import re
 import tempfile
 import importlib.metadata
 from pathlib import Path
@@ -241,13 +242,22 @@ def _merge_field_mapping_flags(
     return merged or None
 
 
-def _validate_url(option_name: str, value: Optional[str]) -> None:
-    """Reject obviously non-URL strings on a flag advertised as taking a URL."""
+_URI_SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*:")
+
+
+def _validate_uri(option_name: str, value: Optional[str]) -> None:
+    """Reject strings that don't start with an RFC 3986 URI scheme.
+
+    Catches free text like 'see license file' but accepts http(s)://, urn:,
+    did:, mailto:, and any other valid scheme. schema.org/usageInfo accepts
+    URLs broadly, not just web URLs.
+    """
     if value is None:
         return
-    if not value.startswith(("http://", "https://")):
+    if not _URI_SCHEME.match(value):
         raise typer.BadParameter(
-            f"{option_name} must be an http(s):// URL, got {value!r}"
+            f"{option_name} must be a URI starting with a scheme "
+            f"(e.g. https://, urn:, did:, mailto:), got {value!r}"
         )
 
 
@@ -466,19 +476,19 @@ def main(
     usage_info: Optional[str] = typer.Option(
         None,
         "--usage-info",
-        help="URL of a usage / consent policy. Examples: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term), or any ODRL Offer URL.",
+        help="URI pointing to a usage or consent policy. Any RFC 3986 scheme (http(s), urn, did, mailto). Example: 'http://purl.obolibrary.org/obo/DUO_0000042' (DUO term).",
     ),
     field_mappings: Optional[Path] = typer.Option(
         None,
         "--field-mappings",
-        help="YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\\n  <col>:\\n    equivalent_property: <URI>\\n    data_types: [<URI>, ...]'. Use for multi-property overrides; for one URI per column see --field-mapping.",
+        help="YAML file mapping columns to external vocabularies (Wikidata, SNOMED, LOINC). Schema: 'fields:\\n  <col>:\\n    equivalent_property: <URI>\\n    data_types: [<URI>, ...]'. Note: column names match across ALL RecordSets, so 'id' applies to every 'id' column in the dataset.",
         exists=True,
         dir_okay=False,
     ),
     field_mapping: Optional[List[str]] = typer.Option(
         None,
         "--field-mapping",
-        help="Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Repeatable; combine with --field-mappings (flags override YAML).",
+        help="Link one column to an external vocabulary URI. Format: 'COLUMN=URI'. Example: --field-mapping 'age=http://www.wikidata.org/entity/Q11464'. Matches by bare column name across all RecordSets; a warning prints if a name resolves to multiple fields. Repeatable; combine with --field-mappings (flags override YAML).",
     ),
     count_csv_rows: bool = typer.Option(
         False,
@@ -748,7 +758,7 @@ def main(
                     err=True,
                 )
 
-        _validate_url("--usage-info", usage_info)
+        _validate_uri("--usage-info", usage_info)
         merged_field_mappings = _merge_field_mapping_flags(
             _load_field_mappings(field_mappings), field_mapping
         )

--- a/src/croissant_baker/handlers/utils.py
+++ b/src/croissant_baker/handlers/utils.py
@@ -18,6 +18,31 @@ logger = logging.getLogger(__name__)
 # 500 covers typical field diversity while keeping memory bounded.
 SCHEMA_SAMPLE = 500
 
+# Croissant 1.1 array_shape: comma-separated dim sizes; -1 means "unknown".
+# Examples: "-1" (1D unknown), "28,28" (fixed 2D), "-1,-1,3" (variable HxW, 3 channels).
+# The mlcroissant 1.1.0 validator only accepts the bare comma-separated form
+# (no parens, no trailing comma) — see normalize_array_shape() for the full
+# rationale.
+ARRAY_SHAPE_UNKNOWN_1D = "-1"
+
+
+def normalize_array_shape(shape: str) -> str:
+    """Coerce common shape spellings to the mlcroissant-accepted form.
+
+    The validator parses array_shape by splitting on commas and casting each
+    piece to int. So "(-1, -1)" or "(-1,)" — natural forms when stringifying
+    a numpy.shape tuple — are rejected. This helper accepts both, returning
+    a string the validator will accept.
+
+    Examples:
+        normalize_array_shape("-1")          -> "-1"
+        normalize_array_shape("(-1,)")       -> "-1"
+        normalize_array_shape("(-1, -1)")    -> "-1,-1"
+        normalize_array_shape("28, 28")      -> "28,28"
+    """
+    inner = shape.strip().strip("()").rstrip(",").strip()
+    return ",".join(part.strip() for part in inner.split(",") if part.strip())
+
 
 def open_text_file(file_path: Path):
     """Return a text file handle, transparently decompressing gzip files."""
@@ -108,8 +133,8 @@ def map_arrow_type(arrow_type: pa.DataType) -> str:
         if patypes.is_null(arrow_type):
             return "sc:Text"
 
-        # List/large-list: caller sets is_array=True; return the inner element type.
-        if patypes.is_list(arrow_type) or patypes.is_large_list(arrow_type):
+        # List / large-list / fixed-size-list: caller sets is_array=True; return the inner element type.
+        if is_arrow_list(arrow_type):
             return map_arrow_type(arrow_type.value_type)
 
     except Exception:
@@ -121,8 +146,24 @@ def map_arrow_type(arrow_type: pa.DataType) -> str:
 
 
 def is_arrow_list(arrow_type: pa.DataType) -> bool:
-    """Return True if the Arrow type is a list or large-list."""
-    return patypes.is_list(arrow_type) or patypes.is_large_list(arrow_type)
+    """Return True if the Arrow type is any list (variable, large, or fixed-size)."""
+    return (
+        patypes.is_list(arrow_type)
+        or patypes.is_large_list(arrow_type)
+        or patypes.is_fixed_size_list(arrow_type)
+    )
+
+
+def arrow_array_shape(arrow_type: pa.DataType) -> str:
+    """Return the Croissant array_shape string for an Arrow list-like type.
+
+    Fixed-size lists report their exact size (e.g. embedding columns of
+    dimension 768). Variable-length lists fall back to the unknown-length
+    sentinel since list lengths can differ row-to-row.
+    """
+    if patypes.is_fixed_size_list(arrow_type):
+        return str(arrow_type.list_size)
+    return ARRAY_SHAPE_UNKNOWN_1D
 
 
 def infer_column_types_from_arrow_schema(schema: pa.Schema) -> Dict[str, str]:
@@ -210,6 +251,7 @@ def _build_fields(
             **source_ref,
         )
 
+        shape = arrow_array_shape(arrow_type) if is_array else None
         if patypes.is_struct(inner_type):
             sub_fields = _build_fields(inner_type, field_id, source_ref, col_path)
             field = mlc.Field(
@@ -217,6 +259,7 @@ def _build_fields(
                 name=col_name,
                 description=f"Column '{col_name}'",
                 is_array=True if is_array else None,
+                array_shape=shape,
                 source=source,
                 sub_fields=sub_fields,
             )
@@ -228,6 +271,7 @@ def _build_fields(
                 description=f"Column '{col_name}'",
                 data_types=[col_type],
                 is_array=True if is_array else None,
+                array_shape=shape,
                 source=source,
             )
         fields.append(field)
@@ -397,6 +441,7 @@ def build_fields_from_json_schema(
                     name=col_name,
                     description=f"{description_prefix} '{col_name}'",
                     is_array=True if is_array else None,
+                    array_shape=ARRAY_SHAPE_UNKNOWN_1D if is_array else None,
                     source=source,
                     sub_fields=sub_fields or None,
                 )
@@ -409,6 +454,7 @@ def build_fields_from_json_schema(
                     description=f"{description_prefix} '{col_name}'",
                     data_types=[type_info["type"]],
                     is_array=True,
+                    array_shape=ARRAY_SHAPE_UNKNOWN_1D,
                     source=source,
                 )
             )

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -43,17 +43,26 @@ def _apply_field_mappings(
     no Python parameter for ``equivalent_property``, so we patch the
     serialised JSON-LD directly.
 
+    Matching is by bare field name across the entire metadata tree. A
+    mapping for ``id`` will apply to every field named ``id`` in every
+    RecordSet. When a name resolves to more than one field, a warning is
+    printed so the user can confirm the override is intended for all of
+    them.
+
     User-supplied ``data_types`` are APPENDED to the inferred Croissant type
-    rather than replacing it — the mlcroissant validator requires at least
+    rather than replacing it. The mlcroissant validator requires at least
     one Croissant dataType per field, and the 1.1 spec explicitly supports
     multiple types coexisting (e.g. ``["sc:URL", "wd:Q515"]``).
     """
+    match_counts: Dict[str, int] = defaultdict(int)
 
     def visit(node: object) -> None:
         if isinstance(node, dict):
             if node.get("@type") == "cr:Field":
-                override = mappings.get(node.get("name"))
+                name = node.get("name")
+                override = mappings.get(name)
                 if override:
+                    match_counts[name] += 1
                     if override.get("equivalent_property"):
                         node["equivalentProperty"] = override["equivalent_property"]
                     extra_types = override.get("data_types") or []
@@ -76,6 +85,14 @@ def _apply_field_mappings(
                 visit(item)
 
     visit(metadata_dict)
+
+    for name, count in match_counts.items():
+        if count > 1:
+            print(
+                f"Warning: field mapping '{name}' applied to {count} fields. "
+                f"If '{name}' means different things in different RecordSets, "
+                "rename the columns or split the bake."
+            )
 
 
 class MetadataGenerator:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -15,12 +15,67 @@ from croissant_baker.handlers.registry import find_handler, register_all_handler
 # Register all handlers
 register_all_handlers()
 
+# conformsTo URIs declared on the Dataset. mlcroissant defaults conforms_to to
+# 1.0 even on 1.1.x — passing CROISSANT_CONFORMS_TO explicitly is the single
+# source of truth for our declared spec version. RAI_CONFORMS_TO is appended
+# to the conformsTo array by _ensure_rai_conforms_to() when RAI fields are
+# present (the RAI extension vocab itself did NOT version-bump in Croissant 1.1).
+# https://docs.mlcommons.org/croissant/docs/croissant-spec-1.1.html
+CROISSANT_CONFORMS_TO = "http://mlcommons.org/croissant/1.1"
+RAI_CONFORMS_TO = "http://mlcommons.org/croissant/RAI/1.0"
+
 
 def serialize_datetime(obj):
     """Convert datetime objects to ISO format strings for JSON serialization."""
     if isinstance(obj, datetime):
         return obj.isoformat()
     raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+def _apply_field_mappings(
+    metadata_dict: dict, mappings: Dict[str, Dict[str, object]]
+) -> None:
+    """Inject equivalentProperty / dataType overrides onto matching Fields.
+
+    Walks the assembled metadata dict and applies user-supplied per-column
+    overrides keyed by field name. Used to link columns to external
+    vocabularies (e.g. Wikidata, SNOMED, LOINC). mlcroissant 1.1.0 exposes
+    no Python parameter for ``equivalent_property``, so we patch the
+    serialised JSON-LD directly.
+
+    User-supplied ``data_types`` are APPENDED to the inferred Croissant type
+    rather than replacing it — the mlcroissant validator requires at least
+    one Croissant dataType per field, and the 1.1 spec explicitly supports
+    multiple types coexisting (e.g. ``["sc:URL", "wd:Q515"]``).
+    """
+
+    def visit(node: object) -> None:
+        if isinstance(node, dict):
+            if node.get("@type") == "cr:Field":
+                override = mappings.get(node.get("name"))
+                if override:
+                    if override.get("equivalent_property"):
+                        node["equivalentProperty"] = override["equivalent_property"]
+                    extra_types = override.get("data_types") or []
+                    if extra_types:
+                        existing = node.get("dataType")
+                        if existing is None:
+                            existing_list = []
+                        elif isinstance(existing, list):
+                            existing_list = list(existing)
+                        else:
+                            existing_list = [existing]
+                        for t in extra_types:
+                            if t not in existing_list:
+                                existing_list.append(t)
+                        node["dataType"] = existing_list
+            for value in node.values():
+                visit(value)
+        elif isinstance(node, list):
+            for item in node:
+                visit(item)
+
+    visit(metadata_dict)
 
 
 class MetadataGenerator:
@@ -41,7 +96,20 @@ class MetadataGenerator:
         citation: Optional[str] = None,
         version: Optional[str] = None,
         date_published: Optional[str] = None,
+        date_created: Optional[str] = None,
+        date_modified: Optional[str] = None,
         creators: Optional[List[Dict[str, str]]] = None,
+        publisher: Optional[str] = None,
+        keywords: Optional[List[str]] = None,
+        in_language: Optional[List[str]] = None,
+        same_as: Optional[List[str]] = None,
+        sd_license: Optional[str] = None,
+        sd_version: Optional[str] = None,
+        alternate_name: Optional[str] = None,
+        is_live_dataset: Optional[bool] = None,
+        temporal_coverage: Optional[str] = None,
+        usage_info: Optional[str] = None,
+        field_mappings: Optional[Dict[str, Dict[str, object]]] = None,
         count_csv_rows: bool = False,
         includes: Optional[List[str]] = None,
         excludes: Optional[List[str]] = None,
@@ -60,13 +128,34 @@ class MetadataGenerator:
             version: Dataset version string.
             date_published: Publication date in ISO format ("2023-12-15" or
                 "2023-12-15T10:30:00").
+            date_created: Creation date in ISO format.
+            date_modified: Last-modified date in ISO format.
             creators: List of dicts with "name", "email", and/or "url" keys.
+            publisher: Name of the publishing organization (schema.org/Organization).
+            keywords: Topical keywords for dataset discovery (schema.org/keywords).
+            in_language: BCP 47 language code(s) (e.g. "en"). Multiple supported.
+            same_as: URLs of equivalent dataset records (e.g. DOI, mirror landing
+                pages). Multiple values supported per schema.org/sameAs.
+            sd_license: License of the metadata description itself, distinct from
+                the data license (schema.org/sdLicense).
+            sd_version: Version of the metadata description, distinct from
+                ``version``. Defaults to None — only emitted when set.
+            alternate_name: Short alias for the dataset (schema.org/alternateName).
+            is_live_dataset: Mark dataset as a live, evolving stream.
+            temporal_coverage: Time period the data covers — schema.org accepts
+                free text or ISO 8601 (e.g., "2008/2019", "2023-01-15").
+            usage_info: URL of a usage/consent policy (e.g., a DUO term URL,
+                ODRL Offer URL).
+            field_mappings: Per-column overrides keyed by field name. Each value
+                is a dict with optional ``equivalent_property`` (vocab URI) and
+                ``data_types`` (list of vocab URIs). Used to link columns to
+                external vocabularies like Wikidata/SNOMED/LOINC.
             count_csv_rows: If True, scan each CSV fully for exact row counts.
                 Defaults to False for performance.
             includes: Glob patterns to include. Applied before excludes.
             excludes: Glob patterns to exclude. Applied after includes.
-            rai_fields: Native mlcroissant RAI metadata fields to pass through
-                to mlc.Metadata unchanged.
+            rai_fields: Native mlcroissant RAI metadata fields, passed through
+                to ``mlc.Metadata`` unchanged.
 
         Raises:
             ValueError: If dataset_path is not a directory.
@@ -82,7 +171,20 @@ class MetadataGenerator:
         self.citation = citation
         self.version = version
         self.date_published = date_published
+        self.date_created = date_created
+        self.date_modified = date_modified
         self.creators = creators
+        self.publisher = publisher
+        self.keywords = keywords
+        self.in_language = in_language
+        self.same_as = same_as
+        self.sd_license = sd_license
+        self.sd_version = sd_version
+        self.alternate_name = alternate_name
+        self.is_live_dataset = is_live_dataset
+        self.temporal_coverage = temporal_coverage
+        self.usage_info = usage_info
+        self.field_mappings = field_mappings or {}
         self.includes = includes
         self.excludes = excludes
         self.rai_fields = rai_fields or {}
@@ -134,8 +236,16 @@ class MetadataGenerator:
             license=self._resolve_license(),
             creators=self._build_creators(),
             date_published=self._resolve_date(),
+            date_created=self._parse_iso(self.date_created),
+            date_modified=self._parse_iso(self.date_modified),
             version=self.version or "1.0.0",
             cite_as=self._build_citation(),
+            conforms_to=CROISSANT_CONFORMS_TO,
+            keywords=self.keywords,
+            in_language=self.in_language,
+            same_as=self.same_as,
+            publisher=self._build_publisher(),
+            sd_licence=self.sd_license,
             **self.rai_fields,
         )
 
@@ -206,7 +316,27 @@ class MetadataGenerator:
         metadata.distribution = distributions
         metadata.record_sets = record_sets
 
-        return metadata.to_json()
+        result = metadata.to_json()
+        # Spec fields without a native mlcroissant parameter — inject
+        # post-serialisation. Keep keys absent (not null) when the caller
+        # didn't supply a value, so optional fields don't pollute outputs
+        # that don't need them. ``sd_version`` IS a native mlc 1.1.0 param,
+        # but mlc emits it as ``cr:sdVersion`` (no @context alias); the
+        # canonical 1.1 examples use the unprefixed form, so we write the
+        # canonical key directly.
+        if self.sd_version is not None:
+            result["sdVersion"] = self.sd_version
+        if self.alternate_name is not None:
+            result["alternateName"] = self.alternate_name
+        if self.is_live_dataset is not None:
+            result["isLiveDataset"] = self.is_live_dataset
+        if self.temporal_coverage is not None:
+            result["temporalCoverage"] = self.temporal_coverage
+        if self.usage_info is not None:
+            result["usageInfo"] = self.usage_info
+        if self.field_mappings:
+            _apply_field_mappings(result, self.field_mappings)
+        return result
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -246,6 +376,23 @@ class MetadataGenerator:
             mlc.Person(**{k: v for k, v in c.items() if k in ("name", "email", "url")})
             for c in self.creators
         ]
+
+    def _build_publisher(self):
+        if not self.publisher:
+            return None
+        return [mlc.Organization(name=self.publisher)]
+
+    @staticmethod
+    def _parse_iso(value: Optional[str]):
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid ISO date: '{value}'. "
+                f"Expected '2023-12-15' or '2023-12-15T10:30:00'. Error: {e}"
+            )
 
     def _build_citation(self) -> str:
         if self.citation:

--- a/tests/data/output/eicu_demo_croissant.jsonld
+++ b/tests/data/output/eicu_demo_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,7 +49,7 @@
   "@type": "sc:Dataset",
   "name": "eICU Collaborative Research Database Demo",
   "description": "Demo version of the eICU Collaborative Research Database",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Johnson, A., Pollard, T., Badawi, O., & Raffa, J. (2021). eICU Collaborative Research Database Demo (version 2.0.1). PhysioNet. https://doi.org/10.13026/4mxk-na84",
   "creator": [
     {
@@ -68,7 +69,7 @@
       "name": "Jesse Raffa"
     }
   ],
-  "datePublished": "2021-05-06T00:00:00",
+  "datePublished": "2021-05-06",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://physionet.org/content/eicu-crd-demo/2.0.1/",
   "version": "2.0.1",

--- a/tests/data/output/gharchive_demo_croissant.jsonld
+++ b/tests/data/output/gharchive_demo_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "GH Archive (demo slice)",
   "description": "200-event slice of GitHub Archive hourly JSONL export (2023-01-01 00:00 UTC)",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). GH Archive (demo slice) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",
     "name": "GitHub Archive"
   },
-  "datePublished": "2023-01-01T00:00:00",
+  "datePublished": "2023-01-01",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://www.gharchive.org/",
   "version": "2023-01-01",
@@ -970,6 +971,7 @@
               "@id": "2023-01-01-0.jsonl/payload/commits",
               "name": "commits",
               "description": "Field 'commits'",
+              "cr:arrayShape": "-1",
               "cr:isArray": true,
               "source": {
                 "fileObject": {
@@ -2865,6 +2867,7 @@
                   "@id": "2023-01-01-0.jsonl/payload/issue/assignees",
                   "name": "assignees",
                   "description": "Field 'assignees'",
+                  "cr:arrayShape": "-1",
                   "cr:isArray": true,
                   "source": {
                     "fileObject": {
@@ -3302,6 +3305,7 @@
                   "@id": "2023-01-01-0.jsonl/payload/issue/labels",
                   "name": "labels",
                   "description": "Field 'labels'",
+                  "cr:arrayShape": "-1",
                   "cr:isArray": true,
                   "source": {
                     "fileObject": {
@@ -5911,6 +5915,7 @@
                           "@id": "2023-01-01-0.jsonl/payload/pull_request/base/repo/topics",
                           "name": "topics",
                           "description": "Field 'topics'",
+                          "cr:arrayShape": "-1",
                           "cr:isArray": true,
                           "dataType": "sc:Text",
                           "source": {
@@ -7957,6 +7962,7 @@
                           "@id": "2023-01-01-0.jsonl/payload/pull_request/head/repo/topics",
                           "name": "topics",
                           "description": "Field 'topics'",
+                          "cr:arrayShape": "-1",
                           "cr:isArray": true,
                           "dataType": "sc:Text",
                           "source": {
@@ -8428,6 +8434,7 @@
                   "@id": "2023-01-01-0.jsonl/payload/pull_request/labels",
                   "name": "labels",
                   "description": "Field 'labels'",
+                  "cr:arrayShape": "-1",
                   "cr:isArray": true,
                   "source": {
                     "fileObject": {

--- a/tests/data/output/glaucoma_fundus_croissant.jsonld
+++ b/tests/data/output/glaucoma_fundus_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "Hillel Yaffe Glaucoma Dataset (subset)",
   "description": "Subset of fundus images for glaucoma screening with GON labels",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). Hillel Yaffe Glaucoma Dataset (subset) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",
     "name": "Hillel Yaffe Medical Center"
   },
-  "datePublished": "2024-11-14T00:00:00",
+  "datePublished": "2024-11-14",
   "license": "https://physionet.org/content/hyg-dataset/1.0.0/LICENSE.txt",
   "url": "https://physionet.org/content/hyg-dataset/1.0.0/",
   "version": "1.0.0",

--- a/tests/data/output/meds_full_croissant.jsonld
+++ b/tests/data/output/meds_full_croissant.jsonld
@@ -48,7 +48,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV in MEDS format (full)",
   "description": "MIMIC-IV converted to Medical Event Data Standard (MEDS) format",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). MIMIC-IV in MEDS format (full) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",

--- a/tests/data/output/mimiciv_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,7 +49,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV Demo Dataset",
   "description": "Demo subset of MIMIC-IV, a freely accessible electronic health record dataset from Beth Israel Deaconess Medical Center (2008-2019)",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Johnson, A., Bulgarelli, L., Pollard, T., Horng, S., Celi, L. A., & Mark, R. (2023). MIMIC-IV (version 2.2). PhysioNet. https://doi.org/10.13026/6mm1-ek67",
   "creator": [
     {
@@ -85,7 +86,7 @@
       "url": "https://lcp.mit.edu/"
     }
   ],
-  "datePublished": "2023-01-06T00:00:00",
+  "datePublished": "2023-01-06",
   "license": "PhysioNet Restricted Health Data License 1.5.0",
   "url": "https://physionet.org/content/mimic-iv-demo/",
   "version": "2.2",

--- a/tests/data/output/mimiciv_demo_croissant_rai.jsonld
+++ b/tests/data/output/mimiciv_demo_croissant_rai.jsonld
@@ -50,7 +50,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV Demo Dataset",
   "description": "Demo subset of MIMIC-IV, a freely accessible electronic health record dataset from Beth Israel Deaconess Medical Center (2008-2019)",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Johnson, A., Bulgarelli, L., Pollard, T., Horng, S., Celi, L. A., & Mark, R. (2023). MIMIC-IV (version 2.2). PhysioNet. https://doi.org/10.13026/6mm1-ek67",
   "creator": [
     {

--- a/tests/data/output/mimiciv_demo_meds_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_meds_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,7 +49,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV demo data in the Medical Event Data Standard (MEDS)",
   "description": "MEDS demo of MIMIC-IV represented as Parquet event streams",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). MIMIC-IV demo data in the Medical Event Data Standard (MEDS) Dataset. Generated with automated type inference.",
   "creator": [
     {
@@ -60,7 +61,7 @@
       "name": "Matthew McDermott"
     }
   ],
-  "datePublished": "2025-09-29T00:00:00",
+  "datePublished": "2025-09-29",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://physionet.org/content/mimic-iv-demo-meds/0.0.1/",
   "version": "0.0.1",

--- a/tests/data/output/mimiciv_demo_omop_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_omop_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,7 +49,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV demo data in the OMOP Common Data Model",
   "description": "A 100-patient demo of MIMIC-IV in the OMOP Common Data Model",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Kallfelz, M., et al. (2021). MIMIC-IV demo data in the OMOP Common Data Model (version 0.9). PhysioNet. https://doi.org/10.13026/p1f5-7x35",
   "creator": [
     {
@@ -64,7 +65,7 @@
       "name": "Tom Pollard"
     }
   ],
-  "datePublished": "2021-06-21T00:00:00",
+  "datePublished": "2021-06-21",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://physionet.org/content/mimic-iv-demo-omop/0.9/",
   "version": "0.9",

--- a/tests/data/output/mimiciv_fhir_demo_croissant.jsonld
+++ b/tests/data/output/mimiciv_fhir_demo_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,7 +49,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV Clinical Database Demo on FHIR",
   "description": "100-patient demo of MIMIC-IV represented as FHIR R4 NDJSON resources",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Johnson, A., Bulgarelli, L., et al. (2023). MIMIC-IV Clinical Database Demo on FHIR (version 2.1.0). PhysioNet. https://doi.org/10.13026/t74w-kd56",
   "creator": [
     {
@@ -63,7 +64,7 @@
       "url": "https://mit.edu/"
     }
   ],
-  "datePublished": "2023-10-23T00:00:00",
+  "datePublished": "2023-10-23",
   "license": "https://physionet.org/content/mimic-iv-fhir-demo/2.1.0/LICENSE.txt",
   "url": "https://physionet.org/content/mimic-iv-fhir-demo/2.1.0/",
   "version": "2.1.0",
@@ -412,6 +413,7 @@
           "@id": "MimicEncounterICU/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -459,6 +461,7 @@
           "@id": "MimicEncounterICU/location",
           "name": "location",
           "description": "Column 'location'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -564,6 +567,7 @@
             "@id": "MimicEncounterICU/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -700,6 +704,7 @@
           "@id": "MimicEncounterICU/type",
           "name": "type",
           "description": "Column 'type'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -714,6 +719,7 @@
             "@id": "MimicEncounterICU/type/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -873,6 +879,7 @@
                 "@id": "MimicEncounter/hospitalization/admitSource/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -934,6 +941,7 @@
                 "@id": "MimicEncounter/hospitalization/dischargeDisposition/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -999,6 +1007,7 @@
           "@id": "MimicEncounter/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -1090,6 +1099,7 @@
           "@id": "MimicEncounter/location",
           "name": "location",
           "description": "Column 'location'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -1195,6 +1205,7 @@
             "@id": "MimicEncounter/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -1271,6 +1282,7 @@
             "@id": "MimicEncounter/priority/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -1376,6 +1388,7 @@
             "@id": "MimicEncounter/serviceType/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -1468,6 +1481,7 @@
           "@id": "MimicEncounter/type",
           "name": "type",
           "description": "Column 'type'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -1482,6 +1496,7 @@
             "@id": "MimicEncounter/type/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -1641,6 +1656,7 @@
                 "@id": "MimicEncounterED/hospitalization/admitSource/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -1702,6 +1718,7 @@
                 "@id": "MimicEncounterED/hospitalization/dischargeDisposition/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -1767,6 +1784,7 @@
           "@id": "MimicEncounterED/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -1871,6 +1889,7 @@
             "@id": "MimicEncounterED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -2036,6 +2055,7 @@
           "@id": "MimicEncounterED/type",
           "name": "type",
           "description": "Column 'type'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -2050,6 +2070,7 @@
             "@id": "MimicEncounterED/type/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -2134,6 +2155,7 @@
             "@id": "MimicMedicationAdministrationICU/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -2314,6 +2336,7 @@
                 "@id": "MimicMedicationAdministrationICU/dosage/method/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -2529,6 +2552,7 @@
             "@id": "MimicMedicationAdministrationICU/medicationCodeableConcept/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -2605,6 +2629,7 @@
             "@id": "MimicMedicationAdministrationICU/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -2806,6 +2831,7 @@
                 "@id": "MimicMedicationAdministration/dosage/method/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -2914,6 +2940,7 @@
             "@id": "MimicMedicationAdministration/medicationCodeableConcept/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -2975,6 +3002,7 @@
             "@id": "MimicMedicationAdministration/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -3148,6 +3176,7 @@
           "@id": "MimicMedicationRequest/dosageInstruction",
           "name": "dosageInstruction",
           "description": "Column 'dosageInstruction'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -3163,6 +3192,7 @@
               "@id": "MimicMedicationRequest/dosageInstruction/doseAndRate",
               "name": "doseAndRate",
               "description": "Field 'doseAndRate'",
+              "cr:arrayShape": "-1",
               "cr:isArray": true,
               "source": {
                 "fileObject": {
@@ -3373,6 +3403,7 @@
                 "@id": "MimicMedicationRequest/dosageInstruction/route/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -3463,6 +3494,7 @@
                     "@id": "MimicMedicationRequest/dosageInstruction/timing/code/coding",
                     "name": "coding",
                     "description": "Field 'coding'",
+                    "cr:arrayShape": "-1",
                     "cr:isArray": true,
                     "source": {
                       "fileObject": {
@@ -3605,6 +3637,7 @@
           "@id": "MimicMedicationRequest/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -3680,6 +3713,7 @@
             "@id": "MimicMedicationRequest/medicationCodeableConcept/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -3770,6 +3804,7 @@
             "@id": "MimicMedicationRequest/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -3869,6 +3904,7 @@
           "@id": "MimicOrganization/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -3929,6 +3965,7 @@
             "@id": "MimicOrganization/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -3961,6 +3998,7 @@
           "@id": "MimicOrganization/type",
           "name": "type",
           "description": "Column 'type'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -3975,6 +4013,7 @@
             "@id": "MimicOrganization/type/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -4090,6 +4129,7 @@
           "@id": "MimicSpecimenLab/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -4150,6 +4190,7 @@
             "@id": "MimicSpecimenLab/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -4209,6 +4250,7 @@
             "@id": "MimicSpecimenLab/type/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -4309,6 +4351,7 @@
           "@id": "MimicSpecimen/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -4369,6 +4412,7 @@
             "@id": "MimicSpecimen/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -4428,6 +4472,7 @@
             "@id": "MimicSpecimen/type/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -4556,6 +4601,7 @@
             "@id": "MimicLocation/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -4601,6 +4647,7 @@
             "@id": "MimicLocation/physicalType/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -4687,6 +4734,7 @@
           "@id": "MimicObservationVitalSignsED/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -4701,6 +4749,7 @@
             "@id": "MimicObservationVitalSignsED/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -4777,6 +4826,7 @@
             "@id": "MimicObservationVitalSignsED/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -4840,6 +4890,7 @@
           "@id": "MimicObservationVitalSignsED/component",
           "name": "component",
           "description": "Column 'component'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -4868,6 +4919,7 @@
                 "@id": "MimicObservationVitalSignsED/component/code/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -4944,6 +4996,7 @@
                 "@id": "MimicObservationVitalSignsED/component/dataAbsentReason/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -5098,6 +5151,7 @@
             "@id": "MimicObservationVitalSignsED/dataAbsentReason/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -5233,6 +5287,7 @@
             "@id": "MimicObservationVitalSignsED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -5250,6 +5305,7 @@
           "@id": "MimicObservationVitalSignsED/partOf",
           "name": "partOf",
           "description": "Column 'partOf'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -5408,6 +5464,7 @@
           "@id": "MimicObservationMicroTest/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -5422,6 +5479,7 @@
             "@id": "MimicObservationMicroTest/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -5498,6 +5556,7 @@
             "@id": "MimicObservationMicroTest/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -5605,6 +5664,7 @@
           "@id": "MimicObservationMicroTest/hasMember",
           "name": "hasMember",
           "description": "Column 'hasMember'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -5663,6 +5723,7 @@
             "@id": "MimicObservationMicroTest/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -5766,6 +5827,7 @@
             "@id": "MimicObservationMicroTest/valueCodeableConcept/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -5852,6 +5914,7 @@
           "@id": "MimicObservationMicroOrg/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -5866,6 +5929,7 @@
             "@id": "MimicObservationMicroOrg/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -5942,6 +6006,7 @@
             "@id": "MimicObservationMicroOrg/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -6005,6 +6070,7 @@
           "@id": "MimicObservationMicroOrg/derivedFrom",
           "name": "derivedFrom",
           "description": "Column 'derivedFrom'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6050,6 +6116,7 @@
           "@id": "MimicObservationMicroOrg/hasMember",
           "name": "hasMember",
           "description": "Column 'hasMember'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6108,6 +6175,7 @@
             "@id": "MimicObservationMicroOrg/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -6192,6 +6260,7 @@
           "@id": "MimicObservationLabevents/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6206,6 +6275,7 @@
             "@id": "MimicObservationLabevents/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -6282,6 +6352,7 @@
             "@id": "MimicObservationLabevents/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -6389,6 +6460,7 @@
           "@id": "MimicObservationLabevents/extension",
           "name": "extension",
           "description": "Column 'extension'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6451,6 +6523,7 @@
           "@id": "MimicObservationLabevents/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6526,6 +6599,7 @@
             "@id": "MimicObservationLabevents/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -6543,6 +6617,7 @@
           "@id": "MimicObservationLabevents/note",
           "name": "note",
           "description": "Column 'note'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6573,6 +6648,7 @@
           "@id": "MimicObservationLabevents/referenceRange",
           "name": "referenceRange",
           "description": "Column 'referenceRange'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6914,6 +6990,7 @@
           "@id": "MimicObservationMicroSusc/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -6928,6 +7005,7 @@
             "@id": "MimicObservationMicroSusc/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7004,6 +7082,7 @@
             "@id": "MimicObservationMicroSusc/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7067,6 +7146,7 @@
           "@id": "MimicObservationMicroSusc/derivedFrom",
           "name": "derivedFrom",
           "description": "Column 'derivedFrom'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7112,6 +7192,7 @@
           "@id": "MimicObservationMicroSusc/extension",
           "name": "extension",
           "description": "Column 'extension'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7205,6 +7286,7 @@
           "@id": "MimicObservationMicroSusc/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7265,6 +7347,7 @@
             "@id": "MimicObservationMicroSusc/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -7282,6 +7365,7 @@
           "@id": "MimicObservationMicroSusc/note",
           "name": "note",
           "description": "Column 'note'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7369,6 +7453,7 @@
             "@id": "MimicObservationMicroSusc/valueCodeableConcept/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7440,6 +7525,7 @@
           "@id": "MimicObservationED/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7454,6 +7540,7 @@
             "@id": "MimicObservationED/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7530,6 +7617,7 @@
             "@id": "MimicObservationED/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7606,6 +7694,7 @@
             "@id": "MimicObservationED/dataAbsentReason/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7741,6 +7830,7 @@
             "@id": "MimicObservationED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -7758,6 +7848,7 @@
           "@id": "MimicObservationED/partOf",
           "name": "partOf",
           "description": "Column 'partOf'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7855,6 +7946,7 @@
           "@id": "MimicObservationOutputevents/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -7869,6 +7961,7 @@
             "@id": "MimicObservationOutputevents/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -7930,6 +8023,7 @@
             "@id": "MimicObservationOutputevents/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -8080,6 +8174,7 @@
             "@id": "MimicObservationOutputevents/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -8225,6 +8320,7 @@
           "@id": "MimicObservationDatetimeevents/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -8239,6 +8335,7 @@
             "@id": "MimicObservationDatetimeevents/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -8300,6 +8397,7 @@
             "@id": "MimicObservationDatetimeevents/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -8450,6 +8548,7 @@
             "@id": "MimicObservationDatetimeevents/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -8534,6 +8633,7 @@
           "@id": "MimicObservationChartevents/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -8548,6 +8648,7 @@
             "@id": "MimicObservationChartevents/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -8609,6 +8710,7 @@
             "@id": "MimicObservationChartevents/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -8759,6 +8861,7 @@
             "@id": "MimicObservationChartevents/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -8776,6 +8879,7 @@
           "@id": "MimicObservationChartevents/referenceRange",
           "name": "referenceRange",
           "description": "Column 'referenceRange'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -9088,6 +9192,7 @@
           "@id": "MimicMedicationDispense/authorizingPrescription",
           "name": "authorizingPrescription",
           "description": "Column 'authorizingPrescription'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -9147,6 +9252,7 @@
           "@id": "MimicMedicationDispense/dosageInstruction",
           "name": "dosageInstruction",
           "description": "Column 'dosageInstruction'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -9281,6 +9387,7 @@
                 "@id": "MimicMedicationDispense/dosageInstruction/route/coding",
                 "name": "coding",
                 "description": "Field 'coding'",
+                "cr:arrayShape": "-1",
                 "cr:isArray": true,
                 "source": {
                   "fileObject": {
@@ -9356,6 +9463,7 @@
                     "@id": "MimicMedicationDispense/dosageInstruction/timing/code/coding",
                     "name": "coding",
                     "description": "Field 'coding'",
+                    "cr:arrayShape": "-1",
                     "cr:isArray": true,
                     "source": {
                       "fileObject": {
@@ -9469,6 +9577,7 @@
           "@id": "MimicMedicationDispense/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -9529,6 +9638,7 @@
             "@id": "MimicMedicationDispense/medicationCodeableConcept/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -9590,6 +9700,7 @@
             "@id": "MimicMedicationDispense/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -9717,6 +9828,7 @@
               "@id": "MimicMedicationDispenseED/medicationCodeableConcept/coding",
               "name": "coding",
               "description": "Field 'coding'",
+              "cr:arrayShape": "-1",
               "cr:isArray": true,
               "source": {
                 "fileObject": {
@@ -9794,6 +9906,7 @@
             "@id": "MimicMedicationDispenseED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -9878,6 +9991,7 @@
           "@id": "MimicConditionED/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -9892,6 +10006,7 @@
             "@id": "MimicConditionED/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -9968,6 +10083,7 @@
             "@id": "MimicConditionED/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10088,6 +10204,7 @@
             "@id": "MimicConditionED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -10142,6 +10259,7 @@
           "@id": "MimicCondition/category",
           "name": "category",
           "description": "Column 'category'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -10156,6 +10274,7 @@
             "@id": "MimicCondition/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10232,6 +10351,7 @@
             "@id": "MimicCondition/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10352,6 +10472,7 @@
             "@id": "MimicCondition/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -10419,6 +10540,7 @@
             "@id": "MimicProcedureED/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10539,6 +10661,7 @@
             "@id": "MimicProcedureED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -10623,6 +10746,7 @@
           "@id": "MimicProcedureICU/bodySite",
           "name": "bodySite",
           "description": "Column 'bodySite'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -10637,6 +10761,7 @@
             "@id": "MimicProcedureICU/bodySite/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10698,6 +10823,7 @@
             "@id": "MimicProcedureICU/category/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10759,6 +10885,7 @@
             "@id": "MimicProcedureICU/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -10879,6 +11006,7 @@
             "@id": "MimicProcedureICU/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -11007,6 +11135,7 @@
             "@id": "MimicProcedure/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -11127,6 +11256,7 @@
             "@id": "MimicProcedure/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -11284,6 +11414,7 @@
               "@id": "MimicMedicationStatementED/medicationCodeableConcept/coding",
               "name": "coding",
               "description": "Field 'coding'",
+              "cr:arrayShape": "-1",
               "cr:isArray": true,
               "source": {
                 "fileObject": {
@@ -11376,6 +11507,7 @@
             "@id": "MimicMedicationStatementED/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -11460,6 +11592,7 @@
           "@id": "MimicPatient/communication",
           "name": "communication",
           "description": "Column 'communication'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -11487,6 +11620,7 @@
               "@id": "MimicPatient/communication/language/coding",
               "name": "coding",
               "description": "Field 'coding'",
+              "cr:arrayShape": "-1",
               "cr:isArray": true,
               "source": {
                 "fileObject": {
@@ -11551,6 +11685,7 @@
           "@id": "MimicPatient/extension",
           "name": "extension",
           "description": "Column 'extension'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -11566,6 +11701,7 @@
               "@id": "MimicPatient/extension/extension",
               "name": "extension",
               "description": "Field 'extension'",
+              "cr:arrayShape": "-1",
               "cr:isArray": true,
               "source": {
                 "fileObject": {
@@ -11736,6 +11872,7 @@
           "@id": "MimicPatient/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -11825,6 +11962,7 @@
             "@id": "MimicPatient/maritalStatus/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -11886,6 +12024,7 @@
             "@id": "MimicPatient/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -11903,6 +12042,7 @@
           "@id": "MimicPatient/name",
           "name": "name",
           "description": "Column 'name'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -11971,6 +12111,7 @@
             "@id": "MimicMedication/code/coding",
             "name": "coding",
             "description": "Field 'coding'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "source": {
               "fileObject": {
@@ -12034,6 +12175,7 @@
           "@id": "MimicMedication/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -12094,6 +12236,7 @@
             "@id": "MimicMedication/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {
@@ -12149,6 +12292,7 @@
           "@id": "MimicMedicationMix/identifier",
           "name": "identifier",
           "description": "Column 'identifier'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -12196,6 +12340,7 @@
           "@id": "MimicMedicationMix/ingredient",
           "name": "ingredient",
           "description": "Column 'ingredient'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -12253,6 +12398,7 @@
             "@id": "MimicMedicationMix/meta/profile",
             "name": "profile",
             "description": "Field 'profile'",
+            "cr:arrayShape": "-1",
             "cr:isArray": true,
             "dataType": "sc:URL",
             "source": {

--- a/tests/data/output/mimiciv_full_croissant.jsonld
+++ b/tests/data/output/mimiciv_full_croissant.jsonld
@@ -48,7 +48,7 @@
   "@type": "sc:Dataset",
   "name": "MIMIC-IV (full)",
   "description": "MIMIC-IV hospital and ICU module data",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). MIMIC-IV (full) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",

--- a/tests/data/output/mitdb_wfdb_croissant.jsonld
+++ b/tests/data/output/mitdb_wfdb_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "MIT-BIH Arrhythmia Database",
   "description": "MIT-BIH Arrhythmia Database containing 48 ECG recordings with annotations",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Moody GB, Mark RG. The impact of the MIT-BIH Arrhythmia Database. IEEE Eng in Med and Biol 20(3):45-50 (May-June 2001).",
   "creator": {
     "@type": "sc:Person",
     "name": "MIT-BIH"
   },
-  "datePublished": "1992-07-30T00:00:00",
+  "datePublished": "1992-07-30",
   "license": "https://physionet.org/content/mitdb/1.0.0/LICENSE.txt",
   "url": "https://physionet.org/content/mitdb/1.0.0/",
   "version": "1.0.0",

--- a/tests/data/output/open_targets_like_croissant.jsonld
+++ b/tests/data/output/open_targets_like_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,7 +49,7 @@
   "@type": "sc:Dataset",
   "name": "Open Targets Platform (toy)",
   "description": "Synthetic subset of Open Targets Platform data for testing partitioned Parquet support",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). Open Targets Platform (toy) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",
@@ -56,7 +57,7 @@
     "email": "data@opentargets.org",
     "url": "https://www.opentargets.org"
   },
-  "datePublished": "2025-03-01T00:00:00",
+  "datePublished": "2025-03-01",
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "url": "https://platform.opentargets.org",
   "version": "25.03",
@@ -300,6 +301,7 @@
           "@id": "credible_set/qualityControls",
           "name": "qualityControls",
           "description": "Column 'qualityControls'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "dataType": "sc:Text",
           "source": {
@@ -316,6 +318,7 @@
           "@id": "credible_set/locus",
           "name": "locus",
           "description": "Column 'locus'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileSet": {

--- a/tests/data/output/open_targets_subset_croissant.jsonld
+++ b/tests/data/output/open_targets_subset_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "Open Targets Platform (subset)",
   "description": "Subset of Open Targets Platform for testing",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Open Targets. (2025). Open Targets Platform (subset).",
   "creator": {
     "@type": "sc:Person",
     "name": "Open Targets"
   },
-  "datePublished": "2025-01-01T00:00:00",
+  "datePublished": "2025-01-01",
   "license": "https://platform-docs.opentargets.org/licence",
   "url": "https://platform.opentargets.org",
   "version": "1.0.0",
@@ -99,6 +100,7 @@
           "@id": "drug_warning/chemblIds",
           "name": "chemblIds",
           "description": "Column 'chemblIds'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "dataType": "sc:Text",
           "source": {
@@ -175,6 +177,7 @@
           "@id": "drug_warning/references",
           "name": "references",
           "description": "Column 'references'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "source": {
             "fileObject": {
@@ -365,6 +368,7 @@
           "@id": "disease_hpo/dbXRefs",
           "name": "dbXRefs",
           "description": "Column 'dbXRefs'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "dataType": "sc:Text",
           "source": {
@@ -381,6 +385,7 @@
           "@id": "disease_hpo/parents",
           "name": "parents",
           "description": "Column 'parents'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "dataType": "sc:Text",
           "source": {
@@ -397,6 +402,7 @@
           "@id": "disease_hpo/obsoleteTerms",
           "name": "obsoleteTerms",
           "description": "Column 'obsoleteTerms'",
+          "cr:arrayShape": "-1",
           "cr:isArray": true,
           "dataType": "sc:Text",
           "source": {

--- a/tests/data/output/reserved_names_croissant.jsonld
+++ b/tests/data/output/reserved_names_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "Reserved-name regression test",
   "description": "Dataset containing 1 files (application/vnd.apache.parquet) with automatically inferred types and structure",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Test Author. (2025). Reserved-name regression test.",
   "creator": {
     "@type": "sc:Person",
     "name": "Test Author"
   },
-  "datePublished": "2025-01-01T00:00:00",
+  "datePublished": "2025-01-01",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://example.com/reserved-name-test",
   "version": "1.0.0",

--- a/tests/data/output/satellite_public_health_croissant.jsonld
+++ b/tests/data/output/satellite_public_health_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "Multi-Modal Satellite Imagery for Public Health (subset)",
   "description": "Subset of Sentinel-2 satellite imagery linked to public health indicators in Colombia",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). Multi-Modal Satellite Imagery for Public Health (subset) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",
     "name": "Suri Allison Garzón Mora"
   },
-  "datePublished": "2024-01-01T00:00:00",
+  "datePublished": "2024-01-01",
   "license": "https://physionet.org/content/multimodal-satellite-data/1.0.0/LICENSE.txt",
   "url": "https://physionet.org/content/multimodal-satellite-data/1.0.0/",
   "version": "1.0.0",

--- a/tests/data/output/uniprot_demo_croissant.jsonld
+++ b/tests/data/output/uniprot_demo_croissant.jsonld
@@ -16,6 +16,7 @@
       "@type": "@vocab"
     },
     "dct": "http://purl.org/dc/terms/",
+    "equivalentProperty": "cr:equivalentProperty",
     "examples": {
       "@id": "cr:examples",
       "@type": "@json"
@@ -48,13 +49,13 @@
   "@type": "sc:Dataset",
   "name": "UniProt Human Reviewed (demo)",
   "description": "200 reviewed human proteins from UniProt Swiss-Prot",
-  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "conformsTo": "http://mlcommons.org/croissant/1.1",
   "citeAs": "Dataset Creator. (2026). UniProt Human Reviewed (demo) Dataset. Generated with automated type inference.",
   "creator": {
     "@type": "sc:Person",
     "name": "UniProt Consortium"
   },
-  "datePublished": "2025-01-01T00:00:00",
+  "datePublished": "2025-01-01",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://www.uniprot.org/uniprotkb?query=reviewed:true&organism_id=9606",
   "version": "1.0.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,11 +514,11 @@ def test_native_rai_flags_generate_metadata(csv_dataset: Path, tmp_path: Path) -
     )
     assert metadata["rai:dataUseCases"] == "Benchmarking"
     assert metadata["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.0",
+        "http://mlcommons.org/croissant/1.1",
         "http://mlcommons.org/croissant/RAI/1.0",
     ]
     assert metadata["rai:dataCollectionTimeFrame"] == [
-        "2023-01-01T00:00:00",
+        "2023-01-01",
         "2023-06-01T12:30:00",
     ]
 
@@ -608,6 +608,266 @@ lineage:
 
     metadata = json.loads(output.read_text())
     assert metadata["conformsTo"] == [
-        "http://mlcommons.org/croissant/1.0",
+        "http://mlcommons.org/croissant/1.1",
         "http://mlcommons.org/croissant/RAI/1.0",
     ]
+
+
+def test_optional_1_1_flags_round_trip(csv_dataset: Path, tmp_path: Path) -> None:
+    """Optional 1.1 flags emit their schema.org fields unchanged.
+
+    Exercises both repeat-flag and comma-delimited input shapes for the
+    list-valued flags, plus single-value plumbing for the rest. Locks in
+    the JSON-LD field names mlcroissant emits for each input.
+    """
+    output = tmp_path / "output.jsonld"
+
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--publisher",
+            "PhysioNet",
+            "--keywords",
+            "ehr,icu",
+            "--keywords",
+            "demo",
+            "--in-language",
+            "en",
+            "--same-as",
+            "https://doi.org/10.1234/example,https://example.org/mirror",
+            "--sd-license",
+            "https://creativecommons.org/publicdomain/zero/1.0/",
+            "--sd-version",
+            "1.0.0",
+            "--alternate-name",
+            "test-ds",
+            "--is-live-dataset",
+            "--date-created",
+            "2023-01-01",
+            "--date-modified",
+            "2023-06-01T12:00:00",
+            "--no-validate",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    metadata = json.loads(output.read_text())
+
+    assert metadata["publisher"] == {
+        "@type": "sc:Organization",
+        "name": "PhysioNet",
+    }
+    assert metadata["keywords"] == ["ehr", "icu", "demo"]
+    assert metadata["sameAs"] == [
+        "https://doi.org/10.1234/example",
+        "https://example.org/mirror",
+    ]
+    # mlcroissant flattens single-item lists for these properties (spec-valid):
+    assert metadata["inLanguage"] == "en"
+    assert metadata["sdLicense"] == (
+        "https://creativecommons.org/publicdomain/zero/1.0/"
+    )
+    assert metadata["sdVersion"] == "1.0.0"
+    assert metadata["alternateName"] == "test-ds"
+    assert metadata["isLiveDataset"] is True
+    assert metadata["dateCreated"] == "2023-01-01"
+    assert metadata["dateModified"] == "2023-06-01T12:00:00"
+
+
+def test_temporal_coverage_and_usage_info(csv_dataset: Path, tmp_path: Path) -> None:
+    """--temporal-coverage and --usage-info flow through as schema.org fields."""
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--temporal-coverage",
+            "2008/2019",
+            "--usage-info",
+            "http://purl.obolibrary.org/obo/DUO_0000042",
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    metadata = json.loads(output.read_text())
+    assert metadata["temporalCoverage"] == "2008/2019"
+    assert metadata["usageInfo"] == "http://purl.obolibrary.org/obo/DUO_0000042"
+
+
+def test_field_mappings_yaml_appends_to_dataType(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """--field-mappings adds equivalentProperty + appends external dataType."""
+    mappings = tmp_path / "mappings.yaml"
+    mappings.write_text(
+        "fields:\n"
+        "  age:\n"
+        "    equivalent_property: 'wdt:P3629'\n"
+        "    data_types: ['wd:Q11464']\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--field-mappings",
+            str(mappings),
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    metadata = json.loads(output.read_text())
+    age_field = next(
+        f
+        for rs in metadata["recordSet"]
+        for f in (rs["field"] if isinstance(rs["field"], list) else [rs["field"]])
+        if f["name"] == "age"
+    )
+    # Inferred Croissant type preserved, external vocab appended.
+    assert age_field["equivalentProperty"] == "wdt:P3629"
+    assert "wd:Q11464" in age_field["dataType"]
+    assert any(t.startswith(("cr:", "sc:")) for t in age_field["dataType"])
+
+
+def test_field_mapping_flag_overrides_yaml(csv_dataset: Path, tmp_path: Path) -> None:
+    """The repeatable --field-mapping flag merges with --field-mappings YAML and wins."""
+    mappings = tmp_path / "mappings.yaml"
+    mappings.write_text(
+        "fields:\n  age:\n    equivalent_property: 'wdt:OLD'\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--field-mappings",
+            str(mappings),
+            "--field-mapping",
+            "age=wdt:NEW",
+            "--field-mapping",
+            "id=wdt:P527",
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    metadata = json.loads(output.read_text())
+    fields = {
+        f["name"]: f
+        for rs in metadata["recordSet"]
+        for f in (rs["field"] if isinstance(rs["field"], list) else [rs["field"]])
+    }
+    assert fields["age"]["equivalentProperty"] == "wdt:NEW"  # flag won
+    assert fields["id"]["equivalentProperty"] == "wdt:P527"  # flag-only column
+
+
+def test_usage_info_rejects_non_url(csv_dataset: Path, tmp_path: Path) -> None:
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--usage-info",
+            "see license file",
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "URL" in result.output or "http" in result.output.lower()
+
+
+def test_field_mappings_yaml_rejects_unknown_keys(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    mappings = tmp_path / "mappings.yaml"
+    mappings.write_text(
+        "fields:\n  age:\n    equivalentProperty: 'wdt:P3629'\n",  # camelCase typo
+        encoding="utf-8",
+    )
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--field-mappings",
+            str(mappings),
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown" in result.output.lower()
+
+
+def test_baked_output_round_trips_through_mlcroissant(
+    csv_dataset: Path, tmp_path: Path
+) -> None:
+    """mlc.Dataset() can load our output and the values read back match the inputs.
+
+    Validator-pass alone proves shape; this proves consumers can iterate values.
+    """
+    import mlcroissant as mlc
+
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--name",
+            "Round-trip dataset",
+            "--description",
+            "Reads back through mlc.Dataset().",
+            "--url",
+            "https://example.com/rt",
+            "--license",
+            "CC-BY-4.0",
+            "--creator",
+            "Test",
+            "--keywords",
+            "rt,demo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    ds = mlc.Dataset(str(output))
+    assert ds.metadata.name == "Round-trip dataset"
+    assert ds.metadata.description == "Reads back through mlc.Dataset()."
+    assert ds.metadata.url == "https://example.com/rt"
+    # Field-level access works too.
+    record_sets = list(ds.metadata.record_sets)
+    fields = list(record_sets[0].fields)
+    assert {f.name for f in fields} == {"id", "name", "age"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -783,7 +783,8 @@ def test_field_mapping_flag_overrides_yaml(csv_dataset: Path, tmp_path: Path) ->
     assert fields["id"]["equivalentProperty"] == "wdt:P527"  # flag-only column
 
 
-def test_usage_info_rejects_non_url(csv_dataset: Path, tmp_path: Path) -> None:
+def test_usage_info_rejects_free_text(csv_dataset: Path, tmp_path: Path) -> None:
+    """Reject strings without a URI scheme; accept any RFC 3986 scheme."""
     output = tmp_path / "output.jsonld"
     result = runner.invoke(
         app,
@@ -800,7 +801,67 @@ def test_usage_info_rejects_non_url(csv_dataset: Path, tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code != 0
-    assert "URL" in result.output or "http" in result.output.lower()
+    assert "URI" in result.output or "scheme" in result.output.lower()
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://example.org/policy",
+        "http://purl.obolibrary.org/obo/DUO_0000042",
+        "urn:lex:eu:council:directive:2022-09-14;2022-2065",
+        "did:web:example.org:dataset",
+        "mailto:dac@example.org",
+    ],
+)
+def test_usage_info_accepts_any_uri_scheme(
+    csv_dataset: Path, tmp_path: Path, uri: str
+) -> None:
+    output = tmp_path / "output.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_dataset),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--usage-info",
+            uri,
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(output.read_text())["usageInfo"] == uri
+
+
+def test_field_mapping_warns_on_multiple_matches(tmp_path: Path) -> None:
+    """A mapping that hits more than one field warns the user."""
+    dataset_dir = tmp_path / "ds"
+    dataset_dir.mkdir()
+    # Two CSVs both with an 'id' column — same name, different semantics.
+    (dataset_dir / "patients.csv").write_text("id,age\n1,40\n2,50\n")
+    (dataset_dir / "diagnoses.csv").write_text("id,code\n1,X\n2,Y\n")
+
+    output = tmp_path / "out.jsonld"
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(dataset_dir),
+            "--output",
+            str(output),
+            "--creator",
+            "Test",
+            "--field-mapping",
+            "id=http://www.wikidata.org/entity/Q577",
+            "--no-validate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    combined = (result.output or "") + (result.stderr or "")
+    assert "field mapping 'id' applied to 2 fields" in combined
 
 
 def test_field_mappings_yaml_rejects_unknown_keys(

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,6 +3,10 @@
 from pathlib import Path
 from croissant_baker.handlers.registry import find_handler, register_all_handlers
 from croissant_baker.handlers.csv_handler import CSVHandler
+from croissant_baker.handlers.utils import (
+    ARRAY_SHAPE_UNKNOWN_1D,
+    normalize_array_shape,
+)
 
 
 def test_find_handler_with_real_handlers() -> None:
@@ -33,3 +37,14 @@ def test_handler_registry_isolation() -> None:
 
     # Should find CSV handler
     assert find_handler(Path("data.csv")) is not None
+
+
+def test_normalize_array_shape_accepts_tuple_and_bare_forms() -> None:
+    """Tuple-style shapes (numpy.shape repr) coerce to mlc-accepted form."""
+    assert normalize_array_shape(ARRAY_SHAPE_UNKNOWN_1D) == "-1"
+    assert normalize_array_shape("-1") == "-1"
+    assert normalize_array_shape("(-1,)") == "-1"
+    assert normalize_array_shape("(-1, -1)") == "-1,-1"
+    assert normalize_array_shape("(28, 28)") == "28,28"
+    assert normalize_array_shape("28,28") == "28,28"
+    assert normalize_array_shape("-1,-1,3") == "-1,-1,3"

--- a/tests/test_mlcroissant_api_gaps.py
+++ b/tests/test_mlcroissant_api_gaps.py
@@ -1,0 +1,98 @@
+"""Tripwire for mlcroissant API gaps that we patch via post-hoc dict edits.
+
+When mlcroissant gains a native parameter (or fixes a context alias) for any
+field listed below, the corresponding assertion fails. That is the signal to
+delete the post-hoc inject in ``metadata_generator.py`` and switch to the
+native API.
+
+Bump the upper pin in ``pyproject.toml`` deliberately when 1.2.x ships and
+reconcile this list against the new release.
+"""
+
+import inspect
+
+import mlcroissant as mlc
+
+
+# Fields the Croissant 1.1 spec defines that mlcroissant 1.1.0 does NOT expose
+# as Python parameters. Each is post-hoc-injected by MetadataGenerator.
+_METADATA_GAPS_AS_OF_MLC_1_1_0 = {
+    "alternate_name",
+    "is_live_dataset",
+    "temporal_coverage",
+    "usage_info",
+}
+
+
+# Field-level gaps. ``equivalent_property`` lives on cr:Field per the spec but
+# mlcroissant 1.1.0 has no constructor parameter for it.
+_FIELD_GAPS_AS_OF_MLC_1_1_0 = {
+    "equivalent_property",
+}
+
+
+def test_metadata_post_hoc_fields_still_lack_native_params() -> None:
+    sig = inspect.signature(mlc.Metadata.__init__).parameters
+    closed_gaps = {name for name in _METADATA_GAPS_AS_OF_MLC_1_1_0 if name in sig}
+    assert not closed_gaps, (
+        f"mlcroissant Metadata gained native support for {closed_gaps}. "
+        "Remove the matching post-hoc inject in MetadataGenerator and "
+        "drop the entry from _METADATA_GAPS_AS_OF_MLC_1_1_0."
+    )
+
+
+def test_field_post_hoc_props_still_lack_native_params() -> None:
+    sig = inspect.signature(mlc.Field.__init__).parameters
+    closed_gaps = {name for name in _FIELD_GAPS_AS_OF_MLC_1_1_0 if name in sig}
+    assert not closed_gaps, (
+        f"mlcroissant Field gained native support for {closed_gaps}. "
+        "Switch _apply_field_mappings to the native API."
+    )
+
+
+def test_sd_version_native_param_still_emits_prefixed_key() -> None:
+    """sd_version is a native Metadata param, but mlcroissant emits it as
+    ``cr:sdVersion`` because the @context lacks an alias for ``sdVersion``.
+    Canonical 1.1 examples use the unprefixed key, so we post-hoc inject.
+    When mlcroissant adds the alias, this test fails — switch to native.
+    """
+    md = mlc.Metadata(
+        name="t",
+        description="d",
+        url="https://example.com",
+        license="mit",
+        conforms_to="http://mlcommons.org/croissant/1.1",
+        sd_version="1.0.0",
+    )
+    out = md.to_json()
+    assert "sdVersion" not in out, (
+        "mlcroissant now emits the unprefixed sdVersion key. "
+        "Drop the post-hoc inject in MetadataGenerator.generate_metadata."
+    )
+    assert "cr:sdVersion" in out
+
+
+def test_rai_conforms_to_not_auto_appended_when_rai_fields_set() -> None:
+    """The Croissant 1.1 spec defines ``http://mlcommons.org/croissant/RAI/1.0``
+    as the conformsTo URI for the RAI extension, but mlcroissant 1.1.0 does
+    NOT append it when RAI fields like ``data_biases`` are populated.
+    croissant-baker patches this via ``_ensure_rai_conforms_to``. When mlc
+    starts auto-appending it, this test fails — drop the helper.
+    """
+    md = mlc.Metadata(
+        name="t",
+        description="d",
+        url="https://example.com",
+        license="mit",
+        conforms_to="http://mlcommons.org/croissant/1.1",
+        data_biases=["single-site cohort"],
+        data_use_cases=["benchmarking"],
+    )
+    out = md.to_json()
+    rai_uri = "http://mlcommons.org/croissant/RAI/1.0"
+    ct = out.get("conformsTo")
+    flat = ct if isinstance(ct, list) else [ct]
+    assert rai_uri not in flat, (
+        "mlcroissant now auto-appends the RAI conformsTo URI. "
+        "Drop _ensure_rai_conforms_to in croissant_baker/__main__.py."
+    )

--- a/tests/test_parquet_handler.py
+++ b/tests/test_parquet_handler.py
@@ -231,3 +231,31 @@ def test_parquet_build_croissant_partitioned(handler: ParquetHandler) -> None:
     assert len(record_sets) == 1
     assert record_sets[0].name == "events"
     assert "events/*.parquet" in filesets[0].includes
+
+
+def test_parquet_array_shape_fixed_vs_variable(
+    handler: ParquetHandler, tmp_path: Path
+) -> None:
+    """Fixed-size lists report exact dim; variable-length lists report -1."""
+    schema = pa.schema(
+        [
+            ("embedding", pa.list_(pa.float32(), 384)),  # fixed-size: dim 384
+            ("tags", pa.list_(pa.string())),  # variable-length
+        ]
+    )
+    table = pa.table(
+        {"embedding": [[0.0] * 384], "tags": [["a", "b"]]},
+        schema=schema,
+    )
+    path = tmp_path / "vectors.parquet"
+    pq.write_table(table, str(path))
+
+    meta = handler.extract_metadata(path)
+    meta["relative_path"] = "vectors.parquet"
+    _, record_sets = handler.build_croissant([meta], ["file_0"])
+
+    fields = {f.name: f for f in record_sets[0].fields}
+    assert fields["embedding"].is_array is True
+    assert fields["embedding"].array_shape == "384"
+    assert fields["tags"].is_array is True
+    assert fields["tags"].array_shape == "-1"

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "croissant-baker"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "mlcroissant" },
@@ -633,7 +633,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mlcroissant", specifier = ">=1.0.20" },
+    { name = "mlcroissant", specifier = ">=1.1.0,<1.2.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "mlcroissant"
-version = "1.0.22"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -1517,9 +1517,9 @@ dependencies = [
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/ab/df5f0c4088c25ddfda8ff1b2c24af3a056c55143cefd33e0e7ff732254bc/mlcroissant-1.0.22.tar.gz", hash = "sha256:906e3a17e0d7de1154e77fd028dbffa3fb191cc22fe08e89eb92a901573db417", size = 103297, upload-time = "2025-08-25T15:53:42.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/94/67287557ad889c85d37700bed09b33f1be8b7a272a5d0dbb84f4a697e7b0/mlcroissant-1.1.0.tar.gz", hash = "sha256:fd4a5fc875fa1531fabe4c131acdf8aaf9428fd69583cc51a7a5c23262b48259", size = 111643, upload-time = "2026-04-16T13:18:44.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/fe/dca45e0f743ba89fc66ac0149600f04400c6a71743ff1084dd947e669c8f/mlcroissant-1.0.22-py2.py3-none-any.whl", hash = "sha256:632016004b6fd560b21085e8eb26a73da74560fb8bdbb890be47b789e325b7a4", size = 145334, upload-time = "2025-08-25T15:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f9/9d4602e4346e4d6625e67ddcfd1ebd8d7d13860025bde43c8ed8149758e5/mlcroissant-1.1.0-py2.py3-none-any.whl", hash = "sha256:46f9ab72fc193e1e3730dbbd872eb8cdf07ca16e854578c5c30c2aad2854423a", size = 155405, upload-time = "2026-04-16T13:18:42.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps croissant-baker to emit Croissant 1.1 JSON-LD, pins
`mlcroissant>=1.1.0,<1.2.0`, and exposes optional schema.org and
Croissant 1.1 Dataset fields as CLI flags. Existing behaviour for
required spec fields is unchanged. Croissant 1.1 is additive over
1.0, so outputs remain valid in both directions.

## Why

Croissant 1.0 is the previously declared spec target. Hugging Face,
Kaggle, and OpenML have integrated Croissant 1.1 since February
2026, and mlcroissant 1.1.0 ships the validator for it. This PR
brings the tool current.

## What you get

### Validator alignment

`conformsTo` now declares `http://mlcommons.org/croissant/1.1`. The
mlcroissant pin sits at `>=1.1.0,<1.2.0`. Patches and minors flow.
The 1.2 boundary is gated for deliberate review since a major bump
likely tracks a new spec revision.

### Field-level array shapes (Croissant 1.1)

`cr:arrayShape` is now emitted alongside `cr:isArray` everywhere
the tool detects an array column. Arrow `fixed_size_list` columns
report the actual dimension. Variable-length lists and JSON arrays
emit `"-1"`, the spec sentinel for "1D, length varies row to row".

### Optional Dataset flags

All flags below are spec-defined, optional, and silent unless used.
Most surface schema.org properties that were already valid in 1.0
but not exposed by the CLI.

| Flag | Property |
|---|---|
| `--keywords` | schema.org/keywords |
| `--in-language` | schema.org/inLanguage |
| `--same-as` | schema.org/sameAs |
| `--publisher` | schema.org/publisher |
| `--alternate-name` | schema.org/alternateName |
| `--date-created` | schema.org/dateCreated |
| `--date-modified` | schema.org/dateModified |
| `--temporal-coverage` | schema.org/temporalCoverage |
| `--usage-info` | schema.org/usageInfo (DUO or ODRL URL) |
| `--sd-license` | schema.org/sdLicense (license of the metadata file) |
| `--sd-version` | cr:sdVersion (version of the metadata file, 1.1) |
| `--is-live-dataset` | cr:isLiveDataset (1.1) |

`--keywords`, `--in-language`, and `--same-as` accept either
repeat-flag form (`--keywords a --keywords b`) or a single
comma-delimited value (`--keywords "a,b"`), matching the
schema.org convention for list properties.

### Vocabulary linking for columns

Two new flags link columns to external vocabularies (Wikidata,
SNOMED, LOINC, etc.) producing `equivalentProperty` and extending
`dataType`:

```
# Quick form, single property:
--field-mapping "age=http://www.wikidata.org/entity/Q11464"

# Rich form, YAML sidecar with per-column lists:
--field-mappings field_mappings.yaml
```

The YAML schema:

```yaml
fields:
  age:
    equivalent_property: "wdt:P3629"
    data_types: ["wd:Q11464"]
  patient_id:
    equivalent_property: "snomed:399097000"
```

External `data_types` are appended to the inferred Croissant base
type rather than replacing it. The 1.1 spec supports this combined
form (for example `["sc:URL", "wd:Q515"]`) and the mlcroissant
validator requires at least one Croissant base type per field.

### Example, end to end

```
croissant-baker -i ./mimic-iv -o mimic.jsonld \
  --name "MIMIC-IV" \
  --creator "MIT-LCP" \
  --license "PhysioNet Restricted Health Data License 1.5.0" \
  --url "https://physionet.org/content/mimiciv/" \
  --publisher "PhysioNet" \
  --keywords "ehr,icu,critical-care" \
  --in-language "en" \
  --temporal-coverage "2008/2019" \
  --usage-info "http://purl.obolibrary.org/obo/DUO_0000042" \
  --same-as "https://doi.org/10.13026/kpb9-mt58"
```

## Verification

- 204 unit tests pass.
- All 16 fixtures in `tests/data/output/` revalidate cleanly against
  an isolated `pip install mlcroissant==1.1.0` venv.
- Bake-and-validate end to end on full MIMIC-IV (9.9 GB, 32 csv.gz)
  and full MIMIC-IV-MEDS (3.7 GB, 374 parquets) both pass the
  validator.
- `tests/test_mlcroissant_api_gaps.py` holds tripwire tests that
  fail when upstream mlcroissant gains native support for fields we
  currently patch after `to_json()`. Failure messages name the
  helper to delete.

## Implementation notes

mlcroissant 1.1.0 has no Python parameter for `alternateName`,
`isLiveDataset`, `temporalCoverage`, `usageInfo`, or field-level
`equivalentProperty`, and emits `cr:sdVersion` instead of the
canonical unprefixed `sdVersion`. Each is patched on the dict
returned by `metadata.to_json()` and covered by a tripwire test.

The RAI extension vocabulary did not version-bump in Croissant 1.1.
The conformsTo URI for the RAI extension remains
`http://mlcommons.org/croissant/RAI/1.0`, hyperlinked from the
official Croissant 1.1 spec page. The existing
`_ensure_rai_conforms_to` helper still appends it when RAI fields
are present.

## Out of scope

PROV-O activity graphs, GeoCroissant, ODRL Offer permission trees,
DUO codes as structured `DefinedTerm` objects, and cross-RecordSet
`references` are all spec-defined but require structured input
models that deserve dedicated PRs. The flat URL form of
`--usage-info` covers the common DUO or ODRL pointer use case in
the meantime.

## Test plan

- [x] CI green on this branch
- [ ] Spot-check one rendered jsonld output for a sample dataset
- [ ] Optional: validate output via `croissant-baker validate <file>` after merge