### PR TITLE
Add MIT Accessibility link to docs footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,9 @@ repo_url: https://github.com/MIT-LCP/croissant-baker
 repo_name: MIT-LCP/croissant-baker
 edit_uri: edit/main/docs/
 
+copyright: >
+  <a href="https://accessibility.mit.edu/">Accessibility</a>
+
 theme:
   name: material
   logo: assets/baker_logo.png


### PR DESCRIPTION
Adds an **Accessibility** link to the documentation site footer, pointing to https://accessibility.mit.edu/.

The link is set through the Material for MkDocs `copyright` field in `mkdocs.yml`, so it renders in the footer of every page alongside the existing GitHub and PyPI links. No theme override is needed.

This satisfies the MIT accessibility requirement, which unblocks requesting an MIT subdomain (for example croissant-baker.mit.edu) for the site.

Closes #115