### PR TITLE
fix: make generated metadata reproducible (drop wall-clock defaults)

### DIFF
--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -467,16 +467,58 @@ class MetadataGenerator:
                 f"Expected '2023-12-15' or '2023-12-15T10:30:00'. Error: {e}"
             )
 
-    def _build_citation(self) -> str:
+    def _build_citation(self) -> Optional[str]:
+        """Return a deterministic default citation, or None.
+
+        A caller-supplied ``citation`` is used verbatim. Otherwise we synthesise
+        one only from metadata we actually have — never from wall-clock state, so
+        the same dataset always bakes to the same citation. The year comes from a
+        supplied publication/creation date (the old ``datetime.now().year`` made
+        output drift across year boundaries); the author comes from the supplied
+        creators (the old default fabricated "Dataset Creator" even when real
+        creators were given). If neither a creator nor a date is available there
+        is nothing real to cite, so we omit ``cite_as`` rather than invent it.
+        """
         if self.citation:
             return self.citation
-        year = datetime.now().year
-        name = self.name or self.dataset_path.name
-        return f"Dataset Creator. ({year}). {name} Dataset. Generated with automated type inference."
 
-    def _resolve_date(self) -> datetime:
+        names = [
+            c["name"]
+            for c in (self.creators or [])
+            if isinstance(c, dict) and c.get("name")
+        ]
+        author = ", ".join(names) if names else None
+
+        year = None
+        for raw in (self.date_published, self.date_created):
+            if not raw:
+                continue
+            try:
+                year = datetime.fromisoformat(raw).year
+                break
+            except ValueError:
+                continue
+
+        if author is None and year is None:
+            return None
+
+        name = self.name or self.dataset_path.name
+        author_part = author if author else "Unknown"
+        year_part = f" ({year})." if year is not None else ""
+        return f"{author_part}.{year_part} {name} [Data set]."
+
+    def _resolve_date(self) -> Optional[datetime]:
+        """Return the parsed publication date, or None when none was supplied.
+
+        Previously this defaulted to ``datetime.now()``, stamping the
+        metadata-generation time (down to the microsecond) as the dataset's
+        ``datePublished``. That made output non-reproducible — baking the same
+        dataset twice produced two different files — and is semantically wrong,
+        since the dataset was not published at generation time. ``datePublished``
+        is optional in schema.org/Croissant, so we omit it when unset.
+        """
         if not self.date_published:
-            return datetime.now()
+            return None
         try:
             return datetime.fromisoformat(self.date_published)
         except ValueError as e:

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -468,16 +468,13 @@ class MetadataGenerator:
             )
 
     def _build_citation(self) -> Optional[str]:
-        """Return a deterministic default citation, or None.
+        """Build the default citation, or None.
 
-        A caller-supplied ``citation`` is used verbatim. Otherwise we synthesise
-        one only from metadata we actually have — never from wall-clock state, so
-        the same dataset always bakes to the same citation. The year comes from a
-        supplied publication/creation date (the old ``datetime.now().year`` made
-        output drift across year boundaries); the author comes from the supplied
-        creators (the old default fabricated "Dataset Creator" even when real
-        creators were given). If neither a creator nor a date is available there
-        is nothing real to cite, so we omit ``cite_as`` rather than invent it.
+        A caller-supplied ``citation`` is used verbatim. Otherwise it is derived
+        only from real metadata — the supplied creators and the year of the
+        publication/creation date — so the same input always bakes to the same
+        citation (no wall-clock state). With neither a creator nor a date there
+        is nothing real to cite, so ``cite_as`` is omitted rather than invented.
         """
         if self.citation:
             return self.citation
@@ -510,12 +507,10 @@ class MetadataGenerator:
     def _resolve_date(self) -> Optional[datetime]:
         """Return the parsed publication date, or None when none was supplied.
 
