### PR TITLE
docs: add arXiv preprint citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,62 @@
+cff-version: 1.2.0
+title: Croissant Baker
+message: >-
+  If you use Croissant Baker in your research, please cite the
+  preprint listed under preferred-citation below.
+type: software
+authors: &author_list
+  - given-names: Rafi
+    family-names: Al Attrach
+  - given-names: Rajna
+    family-names: Fani
+  - given-names: Sebastian
+    family-names: Lobentanzer
+  - given-names: Joan
+    family-names: Giner-Miguelez
+  - given-names: Debanshu
+    family-names: Das
+  - given-names: Varuni
+    family-names: H. K.
+  - given-names: Nobin
+    family-names: Sarwar
+  - given-names: Rajat
+    family-names: Ghosh
+  - given-names: Anwai
+    family-names: Archit
+  - given-names: Surbhi
+    family-names: Motghare
+  - given-names: Christina
+    family-names: Conrad Parry
+  - given-names: Luis
+    family-names: Oala
+  - given-names: Lara
+    family-names: Grosso
+  - given-names: Joaquin
+    family-names: Vanschoren
+  - given-names: Steffen
+    family-names: Vogler
+  - given-names: Sujata
+    family-names: Goswami
+  - given-names: Eric S.
+    family-names: Rosenthal
+  - given-names: Marzyeh
+    family-names: Ghassemi
+  - given-names: Matthew
+    family-names: McDermott
+  - given-names: Tom
+    family-names: Pollard
+repository-code: https://github.com/MIT-LCP/croissant-baker
+url: https://lcp.mit.edu/croissant-baker/
+license: MIT
+preferred-citation:
+  type: article
+  title: "Croissant Baker: Metadata Generation for Discoverable, Governable, and Reusable ML Datasets"
+  authors: *author_list
+  year: 2026
+  month: 5
+  url: https://arxiv.org/abs/2605.15079
+  doi: 10.48550/arXiv.2605.15079
+  identifiers:
+    - type: other
+      value: "arXiv:2605.15079"
+      description: arXiv preprint identifier

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://docs.astral.sh/uv/"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json" alt="uv"></a>
   <a href="https://github.com/MIT-LCP/croissant-baker/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://pypi.org/project/croissant-baker/"><img src="https://img.shields.io/pypi/v/croissant-baker?logo=pypi" alt="PyPI"></a>
+  <a href="https://arxiv.org/abs/2605.15079"><img src="https://img.shields.io/badge/arXiv-2605.15079-b31b1b.svg" alt="arXiv"></a>
   <a href="https://github.com/MIT-LCP/croissant-baker/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
 </p>
 
@@ -90,6 +91,22 @@ See the [documentation](https://lcp.mit.edu/croissant-baker/) for full CLI refer
 ## Contributing
 
 See [CONTRIBUTING.md](https://raw.githubusercontent.com/MIT-LCP/croissant-baker/main/CONTRIBUTING.md) for guidelines and [DEVELOPMENT.md](https://raw.githubusercontent.com/MIT-LCP/croissant-baker/main/DEVELOPMENT.md) for setup, testing, releases, and how to add new file handlers.
+
+## Citation
+
+If you use Croissant Baker in your research, please cite our [arXiv preprint](https://arxiv.org/abs/2605.15079):
+
+```bibtex
+@misc{attrach2026croissantbakermetadatageneration,
+      title={Croissant Baker: Metadata Generation for Discoverable, Governable, and Reusable ML Datasets},
+      author={Rafi Al Attrach and Rajna Fani and Sebastian Lobentanzer and Joan Giner-Miguelez and Debanshu Das and Varuni H. K. and Nobin Sarwar and Rajat Ghosh and Anwai Archit and Surbhi Motghare and Christina Conrad Parry and Luis Oala and Lara Grosso and Joaquin Vanschoren and Steffen Vogler and Sujata Goswami and Eric S. Rosenthal and Marzyeh Ghassemi and Matthew McDermott and Tom Pollard},
+      year={2026},
+      eprint={2605.15079},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2605.15079},
+}
+```
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@
 
 <p align="center">
   <a href="https://pypi.org/project/croissant-baker/"><img src="https://img.shields.io/pypi/v/croissant-baker?logo=pypi&logoColor=white" alt="PyPI"></a>&nbsp;&nbsp;
-  <a href="https://github.com/MIT-LCP/croissant-baker"><img src="https://img.shields.io/badge/GitHub-Source_Code-blue?logo=github" alt="GitHub"></a>
+  <a href="https://github.com/MIT-LCP/croissant-baker"><img src="https://img.shields.io/badge/GitHub-Source_Code-blue?logo=github" alt="GitHub"></a>&nbsp;&nbsp;
+  <a href="https://arxiv.org/abs/2605.15079"><img src="https://img.shields.io/badge/arXiv-2605.15079-b31b1b.svg" alt="arXiv"></a>
 </p>
 
 ## Installation
@@ -48,3 +49,20 @@ See the [Getting Started](getting-started.md) guide for a full walkthrough.
 
 - [:fontawesome-brands-github: Source code on GitHub](https://github.com/MIT-LCP/croissant-baker)
 - [:fontawesome-brands-python: Package on PyPI](https://pypi.org/project/croissant-baker/)
+- [:material-file-document-outline: arXiv preprint (2605.15079)](https://arxiv.org/abs/2605.15079)
+
+## Citation
+
+If you use Croissant Baker in your research, please cite our [arXiv preprint](https://arxiv.org/abs/2605.15079):
+
+```bibtex
+@misc{attrach2026croissantbakermetadatageneration,
+      title={Croissant Baker: Metadata Generation for Discoverable, Governable, and Reusable ML Datasets},
+      author={Rafi Al Attrach and Rajna Fani and Sebastian Lobentanzer and Joan Giner-Miguelez and Debanshu Das and Varuni H. K. and Nobin Sarwar and Rajat Ghosh and Anwai Archit and Surbhi Motghare and Christina Conrad Parry and Luis Oala and Lara Grosso and Joaquin Vanschoren and Steffen Vogler and Sujata Goswami and Eric S. Rosenthal and Marzyeh Ghassemi and Matthew McDermott and Tom Pollard},
+      year={2026},
+      eprint={2605.15079},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2605.15079},
+}
+```


### PR DESCRIPTION
## What

Adds the arXiv preprint citation in three places:

- `CITATION.cff` for GitHub's "Cite this repository" button
- `## Citation` section + arXiv badge in `README.md`
- `## Citation` section + arXiv badge + Links entry in `docs/index.md`

BibTeX is the arxiv-canonical block.

## Why this shape

- `CITATION.cff` uses a YAML anchor for the 20-author list: one place, reused for software-authors and `preferred-citation` authors.
- BibTeX is duplicated in README + docs rather than included via mkdocs snippets. Considered DRY-ing but skipped: snippet markers would be visible in raw README, can break silently, and 14 lines updated once or twice in the project's lifetime isn't worth the tooling. Updates go in the same PR; grep for the arxiv ID.