### PR TITLE
Fix/id collisions followup #63

### DIFF
--- a/src/croissant_baker/handlers/csv_handler.py
+++ b/src/croissant_baker/handlers/csv_handler.py
@@ -15,7 +15,6 @@ from croissant_baker.handlers.utils import (
     infer_column_types_from_arrow_schema,
     make_field_id,
     make_record_set_ids,
-    sanitize_id,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/croissant_baker/handlers/csv_handler.py
+++ b/src/croissant_baker/handlers/csv_handler.py
@@ -13,6 +13,8 @@ from croissant_baker.handlers.utils import (
     compute_file_hash,
     get_clean_record_name,
     infer_column_types_from_arrow_schema,
+    make_field_id,
+    make_record_set_ids,
     sanitize_id,
 )
 
@@ -303,14 +305,14 @@ class CSVHandler(FileTypeHandler):
 
     def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
         record_sets = []
-        for file_id, file_meta in zip(file_ids, file_metas):
+        rs_ids = make_record_set_ids(file_metas)
+        for file_id, file_meta, rs_id in zip(file_ids, file_metas, rs_ids):
             rs_name = get_clean_record_name(file_meta["file_name"])
-            rs_id = sanitize_id(rs_name)
 
+            used_field_ids: set = set()
             fields = []
             for col_name, col_type in file_meta["column_types"].items():
-                safe_name = sanitize_id(col_name)
-                field_id = f"{rs_id}/{safe_name}"
+                field_id = make_field_id(rs_id, col_name, used_field_ids)
                 field = mlc.Field(
                     id=field_id,
                     name=col_name,

--- a/src/croissant_baker/handlers/fhir_handler.py
+++ b/src/croissant_baker/handlers/fhir_handler.py
@@ -23,7 +23,6 @@ from croissant_baker.handlers.utils import (
     SCHEMA_SAMPLE,
     build_fields_from_json_schema,
     compute_file_hash,
-    get_clean_record_name,
     infer_json_schema,
     make_record_set_ids,
     open_text_file,

--- a/src/croissant_baker/handlers/fhir_handler.py
+++ b/src/croissant_baker/handlers/fhir_handler.py
@@ -25,6 +25,7 @@ from croissant_baker.handlers.utils import (
     compute_file_hash,
     get_clean_record_name,
     infer_json_schema,
+    make_record_set_ids,
     open_text_file,
     sanitize_id,
 )
@@ -363,8 +364,9 @@ class FHIRHandler(FileTypeHandler):
                 standalone.extend(chunks)
                 chunks = []
 
-            for fid, meta in standalone:
-                rs_id = sanitize_id(get_clean_record_name(meta["file_name"]))
+            standalone_metas = [m for _, m in standalone]
+            standalone_rs_ids = make_record_set_ids(standalone_metas)
+            for (fid, meta), rs_id in zip(standalone, standalone_rs_ids):
                 num_rows = meta.get("num_rows")
                 row_desc = f" ({num_rows} rows)" if num_rows is not None else ""
                 record_sets.append(

--- a/src/croissant_baker/handlers/json_handler.py
+++ b/src/croissant_baker/handlers/json_handler.py
@@ -23,6 +23,7 @@ from croissant_baker.handlers.utils import (
     compute_file_hash,
     get_clean_record_name,
     infer_json_schema,
+    make_record_set_ids,
     open_text_file,
     sanitize_id,
 )
@@ -219,10 +220,10 @@ class JSONHandler(FileTypeHandler):
             ([], record_sets) — no additional distributions.
         """
         record_sets: list = []
+        rs_ids = make_record_set_ids(file_metas)
 
-        for file_id, meta in zip(file_ids, file_metas):
+        for file_id, meta, rs_id in zip(file_ids, file_metas, rs_ids):
             file_name = meta.get("file_name", "unknown")
-            rs_id = sanitize_id(get_clean_record_name(file_name))
             num_rows = meta.get("num_rows")
             row_desc = f" ({num_rows} rows)" if num_rows is not None else ""
             record_sets.append(
@@ -234,6 +235,7 @@ class JSONHandler(FileTypeHandler):
                         meta["column_types"],
                         rs_id,
                         source_ref={"file_object": file_id},
+                        used_field_ids=set(),
                     ),
                 )
             )

--- a/src/croissant_baker/handlers/json_handler.py
+++ b/src/croissant_baker/handlers/json_handler.py
@@ -21,11 +21,9 @@ from croissant_baker.handlers.utils import (
     SCHEMA_SAMPLE,
     build_fields_from_json_schema,
     compute_file_hash,
-    get_clean_record_name,
     infer_json_schema,
     make_record_set_ids,
     open_text_file,
-    sanitize_id,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/croissant_baker/handlers/parquet_handler.py
+++ b/src/croissant_baker/handlers/parquet_handler.py
@@ -10,9 +10,12 @@ from pyarrow.parquet import ParquetFile
 from croissant_baker.handlers.base_handler import FileTypeHandler
 from croissant_baker.handlers.utils import (
     _build_fields,
+    _disambiguate_ids,
     compute_file_hash,
     get_clean_record_name,
     infer_column_types_from_arrow_schema,
+    make_field_id,
+    make_partition_record_set_ids,
     sanitize_id,
 )
 
@@ -137,6 +140,44 @@ class ParquetHandler(FileTypeHandler):
             parent = str(Path(file_meta["relative_path"]).parent)
             dir_groups[parent].append((file_id, file_meta))
 
+        # Split into partitioned-table directories and standalone files so
+        # each set can be disambiguated independently.
+        partitioned_dirs = [
+            d for d, pairs in dir_groups.items() if len(pairs) >= 2 and d != "."
+        ]
+        standalone_pairs = [
+            (file_id, meta)
+            for d, pairs in dir_groups.items()
+            if not (len(pairs) >= 2 and d != ".")
+            for file_id, meta in pairs
+        ]
+        partitioned_rs_ids = dict(
+            zip(partitioned_dirs, make_partition_record_set_ids(partitioned_dirs))
+        )
+        # Standalone Parquet files take their @id stem from the parent
+        # directory name when one exists, falling back to the cleaned
+        # file basename for files at the dataset root. Parquet basenames
+        # in real datasets are typically partition labels (`part-00000`,
+        # `0`, UUIDs) that make poor identifiers, so the parent dir is
+        # the more meaningful stem. Disambiguation walks up the
+        # grandparent path on collision.
+        standalone_id_items = []
+        for _, meta in standalone_pairs:
+            rel = Path(meta["relative_path"])
+            parents = list(rel.parts[:-1])
+            if parents:
+                stem = sanitize_id(parents[-1])
+                disambig_parents = parents[:-1]
+            else:
+                stem = sanitize_id(get_clean_record_name(meta["file_name"]))
+                disambig_parents = []
+            standalone_id_items.append((stem, disambig_parents))
+        standalone_rs_ids = _disambiguate_ids(standalone_id_items)
+        standalone_rs_id_by_index = {
+            id(meta): rs_id
+            for (_, meta), rs_id in zip(standalone_pairs, standalone_rs_ids)
+        }
+
         for dir_path, pairs in dir_groups.items():
             is_partitioned = len(pairs) >= 2 and dir_path != "."
 
@@ -145,6 +186,7 @@ class ParquetHandler(FileTypeHandler):
                 table_name = Path(dir_path).name
                 dir_id = sanitize_id(dir_path)
                 fileset_id = f"{dir_id}-fileset"
+                rs_id = partitioned_rs_ids[dir_path]
 
                 _suffix = "".join(Path(pairs[0][1]["file_name"]).suffixes)
                 additional_distributions.append(
@@ -160,16 +202,17 @@ class ParquetHandler(FileTypeHandler):
                 if "arrow_schema" in first_meta:
                     fields = _build_fields(
                         first_meta["arrow_schema"],
-                        sanitize_id(table_name),
+                        rs_id,
                         {"file_set": fileset_id},
                     )
                 else:
+                    used_field_ids: set = set()
                     fields = []
                     for col_name, col_type in first_meta["column_types"].items():
-                        safe_name = sanitize_id(col_name)
+                        field_id = make_field_id(rs_id, col_name, used_field_ids)
                         fields.append(
                             mlc.Field(
-                                id=f"{dir_id}/{safe_name}",
+                                id=field_id,
                                 name=col_name,
                                 description=f"Column '{col_name}' from table '{table_name}'",
                                 data_types=[col_type],
@@ -183,7 +226,7 @@ class ParquetHandler(FileTypeHandler):
                 num_rows = sum(m.get("num_rows", 0) for _, m in pairs)
                 record_sets.append(
                     mlc.RecordSet(
-                        id=sanitize_id(table_name),
+                        id=rs_id,
                         name=table_name,
                         description=f"Partitioned table '{table_name}' ({len(pairs)} Parquet files, {num_rows} total rows)",
                         fields=fields,
@@ -197,7 +240,7 @@ class ParquetHandler(FileTypeHandler):
                         rs_name = Path(rel_dir).name
                     else:
                         rs_name = get_clean_record_name(file_meta["file_name"])
-                    rs_id = sanitize_id(rs_name)
+                    rs_id = standalone_rs_id_by_index[id(file_meta)]
 
                     if "arrow_schema" in file_meta:
                         fields = _build_fields(
@@ -206,12 +249,13 @@ class ParquetHandler(FileTypeHandler):
                             {"file_object": file_id},
                         )
                     else:
+                        used_field_ids = set()
                         fields = []
                         for col_name, col_type in file_meta["column_types"].items():
-                            safe_name = sanitize_id(col_name)
+                            field_id = make_field_id(rs_id, col_name, used_field_ids)
                             fields.append(
                                 mlc.Field(
-                                    id=f"{rs_id}/{safe_name}",
+                                    id=field_id,
                                     name=col_name,
                                     description=f"Column '{col_name}' from {file_meta['file_name']}",
                                     data_types=[col_type],

--- a/src/croissant_baker/handlers/utils.py
+++ b/src/croissant_baker/handlers/utils.py
@@ -69,6 +69,125 @@ def sanitize_id(raw: str) -> str:
     return _INVALID_ID_CHARS.sub("_", raw)
 
 
+def _disambiguate_ids(items: list) -> list:
+    """Return a list of unique @id strings parallel to ``items``.
+
+    Each item is a ``(stem, parent_components)`` tuple, where ``stem`` is
+    the desired sanitized identifier and ``parent_components`` is the
+    list of parent path components (closest parent last) available for
+    disambiguation. When two or more items share the same stem, the
+    minimum number of trailing parent components is prepended (joined
+    with ``__``) until every member of the colliding group is unique.
+
+    Filesystem paths are unique by construction, so the loop is
+    guaranteed to converge for items derived from real file metadata.
+    """
+    from collections import defaultdict
+
+    stems = [it[0] for it in items]
+    parents_per = [it[1] for it in items]
+
+    # Bucket items by their proposed stem; only buckets of size >1 need work.
+    groups: dict = defaultdict(list)
+    for i, stem in enumerate(stems):
+        groups[stem].append(i)
+
+    out = list(stems)
+    for stem, indices in groups.items():
+        if len(indices) == 1:
+            continue  # no collision in this bucket; keep bare stem
+        # Try increasing parent-prefix depths in lock-step across the colliding
+        # bucket. The smallest depth at which every candidate is distinct wins.
+        max_depth = max((len(parents_per[i]) for i in indices), default=0)
+        chosen: dict = {}
+        for depth in range(1, max_depth + 1):
+            candidates: dict = {}
+            for i in indices:
+                parents = parents_per[i]
+                prefix_parts = parents[-depth:] if depth <= len(parents) else parents
+                prefix = "__".join(prefix_parts)
+                candidates[i] = sanitize_id(f"{prefix}__{stem}") if prefix else stem
+            if len(set(candidates.values())) == len(indices):
+                chosen = candidates
+                break
+        if not chosen:
+            # Fallback: every available parent component included. Filesystem
+            # paths are unique, so this branch should not fire on real inputs;
+            # kept as a safety net for synthetic / pathological cases.
+            chosen = {
+                i: sanitize_id("__".join([*parents_per[i], stem]))
+                for i in indices
+            }
+        for i, value in chosen.items():
+            out[i] = value
+    return out
+
+
+def make_record_set_ids(file_metas: list) -> list:
+    """Return a unique RecordSet @id for each file in a handler's batch.
+
+    The bare cleaned, sanitized basename is returned when no other file
+    in the batch produces the same basename. When two or more files
+    collide, parent-directory components from ``relative_path`` are
+    prepended (joined with ``__``) up to the minimum depth that
+    disambiguates the collision.
+
+    The pattern follows the namespacing convention used by other
+    Croissant generators (for example, the Hugging Face auto-generator
+    prefixes config-level identifiers into split @id values), so
+    consumers familiar with that style do not encounter a new shape.
+    """
+    items = [
+        (
+            sanitize_id(get_clean_record_name(meta["file_name"])),
+            list(Path(meta.get("relative_path", meta["file_name"])).parts[:-1]),
+        )
+        for meta in file_metas
+    ]
+    return _disambiguate_ids(items)
+
+
+def make_partition_record_set_ids(dir_paths: list) -> list:
+    """Return a unique RecordSet @id for each partitioned-table directory.
+
+    Same algorithm as ``make_record_set_ids``, but the source of the
+    identifier is the trailing directory name rather than a file
+    basename. Used by the Parquet handler when grouping shards into a
+    single logical table.
+    """
+    items = [
+        (sanitize_id(Path(dir_path).name), list(Path(dir_path).parts[:-1]))
+        for dir_path in dir_paths
+    ]
+    return _disambiguate_ids(items)
+
+
+def make_field_id(record_set_id: str, column_name: str, used_field_ids: set) -> str:
+    """Return a unique field @id within a single RecordSet.
+
+    The candidate @id is ``{record_set_id}/{sanitize_id(column_name)}``.
+    On collision (which happens when two distinct column names sanitize
+    to the same string, for example ``Age>30`` and ``Age 30`` both
+    becoming ``Age_30``), a numeric suffix ``__N`` is appended starting
+    at 1. This mirrors the disambiguation that ``pandas.read_csv``
+    applies to duplicate column headers by default.
+
+    ``used_field_ids`` is mutated to record the chosen identifier so
+    subsequent calls within the same RecordSet can detect further
+    collisions.
+    """
+    base = f"{record_set_id}/{sanitize_id(column_name)}"
+    if base not in used_field_ids:
+        used_field_ids.add(base)
+        return base
+    n = 1
+    while f"{base}__{n}" in used_field_ids:
+        n += 1
+    chosen = f"{base}__{n}"
+    used_field_ids.add(chosen)
+    return chosen
+
+
 def map_arrow_type(arrow_type: pa.DataType) -> str:
     """
     Map a PyArrow data type to the corresponding Croissant type string.
@@ -227,6 +346,7 @@ def _build_fields(
     parent_id: str,
     source_ref: dict,
     col_path_prefix: str = "",
+    used_field_ids: set = None,
 ) -> list:
     """Recursively build mlc.Field objects from a PyArrow schema or struct type.
 
@@ -234,13 +354,19 @@ def _build_fields(
     - Scalar column: maps to a Croissant type via map_arrow_type().
     - List column: sets is_array=True; recurses on the element type.
     - Struct column: recurses to produce sub_fields.
+
+    ``used_field_ids`` is an optional set of field @id values already
+    emitted within the parent RecordSet; the function adds chosen ids
+    to it so that columns whose names sanitize to the same string get a
+    deterministic numeric suffix instead of silently colliding.
     """
+    if used_field_ids is None:
+        used_field_ids = set()
     fields = []
     for arrow_field in arrow_schema:
         col_name = arrow_field.name
         arrow_type = arrow_field.type
-        safe_name = sanitize_id(col_name)
-        field_id = f"{parent_id}/{safe_name}"
+        field_id = make_field_id(parent_id, col_name, used_field_ids)
         col_path = f"{col_path_prefix}/{col_name}" if col_path_prefix else col_name
 
         is_array = is_arrow_list(arrow_type)
@@ -401,6 +527,7 @@ def build_fields_from_json_schema(
     source_ref: dict,
     description_prefix: str = "Column",
     _col_path_prefix: str = "",
+    used_field_ids: set = None,
 ) -> list:
     """Recursively build mlc.Field objects from a JSON column schema dict.
 
@@ -415,14 +542,19 @@ def build_fields_from_json_schema(
         source_ref: Dict with either ``file_object=`` or ``file_set=`` key.
         description_prefix: Label prefix for field descriptions (default "Column").
         _col_path_prefix: Internal prefix for nested column paths; callers omit.
+        used_field_ids: Optional set of already-emitted field @id values
+            within the parent RecordSet. The function adds chosen ids to
+            it so callers can detect collisions across multiple invocations
+            against the same RecordSet. Defaults to a fresh per-call set.
 
     Returns:
         List of ``mlc.Field`` objects.
     """
+    if used_field_ids is None:
+        used_field_ids = set()
     fields = []
     for col_name, type_info in col_schema.items():
-        safe_name = sanitize_id(col_name)
-        field_id = f"{parent_id}/{safe_name}"
+        field_id = make_field_id(parent_id, col_name, used_field_ids)
         col_path = f"{_col_path_prefix}/{col_name}" if _col_path_prefix else col_name
         source = mlc.Source(extract=mlc.Extract(column=col_path), **source_ref)
 

--- a/src/croissant_baker/handlers/utils.py
+++ b/src/croissant_baker/handlers/utils.py
@@ -115,8 +115,7 @@ def _disambiguate_ids(items: list) -> list:
             # paths are unique, so this branch should not fire on real inputs;
             # kept as a safety net for synthetic / pathological cases.
             chosen = {
-                i: sanitize_id("__".join([*parents_per[i], stem]))
-                for i in indices
+                i: sanitize_id("__".join([*parents_per[i], stem])) for i in indices
             }
         for i, value in chosen.items():
             out[i] = value

--- a/src/croissant_baker/handlers/wfdb_handler.py
+++ b/src/croissant_baker/handlers/wfdb_handler.py
@@ -6,7 +6,11 @@ import wfdb
 import mlcroissant as mlc
 
 from croissant_baker.handlers.base_handler import FileTypeHandler
-from croissant_baker.handlers.utils import compute_file_hash, sanitize_id
+from croissant_baker.handlers.utils import (
+    _disambiguate_ids,
+    compute_file_hash,
+    sanitize_id,
+)
 
 
 class WFDBHandler(FileTypeHandler):
@@ -114,7 +118,25 @@ class WFDBHandler(FileTypeHandler):
 
     def build_croissant(self, file_metas: list, file_ids: list) -> tuple:
         record_sets = []
-        for file_id, file_meta in zip(file_ids, file_metas):
+        # Record names can repeat across subdirectories; disambiguate via the
+        # parent path components of each record's relative location when
+        # available. Tests may pass minimal metas without path info, in
+        # which case the bare record name is sufficient.
+        rs_id_items = [
+            (
+                sanitize_id(meta["record_name"]),
+                list(
+                    Path(
+                        meta.get("relative_path")
+                        or meta.get("file_name")
+                        or meta["record_name"]
+                    ).parts[:-1]
+                ),
+            )
+            for meta in file_metas
+        ]
+        rs_ids = _disambiguate_ids(rs_id_items)
+        for file_id, file_meta, rs_id in zip(file_ids, file_metas, rs_ids):
             fields = []
             for signal_name, signal_type in file_meta["signal_types"].items():
                 safe_name = sanitize_id(signal_name)
@@ -136,7 +158,7 @@ class WFDBHandler(FileTypeHandler):
 
             record_sets.append(
                 mlc.RecordSet(
-                    id=sanitize_id(file_meta["record_name"]),
+                    id=rs_id,
                     name=file_meta["record_name"],
                     description=(
                         f"WFDB record {file_meta['record_name']}: "

--- a/src/croissant_baker/handlers/wfdb_handler.py
+++ b/src/croissant_baker/handlers/wfdb_handler.py
@@ -9,6 +9,7 @@ from croissant_baker.handlers.base_handler import FileTypeHandler
 from croissant_baker.handlers.utils import (
     _disambiguate_ids,
     compute_file_hash,
+    make_field_id,
     sanitize_id,
 )
 
@@ -137,12 +138,13 @@ class WFDBHandler(FileTypeHandler):
         ]
         rs_ids = _disambiguate_ids(rs_id_items)
         for file_id, file_meta, rs_id in zip(file_ids, file_metas, rs_ids):
+            used_field_ids: set = set()
             fields = []
             for signal_name, signal_type in file_meta["signal_types"].items():
-                safe_name = sanitize_id(signal_name)
+                field_id = make_field_id(rs_id, signal_name, used_field_ids)
                 fields.append(
                     mlc.Field(
-                        id=f"{file_id}_{safe_name}",
+                        id=field_id,
                         name=signal_name,
                         description=f"Signal '{signal_name}' from {file_meta['record_name']}",
                         data_types=[signal_type],

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -56,12 +56,16 @@ def _assert_unique_node_ids(distributions: list, record_sets: list) -> None:
             )
         seen[node_id] = kind
 
+    def _walk_fields(fields) -> None:
+        for f in fields or []:
+            _claim(getattr(f, "id", None), "Field")
+            _walk_fields(getattr(f, "sub_fields", None))
+
     for d in distributions:
         _claim(getattr(d, "id", None), type(d).__name__)
     for r in record_sets:
         _claim(getattr(r, "id", None), "RecordSet")
-        for f in getattr(r, "fields", None) or []:
-            _claim(getattr(f, "id", None), "Field")
+        _walk_fields(getattr(r, "fields", None))
 
 
 def _apply_field_mappings(

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -32,6 +32,38 @@ def serialize_datetime(obj):
     raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
+def _assert_unique_node_ids(distributions: list, record_sets: list) -> None:
+    """Verify every emitted @id is unique across the document.
+
+    JSON-LD merges nodes that share an @id (`json-ld11/#node-identifiers`
+    spec section: nodes with the same identifier represent the same node).
+    A collision therefore silently merges nodes, producing incorrect
+    Croissant output. Surfacing the conflict here keeps the failure
+    local to the generator with the offending @id and node types
+    attached, instead of leaking out as an opaque downstream validation
+    error or, worse, passing validation while silently dropping data.
+    """
+    seen: dict = {}
+
+    def _claim(node_id, kind: str) -> None:
+        if node_id is None:
+            return
+        if node_id in seen:
+            raise ValueError(
+                f"Croissant @id collision: '{node_id}' is used by both "
+                f"{seen[node_id]} and {kind}. Every FileObject, FileSet, "
+                f"RecordSet, and Field must carry a unique @id."
+            )
+        seen[node_id] = kind
+
+    for d in distributions:
+        _claim(getattr(d, "id", None), type(d).__name__)
+    for r in record_sets:
+        _claim(getattr(r, "id", None), "RecordSet")
+        for f in getattr(r, "fields", None) or []:
+            _claim(getattr(f, "id", None), "Field")
+
+
 def _apply_field_mappings(
     metadata_dict: dict, mappings: Dict[str, Dict[str, object]]
 ) -> None:
@@ -347,6 +379,8 @@ class MetadataGenerator:
                 record_sets.extend(rs)
             except Exception as e:
                 print(f"Warning: {type(_h).__name__}.build_croissant failed: {e}")
+
+        _assert_unique_node_ids(distributions, record_sets)
 
         metadata.distribution = distributions
         metadata.record_sets = record_sets

--- a/tests/data/output/mitdb_wfdb_croissant.jsonld
+++ b/tests/data/output/mitdb_wfdb_croissant.jsonld
@@ -1987,7 +1987,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_0_MLII",
+          "@id": "209/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 209",
           "dataType": "sc:Float",
@@ -1999,7 +1999,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_0_V1",
+          "@id": "209/V1",
           "name": "V1",
           "description": "Signal 'V1' from 209",
           "dataType": "sc:Float",
@@ -2019,7 +2019,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_3_MLII",
+          "@id": "221/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 221",
           "dataType": "sc:Float",
@@ -2031,7 +2031,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_3_V1",
+          "@id": "221/V1",
           "name": "V1",
           "description": "Signal 'V1' from 221",
           "dataType": "sc:Float",
@@ -2051,7 +2051,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_6_MLII",
+          "@id": "220/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 220",
           "dataType": "sc:Float",
@@ -2063,7 +2063,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_6_V1",
+          "@id": "220/V1",
           "name": "V1",
           "description": "Signal 'V1' from 220",
           "dataType": "sc:Float",
@@ -2083,7 +2083,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_9_MLII",
+          "@id": "234/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 234",
           "dataType": "sc:Float",
@@ -2095,7 +2095,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_9_V1",
+          "@id": "234/V1",
           "name": "V1",
           "description": "Signal 'V1' from 234",
           "dataType": "sc:Float",
@@ -2115,7 +2115,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_12_MLII",
+          "@id": "208/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 208",
           "dataType": "sc:Float",
@@ -2127,7 +2127,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_12_V1",
+          "@id": "208/V1",
           "name": "V1",
           "description": "Signal 'V1' from 208",
           "dataType": "sc:Float",
@@ -2147,7 +2147,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_15_MLII",
+          "@id": "222/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 222",
           "dataType": "sc:Float",
@@ -2159,7 +2159,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_15_V1",
+          "@id": "222/V1",
           "name": "V1",
           "description": "Signal 'V1' from 222",
           "dataType": "sc:Float",
@@ -2179,7 +2179,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_18_MLII",
+          "@id": "223/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 223",
           "dataType": "sc:Float",
@@ -2191,7 +2191,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_18_V1",
+          "@id": "223/V1",
           "name": "V1",
           "description": "Signal 'V1' from 223",
           "dataType": "sc:Float",
@@ -2211,7 +2211,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_21_MLII",
+          "@id": "233/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 233",
           "dataType": "sc:Float",
@@ -2223,7 +2223,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_21_V1",
+          "@id": "233/V1",
           "name": "V1",
           "description": "Signal 'V1' from 233",
           "dataType": "sc:Float",
@@ -2243,7 +2243,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_24_MLII",
+          "@id": "232/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 232",
           "dataType": "sc:Float",
@@ -2255,7 +2255,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_24_V1",
+          "@id": "232/V1",
           "name": "V1",
           "description": "Signal 'V1' from 232",
           "dataType": "sc:Float",
@@ -2275,7 +2275,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_27_MLII",
+          "@id": "230/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 230",
           "dataType": "sc:Float",
@@ -2287,7 +2287,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_27_V1",
+          "@id": "230/V1",
           "name": "V1",
           "description": "Signal 'V1' from 230",
           "dataType": "sc:Float",
@@ -2307,7 +2307,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_30_MLII",
+          "@id": "219/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 219",
           "dataType": "sc:Float",
@@ -2319,7 +2319,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_30_V1",
+          "@id": "219/V1",
           "name": "V1",
           "description": "Signal 'V1' from 219",
           "dataType": "sc:Float",
@@ -2339,7 +2339,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_33_MLII",
+          "@id": "231/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 231",
           "dataType": "sc:Float",
@@ -2351,7 +2351,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_33_V1",
+          "@id": "231/V1",
           "name": "V1",
           "description": "Signal 'V1' from 231",
           "dataType": "sc:Float",
@@ -2371,7 +2371,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_36_MLII",
+          "@id": "108/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 108",
           "dataType": "sc:Float",
@@ -2383,7 +2383,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_36_V1",
+          "@id": "108/V1",
           "name": "V1",
           "description": "Signal 'V1' from 108",
           "dataType": "sc:Float",
@@ -2403,7 +2403,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_39_MLII",
+          "@id": "121/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 121",
           "dataType": "sc:Float",
@@ -2415,7 +2415,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_39_V1",
+          "@id": "121/V1",
           "name": "V1",
           "description": "Signal 'V1' from 121",
           "dataType": "sc:Float",
@@ -2435,7 +2435,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_42_MLII",
+          "@id": "109/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 109",
           "dataType": "sc:Float",
@@ -2447,7 +2447,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_42_V1",
+          "@id": "109/V1",
           "name": "V1",
           "description": "Signal 'V1' from 109",
           "dataType": "sc:Float",
@@ -2467,7 +2467,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_45_MLII",
+          "@id": "123/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 123",
           "dataType": "sc:Float",
@@ -2479,7 +2479,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_45_V5",
+          "@id": "123/V5",
           "name": "V5",
           "description": "Signal 'V5' from 123",
           "dataType": "sc:Float",
@@ -2499,7 +2499,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_48_MLII",
+          "@id": "122/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 122",
           "dataType": "sc:Float",
@@ -2511,7 +2511,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_48_V1",
+          "@id": "122/V1",
           "name": "V1",
           "description": "Signal 'V1' from 122",
           "dataType": "sc:Float",
@@ -2531,7 +2531,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_51_MLII",
+          "@id": "119/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 119",
           "dataType": "sc:Float",
@@ -2543,7 +2543,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_51_V1",
+          "@id": "119/V1",
           "name": "V1",
           "description": "Signal 'V1' from 119",
           "dataType": "sc:Float",
@@ -2563,7 +2563,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_54_MLII",
+          "@id": "118/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 118",
           "dataType": "sc:Float",
@@ -2575,7 +2575,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_54_V1",
+          "@id": "118/V1",
           "name": "V1",
           "description": "Signal 'V1' from 118",
           "dataType": "sc:Float",
@@ -2595,7 +2595,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_57_MLII",
+          "@id": "124/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 124",
           "dataType": "sc:Float",
@@ -2607,7 +2607,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_57_V4",
+          "@id": "124/V4",
           "name": "V4",
           "description": "Signal 'V4' from 124",
           "dataType": "sc:Float",
@@ -2627,7 +2627,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_60_MLII",
+          "@id": "101/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 101",
           "dataType": "sc:Float",
@@ -2639,7 +2639,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_60_V1",
+          "@id": "101/V1",
           "name": "V1",
           "description": "Signal 'V1' from 101",
           "dataType": "sc:Float",
@@ -2659,7 +2659,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_63_MLII",
+          "@id": "115/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 115",
           "dataType": "sc:Float",
@@ -2671,7 +2671,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_63_V1",
+          "@id": "115/V1",
           "name": "V1",
           "description": "Signal 'V1' from 115",
           "dataType": "sc:Float",
@@ -2691,7 +2691,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_66_V5",
+          "@id": "114/V5",
           "name": "V5",
           "description": "Signal 'V5' from 114",
           "dataType": "sc:Float",
@@ -2703,7 +2703,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_66_MLII",
+          "@id": "114/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 114",
           "dataType": "sc:Float",
@@ -2723,7 +2723,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_69_MLII",
+          "@id": "100/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 100",
           "dataType": "sc:Float",
@@ -2735,7 +2735,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_69_V5",
+          "@id": "100/V5",
           "name": "V5",
           "description": "Signal 'V5' from 100",
           "dataType": "sc:Float",
@@ -2755,7 +2755,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_72_MLII",
+          "@id": "116/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 116",
           "dataType": "sc:Float",
@@ -2767,7 +2767,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_72_V1",
+          "@id": "116/V1",
           "name": "V1",
           "description": "Signal 'V1' from 116",
           "dataType": "sc:Float",
@@ -2787,7 +2787,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_75_V5",
+          "@id": "102/V5",
           "name": "V5",
           "description": "Signal 'V5' from 102",
           "dataType": "sc:Float",
@@ -2799,7 +2799,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_75_V2",
+          "@id": "102/V2",
           "name": "V2",
           "description": "Signal 'V2' from 102",
           "dataType": "sc:Float",
@@ -2819,7 +2819,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_78_MLII",
+          "@id": "103/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 103",
           "dataType": "sc:Float",
@@ -2831,7 +2831,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_78_V2",
+          "@id": "103/V2",
           "name": "V2",
           "description": "Signal 'V2' from 103",
           "dataType": "sc:Float",
@@ -2851,7 +2851,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_81_MLII",
+          "@id": "117/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 117",
           "dataType": "sc:Float",
@@ -2863,7 +2863,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_81_V2",
+          "@id": "117/V2",
           "name": "V2",
           "description": "Signal 'V2' from 117",
           "dataType": "sc:Float",
@@ -2883,7 +2883,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_84_MLII",
+          "@id": "113/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 113",
           "dataType": "sc:Float",
@@ -2895,7 +2895,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_84_V1",
+          "@id": "113/V1",
           "name": "V1",
           "description": "Signal 'V1' from 113",
           "dataType": "sc:Float",
@@ -2915,7 +2915,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_87_MLII",
+          "@id": "107/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 107",
           "dataType": "sc:Float",
@@ -2927,7 +2927,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_87_V1",
+          "@id": "107/V1",
           "name": "V1",
           "description": "Signal 'V1' from 107",
           "dataType": "sc:Float",
@@ -2947,7 +2947,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_90_MLII",
+          "@id": "106/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 106",
           "dataType": "sc:Float",
@@ -2959,7 +2959,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_90_V1",
+          "@id": "106/V1",
           "name": "V1",
           "description": "Signal 'V1' from 106",
           "dataType": "sc:Float",
@@ -2979,7 +2979,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_93_MLII",
+          "@id": "112/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 112",
           "dataType": "sc:Float",
@@ -2991,7 +2991,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_93_V1",
+          "@id": "112/V1",
           "name": "V1",
           "description": "Signal 'V1' from 112",
           "dataType": "sc:Float",
@@ -3011,7 +3011,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_96_V5",
+          "@id": "104/V5",
           "name": "V5",
           "description": "Signal 'V5' from 104",
           "dataType": "sc:Float",
@@ -3023,7 +3023,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_96_V2",
+          "@id": "104/V2",
           "name": "V2",
           "description": "Signal 'V2' from 104",
           "dataType": "sc:Float",
@@ -3043,7 +3043,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_99_MLII",
+          "@id": "111/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 111",
           "dataType": "sc:Float",
@@ -3055,7 +3055,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_99_V1",
+          "@id": "111/V1",
           "name": "V1",
           "description": "Signal 'V1' from 111",
           "dataType": "sc:Float",
@@ -3075,7 +3075,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_102_MLII",
+          "@id": "105/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 105",
           "dataType": "sc:Float",
@@ -3087,7 +3087,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_102_V1",
+          "@id": "105/V1",
           "name": "V1",
           "description": "Signal 'V1' from 105",
           "dataType": "sc:Float",
@@ -3107,7 +3107,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_105_MLII",
+          "@id": "228/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 228",
           "dataType": "sc:Float",
@@ -3119,7 +3119,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_105_V1",
+          "@id": "228/V1",
           "name": "V1",
           "description": "Signal 'V1' from 228",
           "dataType": "sc:Float",
@@ -3139,7 +3139,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_108_MLII",
+          "@id": "214/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 214",
           "dataType": "sc:Float",
@@ -3151,7 +3151,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_108_V1",
+          "@id": "214/V1",
           "name": "V1",
           "description": "Signal 'V1' from 214",
           "dataType": "sc:Float",
@@ -3171,7 +3171,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_111_MLII",
+          "@id": "200/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 200",
           "dataType": "sc:Float",
@@ -3183,7 +3183,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_111_V1",
+          "@id": "200/V1",
           "name": "V1",
           "description": "Signal 'V1' from 200",
           "dataType": "sc:Float",
@@ -3203,7 +3203,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_114_MLII",
+          "@id": "201/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 201",
           "dataType": "sc:Float",
@@ -3215,7 +3215,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_114_V1",
+          "@id": "201/V1",
           "name": "V1",
           "description": "Signal 'V1' from 201",
           "dataType": "sc:Float",
@@ -3235,7 +3235,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_117_MLII",
+          "@id": "215/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 215",
           "dataType": "sc:Float",
@@ -3247,7 +3247,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_117_V1",
+          "@id": "215/V1",
           "name": "V1",
           "description": "Signal 'V1' from 215",
           "dataType": "sc:Float",
@@ -3267,7 +3267,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_120_MLII",
+          "@id": "203/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 203",
           "dataType": "sc:Float",
@@ -3279,7 +3279,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_120_V1",
+          "@id": "203/V1",
           "name": "V1",
           "description": "Signal 'V1' from 203",
           "dataType": "sc:Float",
@@ -3299,7 +3299,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_123_MLII",
+          "@id": "217/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 217",
           "dataType": "sc:Float",
@@ -3311,7 +3311,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_123_V1",
+          "@id": "217/V1",
           "name": "V1",
           "description": "Signal 'V1' from 217",
           "dataType": "sc:Float",
@@ -3331,7 +3331,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_126_MLII",
+          "@id": "202/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 202",
           "dataType": "sc:Float",
@@ -3343,7 +3343,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_126_V1",
+          "@id": "202/V1",
           "name": "V1",
           "description": "Signal 'V1' from 202",
           "dataType": "sc:Float",
@@ -3363,7 +3363,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_129_MLII",
+          "@id": "212/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 212",
           "dataType": "sc:Float",
@@ -3375,7 +3375,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_129_V1",
+          "@id": "212/V1",
           "name": "V1",
           "description": "Signal 'V1' from 212",
           "dataType": "sc:Float",
@@ -3395,7 +3395,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_132_MLII",
+          "@id": "213/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 213",
           "dataType": "sc:Float",
@@ -3407,7 +3407,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_132_V1",
+          "@id": "213/V1",
           "name": "V1",
           "description": "Signal 'V1' from 213",
           "dataType": "sc:Float",
@@ -3427,7 +3427,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_135_MLII",
+          "@id": "207/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 207",
           "dataType": "sc:Float",
@@ -3439,7 +3439,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_135_V1",
+          "@id": "207/V1",
           "name": "V1",
           "description": "Signal 'V1' from 207",
           "dataType": "sc:Float",
@@ -3459,7 +3459,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_138_MLII",
+          "@id": "205/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 205",
           "dataType": "sc:Float",
@@ -3471,7 +3471,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_138_V1",
+          "@id": "205/V1",
           "name": "V1",
           "description": "Signal 'V1' from 205",
           "dataType": "sc:Float",
@@ -3491,7 +3491,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_141_MLII",
+          "@id": "210/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from 210",
           "dataType": "sc:Float",
@@ -3503,7 +3503,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_141_V1",
+          "@id": "210/V1",
           "name": "V1",
           "description": "Signal 'V1' from 210",
           "dataType": "sc:Float",
@@ -3523,7 +3523,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_144_MLII",
+          "@id": "x_228/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_228",
           "dataType": "sc:Float",
@@ -3535,7 +3535,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_144_V1",
+          "@id": "x_228/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_228",
           "dataType": "sc:Float",
@@ -3555,7 +3555,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_147_MLII",
+          "@id": "x_112/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_112",
           "dataType": "sc:Float",
@@ -3567,7 +3567,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_147_V1",
+          "@id": "x_112/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_112",
           "dataType": "sc:Float",
@@ -3587,7 +3587,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_150_MLII",
+          "@id": "x_113/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_113",
           "dataType": "sc:Float",
@@ -3599,7 +3599,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_150_V1",
+          "@id": "x_113/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_113",
           "dataType": "sc:Float",
@@ -3619,7 +3619,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_153_MLII",
+          "@id": "x_111/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_111",
           "dataType": "sc:Float",
@@ -3631,7 +3631,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_153_V1",
+          "@id": "x_111/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_111",
           "dataType": "sc:Float",
@@ -3651,7 +3651,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_156_V5",
+          "@id": "x_114/V5",
           "name": "V5",
           "description": "Signal 'V5' from x_114",
           "dataType": "sc:Float",
@@ -3663,7 +3663,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_156_MLII",
+          "@id": "x_114/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_114",
           "dataType": "sc:Float",
@@ -3683,7 +3683,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_159_MLII",
+          "@id": "x_115/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_115",
           "dataType": "sc:Float",
@@ -3695,7 +3695,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_159_V1",
+          "@id": "x_115/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_115",
           "dataType": "sc:Float",
@@ -3715,7 +3715,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_162_MLII",
+          "@id": "x_117/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_117",
           "dataType": "sc:Float",
@@ -3727,7 +3727,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_162_V2",
+          "@id": "x_117/V2",
           "name": "V2",
           "description": "Signal 'V2' from x_117",
           "dataType": "sc:Float",
@@ -3747,7 +3747,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_165_MLII",
+          "@id": "x_116/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_116",
           "dataType": "sc:Float",
@@ -3759,7 +3759,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_165_V1",
+          "@id": "x_116/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_116",
           "dataType": "sc:Float",
@@ -3779,7 +3779,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_168_MLII",
+          "@id": "x_124/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_124",
           "dataType": "sc:Float",
@@ -3791,7 +3791,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_168_V4",
+          "@id": "x_124/V4",
           "name": "V4",
           "description": "Signal 'V4' from x_124",
           "dataType": "sc:Float",
@@ -3811,7 +3811,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_171_MLII",
+          "@id": "x_109/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_109",
           "dataType": "sc:Float",
@@ -3823,7 +3823,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_171_V1",
+          "@id": "x_109/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_109",
           "dataType": "sc:Float",
@@ -3843,7 +3843,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_174_MLII",
+          "@id": "x_121/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_121",
           "dataType": "sc:Float",
@@ -3855,7 +3855,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_174_V1",
+          "@id": "x_121/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_121",
           "dataType": "sc:Float",
@@ -3875,7 +3875,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_177_MLII",
+          "@id": "x_108/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_108",
           "dataType": "sc:Float",
@@ -3887,7 +3887,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_177_V1",
+          "@id": "x_108/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_108",
           "dataType": "sc:Float",
@@ -3907,7 +3907,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_180_MLII",
+          "@id": "x_122/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_122",
           "dataType": "sc:Float",
@@ -3919,7 +3919,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_180_V1",
+          "@id": "x_122/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_122",
           "dataType": "sc:Float",
@@ -3939,7 +3939,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_183_MLII",
+          "@id": "x_123/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_123",
           "dataType": "sc:Float",
@@ -3951,7 +3951,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_183_V5",
+          "@id": "x_123/V5",
           "name": "V5",
           "description": "Signal 'V5' from x_123",
           "dataType": "sc:Float",
@@ -3971,7 +3971,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_186_MLII",
+          "@id": "x_232/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_232",
           "dataType": "sc:Float",
@@ -3983,7 +3983,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_186_V1",
+          "@id": "x_232/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_232",
           "dataType": "sc:Float",
@@ -4003,7 +4003,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_189_MLII",
+          "@id": "x_233/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_233",
           "dataType": "sc:Float",
@@ -4015,7 +4015,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_189_V1",
+          "@id": "x_233/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_233",
           "dataType": "sc:Float",
@@ -4035,7 +4035,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_192_MLII",
+          "@id": "x_231/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_231",
           "dataType": "sc:Float",
@@ -4047,7 +4047,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_192_V1",
+          "@id": "x_231/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_231",
           "dataType": "sc:Float",
@@ -4067,7 +4067,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_195_MLII",
+          "@id": "x_230/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_230",
           "dataType": "sc:Float",
@@ -4079,7 +4079,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_195_V1",
+          "@id": "x_230/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_230",
           "dataType": "sc:Float",
@@ -4099,7 +4099,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_198_MLII",
+          "@id": "x_234/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_234",
           "dataType": "sc:Float",
@@ -4111,7 +4111,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_198_V1",
+          "@id": "x_234/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_234",
           "dataType": "sc:Float",
@@ -4131,7 +4131,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_201_MLII",
+          "@id": "x_220/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_220",
           "dataType": "sc:Float",
@@ -4143,7 +4143,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_201_V1",
+          "@id": "x_220/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_220",
           "dataType": "sc:Float",
@@ -4163,7 +4163,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_204_MLII",
+          "@id": "x_221/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_221",
           "dataType": "sc:Float",
@@ -4175,7 +4175,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_204_V1",
+          "@id": "x_221/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_221",
           "dataType": "sc:Float",
@@ -4195,7 +4195,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_207_MLII",
+          "@id": "x_223/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_223",
           "dataType": "sc:Float",
@@ -4207,7 +4207,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_207_V1",
+          "@id": "x_223/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_223",
           "dataType": "sc:Float",
@@ -4227,7 +4227,7 @@
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "file_210_MLII",
+          "@id": "x_222/MLII",
           "name": "MLII",
           "description": "Signal 'MLII' from x_222",
           "dataType": "sc:Float",
@@ -4239,7 +4239,7 @@
         },
         {
           "@type": "cr:Field",
-          "@id": "file_210_V1",
+          "@id": "x_222/V1",
           "name": "V1",
           "description": "Signal 'V1' from x_222",
           "dataType": "sc:Float",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,88 @@
+"""Tests for handler utilities."""
+
+from croissant_baker.handlers.utils import (
+    _disambiguate_ids,
+    make_field_id,
+)
+
+
+def test_disambiguate_ids_no_collisions_keeps_bare_stems() -> None:
+    """Stems unique within the batch pass through unchanged."""
+    items = [("admissions", ["hosp"]), ("patients", ["hosp"]), ("icustays", ["icu"])]
+    assert _disambiguate_ids(items) == ["admissions", "patients", "icustays"]
+
+
+def test_disambiguate_ids_two_colliders_get_immediate_parent_prefix() -> None:
+    """Two files with the same basename in distinct subdirectories are
+    disambiguated by their immediate parent directory."""
+    items = [("data", ["topic_a"]), ("data", ["topic_b"])]
+    assert _disambiguate_ids(items) == ["topic_a__data", "topic_b__data"]
+
+
+def test_disambiguate_ids_three_colliders_share_minimum_depth() -> None:
+    """All members of a colliding group walk up to the same depth — the
+    minimum at which every member is unique."""
+    items = [
+        ("data", ["root", "topic_a"]),
+        ("data", ["root", "topic_b"]),
+        ("data", ["root", "topic_c"]),
+    ]
+    # depth=1 (immediate parent) is sufficient: topic_a, topic_b, topic_c all differ.
+    assert _disambiguate_ids(items) == [
+        "topic_a__data",
+        "topic_b__data",
+        "topic_c__data",
+    ]
+
+
+def test_disambiguate_ids_walks_deeper_when_immediate_parents_collide() -> None:
+    """When the immediate parent also collides, the algorithm climbs further."""
+    items = [
+        ("data", ["alpha", "shared"]),
+        ("data", ["beta", "shared"]),
+    ]
+    # depth=1 collides on "shared"; depth=2 differentiates by alpha vs beta.
+    assert _disambiguate_ids(items) == [
+        "alpha__shared__data",
+        "beta__shared__data",
+    ]
+
+
+def test_disambiguate_ids_root_level_file_keeps_bare_stem() -> None:
+    """A file at the dataset root has no parent components; if its stem
+    collides with a nested file's stem, the nested file is the one that
+    grows a prefix."""
+    items = [("data", []), ("data", ["topic_a"])]
+    out = _disambiguate_ids(items)
+    # The root file falls back to the bare stem; the nested one prefixes.
+    assert out == ["data", "topic_a__data"]
+
+
+def test_disambiguate_ids_preserves_input_order() -> None:
+    """Returned list is parallel to the input list (positionally)."""
+    items = [
+        ("a", ["x"]),
+        ("b", ["x"]),
+        ("a", ["y"]),
+    ]
+    assert _disambiguate_ids(items) == ["x__a", "b", "y__a"]
+
+
+def test_make_field_id_unique_column_returns_bare_id() -> None:
+    used: set = set()
+    assert make_field_id("rs1", "age", used) == "rs1/age"
+    assert "rs1/age" in used
+
+
+def test_make_field_id_collision_appends_numeric_suffix() -> None:
+    """Two distinct column names that sanitize to the same string get
+    disambiguated by an appended numeric suffix, mirroring how
+    pandas.read_csv handles duplicate column headers by default."""
+    used: set = set()
+    first = make_field_id("rs1", "Age>30", used)
+    second = make_field_id("rs1", "Age 30", used)
+    assert first == "rs1/Age_30"
+    assert second == "rs1/Age_30__1"
+    # Both ids are recorded so a third collision continues the sequence.
+    third = make_field_id("rs1", "Age=30", used)
+    assert third == "rs1/Age_30__2"


### PR DESCRIPTION
When two files share the same basename in different subdirectories, or two column names sanitize to the same    
  string, the generator was emitting duplicate @id values. JSON-LD consumers silently merge nodes that share an
  @id, causing missing data or cryptic validation errors.                                                         
                                                             
  This adds disambiguation helpers in utils.py that prefix colliding identifiers with parent directory components,
   updates all handlers to use them, and adds a generator-level uniqueness check that catches any future          
  regressions before serialization.

Follow-up to PR #63 