-        Previously this defaulted to ``datetime.now()``, stamping the
-        metadata-generation time (down to the microsecond) as the dataset's
-        ``datePublished``. That made output non-reproducible — baking the same
-        dataset twice produced two different files — and is semantically wrong,
-        since the dataset was not published at generation time. ``datePublished``
-        is optional in schema.org/Croissant, so we omit it when unset.
+        ``datePublished`` is omitted when unset rather than defaulted, so output
+        stays reproducible (no generation-time wall clock leaks into it) and we
+        don't assert a publication date the caller never gave. It is optional in
+        schema.org/Croissant.
         """
         if not self.date_published:
             return None

--- a/tests/data/output/gharchive_demo_croissant.jsonld
+++ b/tests/data/output/gharchive_demo_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "GH Archive (demo slice)",
   "description": "200-event slice of GitHub Archive hourly JSONL export (2023-01-01 00:00 UTC)",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). GH Archive (demo slice) Dataset. Generated with automated type inference.",
+  "citeAs": "GitHub Archive. (2023). GH Archive (demo slice) [Data set].",
   "creator": {
     "@type": "sc:Person",
     "name": "GitHub Archive"

--- a/tests/data/output/glaucoma_fundus_croissant.jsonld
+++ b/tests/data/output/glaucoma_fundus_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "Hillel Yaffe Glaucoma Dataset (subset)",
   "description": "Subset of fundus images for glaucoma screening with GON labels",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). Hillel Yaffe Glaucoma Dataset (subset) Dataset. Generated with automated type inference.",
+  "citeAs": "Hillel Yaffe Medical Center. (2024). Hillel Yaffe Glaucoma Dataset (subset) [Data set].",
   "creator": {
     "@type": "sc:Person",
     "name": "Hillel Yaffe Medical Center"

--- a/tests/data/output/mimiciv_demo_meds_croissant.jsonld
+++ b/tests/data/output/mimiciv_demo_meds_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "MIMIC-IV demo data in the Medical Event Data Standard (MEDS)",
   "description": "MEDS demo of MIMIC-IV represented as Parquet event streams",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). MIMIC-IV demo data in the Medical Event Data Standard (MEDS) Dataset. Generated with automated type inference.",
+  "citeAs": "Robin van de Water, Matthew McDermott. (2025). MIMIC-IV demo data in the Medical Event Data Standard (MEDS) [Data set].",
   "creator": [
     {
       "@type": "sc:Person",

--- a/tests/data/output/open_targets_like_croissant.jsonld
+++ b/tests/data/output/open_targets_like_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "Open Targets Platform (toy)",
   "description": "Synthetic subset of Open Targets Platform data for testing partitioned Parquet support",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). Open Targets Platform (toy) Dataset. Generated with automated type inference.",
+  "citeAs": "Open Targets. (2025). Open Targets Platform (toy) [Data set].",
   "creator": {
     "@type": "sc:Person",
     "name": "Open Targets",

--- a/tests/data/output/satellite_public_health_croissant.jsonld
+++ b/tests/data/output/satellite_public_health_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "Multi-Modal Satellite Imagery for Public Health (subset)",
   "description": "Subset of Sentinel-2 satellite imagery linked to public health indicators in Colombia",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). Multi-Modal Satellite Imagery for Public Health (subset) Dataset. Generated with automated type inference.",
+  "citeAs": "Suri Allison Garzón Mora. (2024). Multi-Modal Satellite Imagery for Public Health (subset) [Data set].",
   "creator": {
     "@type": "sc:Person",
     "name": "Suri Allison Garzón Mora"

--- a/tests/data/output/spect_demo_croissant.jsonld
+++ b/tests/data/output/spect_demo_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "Myocardial Perfusion SPECT (demo subset)",
   "description": "Mixed DICOM + NIfTI subset of the PhysioNet open-access SPECT database",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). Myocardial Perfusion SPECT (demo subset) Dataset. Generated with automated type inference.",
+  "citeAs": "Calixto et al.. (2025). Myocardial Perfusion SPECT (demo subset) [Data set].",
   "creator": {
     "@type": "sc:Person",
     "name": "Calixto et al."

--- a/tests/data/output/uniprot_demo_croissant.jsonld
+++ b/tests/data/output/uniprot_demo_croissant.jsonld
@@ -50,7 +50,7 @@
   "name": "UniProt Human Reviewed (demo)",
   "description": "200 reviewed human proteins from UniProt Swiss-Prot",
   "conformsTo": "http://mlcommons.org/croissant/1.1",
-  "citeAs": "Dataset Creator. (2026). UniProt Human Reviewed (demo) Dataset. Generated with automated type inference.",
+  "citeAs": "UniProt Consortium. (2025). UniProt Human Reviewed (demo) [Data set].",
   "creator": {
     "@type": "sc:Person",
     "name": "UniProt Consortium"

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -73,6 +73,22 @@ def test_default_citation_uses_real_creators_and_date_year(
     assert "Dataset Creator" not in meta["citeAs"]
 
 
+def test_default_citation_creator_without_date(mimic_demo_dir: Path) -> None:
+    """Common CLI path: --creator given, --date-published omitted → no year.
+
+    --creator is required by the CLI but --date-published is optional, so the
+    "creator, no date" case is the default citation most runs produce. It must
+    be deterministic and carry no fabricated year.
+    """
+    meta = MetadataGenerator(
+        str(mimic_demo_dir),
+        name="My DS",
+        description="d",
+        creators=[{"name": "Ada Lovelace"}],
+    ).generate_metadata()
+    assert meta["citeAs"] == "Ada Lovelace. My DS [Data set]."
+
+
 def test_default_citation_omitted_when_nothing_to_cite(mimic_demo_dir: Path) -> None:
     """With neither creators nor a date there is nothing real to cite, so omit it."""
     meta = MetadataGenerator(

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,95 @@
+"""Reproducibility tests: the same dataset must always bake to the same bytes.
+
+Regression guard for the old ``datetime.now()`` defaults in MetadataGenerator,
+which stamped the metadata-generation time (down to the microsecond) into
+``datePublished`` and the current year into the default citation — so baking the
+same input twice produced two different files. See ``_resolve_date`` and
+``_build_citation``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
+
+
+@pytest.fixture
+def mimic_demo_dir() -> Path:
+    """Path to the bundled MIMIC-IV demo dataset."""
+    path = (
+        Path(__file__).parent
+        / "data"
+        / "input"
+        / "mimiciv_demo"
+        / "physionet.org"
+        / "files"
+        / "mimic-iv-demo"
+        / "2.2"
+    )
+    if not path.exists():
+        pytest.skip(f"MIMIC-IV demo dataset not found at {path}")
+    return path
+
+
+def _dump(meta: dict) -> str:
+    return json.dumps(
+        meta, indent=2, ensure_ascii=False, sort_keys=True, default=serialize_datetime
+    )
+
+
+def test_output_is_reproducible(mimic_demo_dir: Path) -> None:
+    """Baking the same dataset twice yields byte-identical metadata."""
+    common = dict(name="Repro DS", description="d", creators=[{"name": "A. Author"}])
+    first = MetadataGenerator(str(mimic_demo_dir), **common).generate_metadata()
+    second = MetadataGenerator(str(mimic_demo_dir), **common).generate_metadata()
+    assert _dump(first) == _dump(second)
+
+
+def test_date_published_omitted_when_not_supplied(mimic_demo_dir: Path) -> None:
+    """No --date-published means no datePublished — not a wall-clock timestamp."""
+    meta = MetadataGenerator(
+        str(mimic_demo_dir),
+        name="X",
+        description="d",
+        creators=[{"name": "A. Author"}],
+    ).generate_metadata()
+    assert "datePublished" not in meta
+
+
+def test_default_citation_uses_real_creators_and_date_year(
+    mimic_demo_dir: Path,
+) -> None:
+    """The default citation is built from supplied creators + date, deterministically."""
+    meta = MetadataGenerator(
+        str(mimic_demo_dir),
+        name="My DS",
+        description="d",
+        creators=[{"name": "Ada Lovelace"}],
+        date_published="2021-06-21",
+    ).generate_metadata()
+    assert meta["citeAs"] == "Ada Lovelace. (2021). My DS [Data set]."
+    assert "Dataset Creator" not in meta["citeAs"]
+
+
+def test_default_citation_omitted_when_nothing_to_cite(mimic_demo_dir: Path) -> None:
+    """With neither creators nor a date there is nothing real to cite, so omit it."""
+    meta = MetadataGenerator(
+        str(mimic_demo_dir), name="X", description="d"
+    ).generate_metadata()
+    assert "citeAs" not in meta
+
+
+def test_validates_without_date_published(mimic_demo_dir: Path, tmp_path: Path) -> None:
+    """Omitting datePublished still produces metadata that passes validation."""
+    out = tmp_path / "croissant.jsonld"
+    gen = MetadataGenerator(
+        str(mimic_demo_dir),
+        name="X",
+        description="d",
+        creators=[{"name": "A. Author"}],
+    )
+    gen.save_metadata(str(out), validate=True)  # must not raise
+    meta = json.loads(out.read_text())
+    assert "datePublished" not in meta


