### PR TITLE
perf: extract file metadata concurrently (thread pool)

### DIFF
--- a/src/croissant_baker/__main__.py
+++ b/src/croissant_baker/__main__.py
@@ -495,6 +495,12 @@ def main(
         "--count-csv-rows",
         help="Count exact row numbers for CSV files (slow for large datasets)",
     ),
+    jobs: int = typer.Option(
+        0,
+        "--jobs",
+        "-j",
+        help="Worker threads for file extraction. 0 = auto (from CPU count), 1 = serial. Output is identical regardless of this value.",
+    ),
     # Native mlcroissant RAI fields exposed directly as CLI flags.
     rai_data_collection: Optional[str] = typer.Option(
         None, "--rai-data-collection", help="How and where the data was gathered."
@@ -787,6 +793,7 @@ def main(
             usage_info=usage_info,
             field_mappings=merged_field_mappings,
             count_csv_rows=count_csv_rows,
+            max_workers=jobs or None,
             includes=include,
             excludes=exclude,
             rai_fields=native_rai_fields,

--- a/src/croissant_baker/handlers/base_handler.py
+++ b/src/croissant_baker/handlers/base_handler.py
@@ -47,6 +47,15 @@ class FileTypeHandler(ABC):
         """
         Extract comprehensive metadata from a single file.
 
+        Thread-safety: ``extract_metadata`` may be called concurrently across
+        files on a single shared handler instance — handlers are registered as
+        singletons and extraction is parallelised (see ``MetadataGenerator``).
+        Implementations must be safe to call concurrently: do not mutate shared
+        or instance state during extraction, and use only parsers that are safe
+        for concurrent reads of independent files. Read-only state set once at
+        construction is fine; mutable per-call state must stay local — never on
+        ``self`` (nor on the class or module).
+
         Should return a dictionary containing file information, structure,
         types, and any format-specific metadata needed for Croissant generation.
 

--- a/src/croissant_baker/metadata_generator.py
+++ b/src/croissant_baker/metadata_generator.py
@@ -2,8 +2,10 @@
 
 import json
 import logging
+import os
 import tempfile
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -170,6 +172,7 @@ class MetadataGenerator:
         usage_info: Optional[str] = None,
         field_mappings: Optional[Dict[str, Dict[str, object]]] = None,
         count_csv_rows: bool = False,
+        max_workers: Optional[int] = None,
         includes: Optional[List[str]] = None,
         excludes: Optional[List[str]] = None,
         rai_fields: Optional[Dict[str, object]] = None,
@@ -211,6 +214,9 @@ class MetadataGenerator:
                 external vocabularies like Wikidata/SNOMED/LOINC.
             count_csv_rows: If True, scan each CSV fully for exact row counts.
                 Defaults to False for performance.
+            max_workers: Maximum worker threads for per-file metadata
+                extraction. None (default) auto-sizes from the CPU count; 1
+                forces serial. Output is identical regardless of this value.
             includes: Glob patterns to include. Applied before excludes.
             excludes: Glob patterns to exclude. Applied after includes.
             rai_fields: Native mlcroissant RAI metadata fields, passed through
@@ -247,6 +253,7 @@ class MetadataGenerator:
         self.includes = includes
         self.excludes = excludes
         self.rai_fields = rai_fields or {}
+        self.max_workers = max_workers
         # Generic options forwarded to every handler via **kwargs.
         # Handlers declare what they use; others ignore the rest.
         # To add a new handler-specific flag: add one key here — the call site never changes.
@@ -257,43 +264,67 @@ class MetadataGenerator:
     def generate_metadata(self, progress_callback=None) -> dict:
         """Generate complete Croissant metadata for the dataset.
 
+        Per-file metadata extraction (handler selection, whole-file SHA-256,
+        header/schema reads) is I/O-bound and independent across files, so it
+        runs on a thread pool sized by ``max_workers``. Results are reassembled
+        in discovery order before any FileObject @id is assigned, so the output
+        — including the order of warnings — is identical regardless of worker
+        count.
+
         Args:
             progress_callback: Optional callback with signature
-                (current: int, total: int, file_path: str) -> None
-                called before processing each file.
+                (completed: int, total: int, file_path: str) -> None
+                invoked once per file as it finishes extraction.
         """
         files = discover_files(
             str(self.dataset_path),
             include_patterns=self.includes,
             exclude_patterns=self.excludes,
         )
-
-        # Extract metadata as (handler, meta) pairs so handler identity is
-        # stored by reference, not by id() — no fragility if dicts are copied.
         total_files = len(files)
+
+        # Extract every file's metadata, possibly concurrently. results[i]
+        # corresponds to files[i], so downstream assembly stays deterministic
+        # no matter what order the threads finish in.
+        results: list = [None] * total_files
+        workers = self._resolve_worker_count(total_files)
+        if workers == 1:
+            for i, file_path in enumerate(files):
+                results[i] = self._extract_file(file_path)
+                if progress_callback:
+                    progress_callback(i + 1, total_files, str(file_path))
+        else:
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                future_to_idx = {
+                    pool.submit(self._extract_file, fp): i for i, fp in enumerate(files)
+                }
+                completed = 0
+                for future in as_completed(future_to_idx):
+                    idx = future_to_idx[future]
+                    results[idx] = future.result()
+                    completed += 1
+                    if progress_callback:
+                        progress_callback(completed, total_files, str(files[idx]))
+
+        # Reassemble in discovery order. Handler identity is stored by reference
+        # (not id()), so there is no fragility if dicts are copied. Warnings and
+        # the skip-note are emitted here, in order, to match the serial path.
         file_metadata: list[tuple] = []
-        # Track files that look like a recognised binary format by extension
-        # but were rejected at handler-selection time (e.g. .dcm files
-        # without the DICM preamble at offset 128). These are valid skips,
-        # not errors, but worth surfacing so the user knows not all .dcm
-        # files made it into the output.
+        # Files that look like a recognised binary format by extension but were
+        # rejected at handler-selection time (e.g. .dcm files without the DICM
+        # preamble at offset 128) are valid skips, not errors — surfaced so the
+        # user knows not all such files made it into the output.
         unmatched_by_ext: dict[str, int] = {}
-        for i, file_path in enumerate(files):
-            if progress_callback:
-                progress_callback(i, total_files, str(file_path))
-            full_path = self.dataset_path / file_path
-            handler = find_handler(full_path)
-            if handler:
-                try:
-                    meta = handler.extract_metadata(full_path, **self._handler_kwargs)
-                    meta["relative_path"] = str(file_path)
-                    file_metadata.append((handler, meta))
-                except Exception as e:
-                    logger.warning("Failed to process %s: %s", file_path, e)
-            else:
-                ext = full_path.suffix.lower()
+        for file_path, handler, meta, error in results:
+            if error is not None:
+                logger.warning("Failed to process %s: %s", file_path, error)
+                continue
+            if handler is None:
+                ext = (self.dataset_path / file_path).suffix.lower()
                 if ext in {".dcm", ".dicom"}:
                     unmatched_by_ext[ext] = unmatched_by_ext.get(ext, 0) + 1
+                continue
+            file_metadata.append((handler, meta))
 
         if unmatched_by_ext:
             total = sum(unmatched_by_ext.values())
@@ -420,6 +451,42 @@ class MetadataGenerator:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _resolve_worker_count(self, n_files: int) -> int:
+        """Decide how many threads to use for extraction.
+
+        An explicit ``max_workers`` wins (floored at 1). Otherwise auto-size: 1
+        for trivial inputs, else a modest oversubscription of the CPU count (the
+        work is I/O-bound — whole-file hashing and header reads — so threads
+        spend most of their time off-CPU), capped to bound open file descriptors.
+        """
+        if self.max_workers is not None:
+            return max(1, self.max_workers)
+        if n_files <= 1:
+            return 1
+        cpu = os.cpu_count() or 1
+        return min(8, n_files, cpu * 2)
+
+    def _extract_file(self, file_path: Path) -> tuple:
+        """Select a handler and extract one file's metadata.
+
+        Reads only the file at ``file_path`` and returns plain data, holding no
+        generator state, so it is safe to call concurrently across files. No
+        mlcroissant objects are built here — that happens single-threaded during
+        assembly. Returns ``(file_path, handler, meta, error)``: for a handled
+        file ``handler``/``meta`` are set; for an extraction failure ``error`` is
+        set; for an unmatched file all three are None.
+        """
+        full_path = self.dataset_path / file_path
+        handler = find_handler(full_path)
+        if handler is None:
+            return (file_path, None, None, None)
+        try:
+            meta = handler.extract_metadata(full_path, **self._handler_kwargs)
+            meta["relative_path"] = str(file_path)
+            return (file_path, handler, meta, None)
+        except Exception as e:  # noqa: BLE001 — re-surfaced as a per-file warning
+            return (file_path, None, None, e)
 
     def _build_description(self, file_metadata: list) -> str:
         if self.description:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 import pytest
 
+from croissant_baker.handlers.registry import (
+    get_registered_handlers,
+    register_all_handlers,
+)
 from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
 
 
@@ -93,3 +97,41 @@ def test_resolve_worker_count(mimic_demo_dir: Path) -> None:
     assert gen._resolve_worker_count(0) == 1
     assert gen._resolve_worker_count(1) == 1
     assert gen._resolve_worker_count(100) >= 1
+
+
+def _instance_state(handler) -> dict:
+    """Return a handler's per-instance state — covering both ``__dict__`` and
+    ``__slots__`` layouts, so a future ``__slots__`` handler is neither missed
+    nor crashes this check with ``TypeError`` (which bare ``vars(h)`` would)."""
+    state = dict(getattr(handler, "__dict__", {}) or {})
+    for cls in type(handler).__mro__:
+        for slot in getattr(cls, "__slots__", ()):
+            if slot not in ("__dict__", "__weakref__") and hasattr(handler, slot):
+                state[slot] = getattr(handler, slot)
+    return state
+
+
+def test_registered_handlers_are_stateless() -> None:
+    """Extraction runs concurrently on shared handler singletons (#112), so
+    handlers must carry no mutable per-instance state — a byte-identical test
+    won't reliably catch a resulting race. This fails loudly if a future handler
+    adds instance state, forcing a conscious thread-safety review before it ships.
+
+    Scope: this guards the instance-state case only. Class-level mutable
+    attributes (e.g. a shared ``_cache = {}`` mutated during extraction),
+    module-level globals, and non-reentrant parser libraries are equally unsafe
+    but are not introspectable here — they are covered by the thread-safety
+    contract on ``FileTypeHandler.extract_metadata`` and by review of the
+    extraction path.
+    """
+    register_all_handlers()
+    stateful = {}
+    for handler in get_registered_handlers():
+        state = _instance_state(handler)
+        if state:
+            stateful[type(handler).__name__] = state
+    assert not stateful, (
+        f"Handlers with instance state: {stateful}. extract_metadata is called "
+        "concurrently on a shared instance (#112). If this state is read-only and "
+        "set once at construction, confirm it is thread-safe and update this test."
+    )

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,95 @@
+"""Parallel extraction must not change output and must respect ``max_workers``.
+
+The extraction loop in ``MetadataGenerator.generate_metadata`` runs on a thread
+pool, but results are reassembled in discovery order before any @id is assigned.
+These tests pin that invariant: the same dataset bakes to byte-identical metadata
+regardless of worker count, and the progress callback reports one event per file.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from croissant_baker.metadata_generator import MetadataGenerator, serialize_datetime
+
+
+@pytest.fixture
+def mimic_demo_dir() -> Path:
+    path = (
+        Path(__file__).parent
+        / "data"
+        / "input"
+        / "mimiciv_demo"
+        / "physionet.org"
+        / "files"
+        / "mimic-iv-demo"
+        / "2.2"
+    )
+    if not path.exists():
+        pytest.skip(f"MIMIC-IV demo dataset not found at {path}")
+    return path
+
+
+def _dump(meta: dict) -> str:
+    return json.dumps(
+        meta, indent=2, ensure_ascii=False, sort_keys=True, default=serialize_datetime
+    )
+
+
+def _bake(path: Path, workers: int) -> dict:
+    # Supply date + creators so the comparison isolates worker-count effects
+    # from any other default.
+    return MetadataGenerator(
+        str(path),
+        name="Parallel DS",
+        description="d",
+        creators=[{"name": "A. Author"}],
+        date_published="2024-01-01",
+        max_workers=workers,
+    ).generate_metadata()
+
+
+@pytest.mark.parametrize("workers", [2, 4, 8])
+def test_output_identical_across_worker_counts(
+    mimic_demo_dir: Path, workers: int
+) -> None:
+    """Parallel runs produce byte-identical metadata to the serial run."""
+    serial = _dump(_bake(mimic_demo_dir, 1))
+    parallel = _dump(_bake(mimic_demo_dir, workers))
+    assert parallel == serial
+
+
+def test_progress_callback_reports_each_file_once(mimic_demo_dir: Path) -> None:
+    """The callback fires once per file and the final event reports completion."""
+    calls: list[tuple[int, int]] = []
+    MetadataGenerator(
+        str(mimic_demo_dir),
+        name="X",
+        description="d",
+        creators=[{"name": "A"}],
+        max_workers=4,
+    ).generate_metadata(progress_callback=lambda c, t, p: calls.append((c, t)))
+
+    total = calls[-1][1]
+    assert len(calls) == total  # one event per discovered file
+    assert calls[-1][0] == total  # final event reports all files complete
+    assert {c for c, _ in calls} == set(range(1, total + 1))  # 1..total, no dupes
+
+
+def test_resolve_worker_count(mimic_demo_dir: Path) -> None:
+    """Explicit worker counts are floored at 1; auto-sizing stays serial for ≤1 file."""
+    gen = MetadataGenerator(
+        str(mimic_demo_dir), name="X", description="d", creators=[{"name": "A"}]
+    )
+
+    gen.max_workers = 1
+    assert gen._resolve_worker_count(100) == 1
+
+    gen.max_workers = 0  # nonsensical explicit value → floored to serial
+    assert gen._resolve_worker_count(100) == 1
+
+    gen.max_workers = None  # auto
+    assert gen._resolve_worker_count(0) == 1
+    assert gen._resolve_worker_count(1) == 1
+    assert gen._resolve_worker_count(100) >= 1


### PR DESCRIPTION
Draft PR opened by **Chimera** (an autonomous code agent operated by @elementalcollision), as part of a review of croissant-baker. Opened as a **draft** for maintainer review.

## What

Per-file metadata extraction — handler selection, whole-file **SHA-256**, and header/schema reads — is I/O-bound and independent across files, but ran strictly serially in `generate_metadata`. On datasets with many files (PhysioNet/MIMIC-scale: thousands) that loop is the dominant cost of a bake.

This runs extraction on a `ThreadPoolExecutor`. The work is off-GIL (file reads + `hashlib` + pyarrow/pydicom/nibabel header parsing), so threads give real overlap.

## Correctness is preserved exactly

The risk with parallelism here is output drift (FileObject `@id`s are positional). Guarded by construction:

- Worker results are collected by submission index and **reassembled in discovery order** *before* any `@id` is assigned.
- Per-file warnings and the DICOM skip-note are emitted during that in-order pass, so even diagnostic order is unchanged.
- No `mlcroissant` objects are built off the main thread — workers return plain dicts.

`tests/test_parallel.py` pins this: **byte-identical output across worker counts 1/2/4/8**. And the full e2e suite now runs through the auto-parallel path (`max_workers=None`) with **zero change to the committed `tests/data/output/*.jsonld`** — the strongest possible evidence the output is unchanged.

## API

- `MetadataGenerator(max_workers=None)` — auto-sizes to `min(8, cpu*2)`; `1` forces serial.
- New CLI flag **`--jobs` / `-j`** (`0` = auto, `1` = serial).
- The progress callback now reports a completion count (one event per file as it finishes).

## Benchmark

Synthetic dataset, 60 CSVs / 1.2 GB, 18-core box, warm cache (isolates compute concurrency):

| workers | best | speedup |
|--------:|-----:|--------:|
| 1 | 1.19s | 1.0× |
| 2 | 0.86s | 1.4× |
| 4 | 0.72s | 1.65× |
| 8 | 0.80s | 1.5× |

Caveat: This is a **warm-cache, CPU-bound** measurement (SHA-256 throughput becomes memory-bandwidth bound past ~4 threads, hence the tail-off). On cold or networked storage where PhysioNet-scale datasets actually live, the gain should be larger because per-file I/O latency overlaps across threads. The `--jobs` flag lets users tune for their storage.

## Tests

Full suite: **274 passed** (269 + 5 new). No changes to committed outputs.
