### PR TITLE
ci: add workflow_dispatch fallback for manual PyPI publish

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,6 +3,12 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish to PyPI (format: croissant-baker-vX.Y.Z)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -22,7 +28,6 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   # Runs only when a release PR is merged and a GitHub Release is created.
-  # Add PyPI publish steps here when ready (e.g. uv build + twine upload).
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
@@ -30,6 +35,28 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build package
+        run: uv build --wheel
+
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish
+
+  # Manual fallback for when the auto publish job didn't fire
+  # (e.g. release-please job failed after the GitHub Release was created).
+  manual-publish:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

Adds a manual fallback path for publishing to PyPI when the auto-publish job is skipped due to a transient release-please failure.

## Why

On 2026-05-06, the v0.3.0 \`Release Please\` workflow run completed the GitHub release successfully but then failed on a follow-up GraphQL timeout (\`We couldn't respond to your request in time\`). Because the existing \`publish\` job has \`needs: release-please\` and is gated by \`if: needs.release-please.outputs.release_created == 'true'\`, the failure cascaded:

- v0.3.0 GitHub release created and tagged
- release-please job exited non-zero
- publish job skipped (\`needs\` not satisfied)
- v0.3.0 never reached PyPI (still showing 0.2.0 on https://pypi.org/project/croissant-baker/)

Re-running the workflow does not help: release-please sees v0.3.0 already exists, sets \`release_created=false\`, and publish skips again.

## What this changes

Auto path on \`push: branches: [main]\` is byte-for-byte unchanged.

- Adds \`workflow_dispatch\` trigger with a required \`tag\` input (e.g. \`croissant-baker-vX.Y.Z\`)
- Adds a new \`manual-publish\` job gated to \`if: github.event_name == 'workflow_dispatch'\` that checks out the specified tag, builds the wheel, and publishes using the existing \`PYPI_API_TOKEN\`
- Removes a stale TODO comment (\"Add PyPI publish steps here when ready\") on the existing \`publish\` job; the publish steps are already there

## How to use after merge

GitHub, Actions, \"Release Please\", \"Run workflow\", enter \`croissant-baker-v0.3.0\`, Run.

## Notes

There is some duplication between \`publish\` and \`manual-publish\` (about 4 step lines). I considered extracting into a reusable workflow or composite action but decided against it. The abstraction costs more than the duplication, and the two jobs have semantically different gates (release-created vs dispatch event). Worth revisiting if a third PyPI publish path appears.