### PR DESCRIPTION
Draft PR opened by **Chimera** (an autonomous code agent operated by @elementalcollision), as part of a review of croissant-baker. Opened as a **draft** for maintainer review.

## Problem: output is not reproducible

`MetadataGenerator` derived parts of its output from `datetime.now()` whenever the caller didn't supply a date or citation. Baking the **same dataset twice, one second apart**, produces two different files:

```
$ croissant-baker --input demo/ --creator "T,t@e.com" --name X -o run1.jsonld
$ croissant-baker --input demo/ --creator "T,t@e.com" --name X -o run2.jsonld
$ diff run1.jsonld run2.jsonld
<   "datePublished": "2026-06-30T12:36:52.236716"
>   "datePublished": "2026-06-30T12:36:53.177421"
```

Two sources of wall-clock leakage:

1. **`datePublished`** defaulted to `datetime.now()` — the metadata-generation timestamp, down to the microsecond. That breaks reproducibility (spurious VCS diffs, broken content-addressed caching) and is semantically wrong: the dataset was not *published* at generation time.
2. **The default citation** embedded `datetime.now().year` *and* a fabricated author — `"Dataset Creator. (2026). <name> Dataset. Generated with automated type inference."` — even when real `--creator` values were supplied. (You can see this today in 7 committed example outputs under `tests/data/output/`, e.g. the MEDS one reads `"Dataset Creator. (2026). …"`.)

## Fix — never derive output from wall-clock state

- **`_resolve_date()`** omits `datePublished` when none is supplied (it's optional in schema.org/Croissant) instead of stamping `now()`.
- **`_build_citation()`** synthesises the default citation from the supplied **creators** and the **publication/creation-date year**; if neither is available there's nothing real to cite, so `cite_as` is omitted rather than invented.

## Tests & artifacts

- New `tests/test_determinism.py`: bake-twice byte-equality, `datePublished` omission, citation derivation, and that omitting `datePublished` still passes `mlcroissant` validation.
- Full suite: **274 passed** (269 + 5 new).
- Regenerated the 7 committed example outputs — each is a **one-line** `citeAs` change, e.g.:
  ```
  - "Dataset Creator. (2026). MIMIC-IV demo … Dataset. Generated with automated type inference."
  + "Robin van de Water, Matthew McDermott. (2025). MIMIC-IV demo … [Data set]."
  ```

## Behavior change (intentional)

Default `datePublished` and the default `citeAs` format change for callers who don't pass `--date-published` / `--citation`. This is the point — the previous defaults fabricated metadata and drifted with the clock. Callers who pass those flags explicitly are unaffected. Happy to adjust the default citation wording (`… [Data set].`) to your preference.
